### PR TITLE
jmp_dftest : Dickey-Fuller tests

### DIFF
--- a/api/LEC.md
+++ b/api/LEC.md
@@ -242,6 +242,7 @@ Functions to evaluate a compiled and linked LEC expression.
 |:---|:---|
 |`L_REAL L_exec_sub(unsigned char* expr, int lg, int t, L_REAL* stack)`|Execution of a CLEC sub expression.|
 |`L_REAL L_exec(KDB* dbv, KDB* dbs, CLEC* expr, int t)`|Execution of a compiled and linked CLEC expression.|
+|`L_REAL* L_cc_link_exec(char* lec, KDB* dbv, KDB* dbs)`|Compiles, links and executes a LEC expression.|
 
 ### l\_exec\_var.c {#T23}
 

--- a/api/iodebase.h
+++ b/api/iodebase.h
@@ -263,6 +263,7 @@ extern void L_link_endos(KDB* kde, CLEC* cl);
 extern void L_fperror(void);
 extern double L_exec(KDB *,KDB *,CLEC *,int );
 extern double L_exec_sub(unsigned char *,int ,int ,double *);
+extern L_REAL* L_cc_link_exec(char* lec, KDB* dbv, KDB* dbs);
 extern int L_intlag(double );
 extern double L_uminus(double *);
 extern double L_uplus(double *);

--- a/api/l_exec.c
+++ b/api/l_exec.c
@@ -5,6 +5,7 @@
  *  
  *   - L_REAL L_exec_sub(unsigned char* expr, int lg, int t, L_REAL* stack)     Execution of a CLEC sub expression.
  *   - L_REAL L_exec(KDB* dbv, KDB* dbs, CLEC* expr, int t)                     Execution of a compiled and linked CLEC expression.
+ *   - L_REAL* L_cc_link_exec(char* lec, KDB* dbv, KDB* dbs)                    Compiles, links and executes a LEC expression.
  */
 
 #include "iode.h"
@@ -342,3 +343,33 @@ void L_tfn_args(int t, L_REAL* stack, int nargs, int* from, int* to)
     }
 }
 
+
+/**
+ *  Compiles, links and executes a LEC expression.
+ *  
+ *  @param [in] char*       lec     LEC expression 
+ *  @param [in] KDB*        dbv     KDB of variables used in lec 
+ *  @param [in] KDB*        dbs     KDB of SCL used in lec
+ *  @return     IODE_REAL*          calculated lec expression on the whole dbv sample    
+ *                                  NULL on error (error can be retrieved via a call to L_error()
+ */
+L_REAL* L_cc_link_exec(char* lec, KDB* dbv, KDB* dbs)
+{
+    int      t, nb;
+    CLEC     *clec = 0;
+    L_REAL   *vec = NULL;
+
+    
+    if(lec == 0 || lec[0] == 0) return(vec);
+    clec = L_cc(lec);
+    if(clec != 0 && !L_link(dbv, dbs, clec)) {
+        nb = KSMPL(dbv)->s_nb;
+        vec = (IODE_REAL*) SW_nalloc(nb * sizeof(IODE_REAL));
+        for(t = 0 ; t < nb ; t++) {
+            vec[t] = L_exec(dbv, dbs, clec, t);
+        }
+    }
+
+    SW_nfree(clec);
+    return(vec);
+}

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -811,14 +811,14 @@ void Tests_Simulation()
 
     // Test Endo-exo
     
-    // Version avec échange dans une seule équation
+    // Version with exchange in one equation only
     // endo_exo = SCR_vtoms("UY-NIY", ",; ");
     // rc = K_simul(kdbe, kdbv, kdbs, smpl, endo_exo, NULL);
     // S4ASSERT(rc == 0, "Exchange UY-NIY converges on 2000Y1-2002Y1");
     // S4ASSERT(UY[pos2000] == 650.0, "Exchange UY-NIY: UY[2000Y1] == 650.0");
     // S4ASSERT(fabs(NIY[pos2000] - 658.423) < 0.01, "Exchange UY-NIY: NIY[2000Y1] == 658.423");
 
-    // Version avec échange dans min 2 equations
+    // Version with exchange in at least 2 equations
     // Set values of endo UY
     KV_set_at_aper("UY", "2000Y1", 650.0);
     KV_set_at_aper("UY", "2001Y1", 670.0);
@@ -911,7 +911,7 @@ void Tests_Estimation()
     int         rc;
     void        (*kmsg_super_ptr)(char*);
     SAMPLE      *smpl;
-    IODE_REAL   r2;
+    IODE_REAL   r2, *df;
 
     U_test_suppress_a2m_msgs();
     U_test_print_title("Tests Estimation");
@@ -950,7 +950,15 @@ void Tests_Estimation()
     SCR_free(smpl);
     
     // Dickey-Fuller test (E_UnitRoot)
-    // TODO: implement a test
+    df = E_UnitRoot("ACAF+ACAG", 0, 0, 0);
+    S4ASSERT(U_test_eq(df[2], -1.602170), "E_UnitRoot(\"ACAF+ACAG\", 0, 0, 0) == -1.602170");
+    df = E_UnitRoot("ACAF+ACAG", 1, 0, 0);
+    S4ASSERT(U_test_eq(df[2], -2.490054), "E_UnitRoot(\"ACAF+ACAG\", 1, 0, 0) == -2.49005");
+    df = E_UnitRoot("ACAF+ACAG", 1, 1, 0);
+    S4ASSERT(U_test_eq(df[2], -2.638717), "E_UnitRoot(\"ACAF+ACAG\", 1, 1, 0) == -2.638717");
+    df = E_UnitRoot("ACAF+ACAG", 0, 0, 1);
+    S4ASSERT(U_test_eq(df[2], -1.300049), "E_UnitRoot(\"ACAF+ACAG\", 0, 0, 1) == -1.300049");
+        
     
     // Reset initial kmsg fn
     kmsg_super = kmsg_super_ptr; // Reset initial output to 
@@ -1087,7 +1095,7 @@ void Tests_SWAP()
     SW_free(item);
     SW_free(item);
     
-    // test 2 :  on réutilise l'espace freeé
+    // test 2 :  reusing freed space
     item = SW_alloc(15);
     SW_free(item);
     item2 = SW_alloc(10);
@@ -1119,7 +1127,7 @@ void Tests_B_DATA()
     U_test_CreateObjects();
     
     // B_DataPattern()
-    // Foireux. Faut utiliser des listes (avec A;B au lieu de $AB ça marche pas...) => A changer ? Voir B_DataListSort() 
+    // Foireux. Faut utiliser des listes (avec A;B au lieu de $AB ca marche pas...) => A changer ? Voir B_DataListSort() 
     B_DataPattern("RC xy $AB $BC", K_VAR); 
     lst = KLPTR("RC");
     S4ASSERT(U_cmp_strs(lst, "AB,AC,BB,BC"), "B_DataPattern(\"RC xy $AB $BC\", K_VAR) = \"AB,AC,BB,BC\"");
@@ -1321,7 +1329,7 @@ void U_test_create_a_file(char* filename, int type)
     //  Create a file
     U_test_suppress_a2m_msgs();
     W_dest(filename, type); 
-    W_printf("This is a paragraph with accents: éàâêë\n\n"); // the current source file (test1.c) is ANSI coded
+    W_printf("This is a paragraph with accents: éàâêë\n"); // the current source file (test1.c) is ANSI coded
     W_close();
 }
 
@@ -1563,7 +1571,7 @@ void Tests_B_XODE()
     char    rulefile[256];
     char    cmd[512];
     char    trace[] = " ";
-    int     cond, rc;
+    int     rc;
     
     U_test_print_title("Tests XODE: Import ASCII via report function");
     U_test_suppress_kmsg_msgs();
@@ -1658,7 +1666,7 @@ void Tests_B_HTOL()
     // Clear the vars and set the sample for the variable WS
     K_clear(KV_WS);
     smpl = PER_atosmpl("2000Y1", "2020Y1");
-    KV_sample(KV_WS, smpl);
+    KV_sample(KV_WS, smpl); 
     SCR_free(smpl);
     
     sprintf(varfile, "%s\\fun_q.var", IODE_DATA_DIR);
@@ -1684,10 +1692,171 @@ void Tests_B_HTOL()
     U_test_reset_kmsg_msgs();   
 }
 
-void Tests_B_Model()
+void Tests_B_MODEL()
 {
+//    KDB         *kdbv, 
+//                *kdbe, 
+//                *kdbs;
+//    SAMPLE      *smpl;
+//    char        *filename = "fun";
+//    U_ch**      endo_exo;
+//    int         rc;
+//    LIS         lst, expected_lst;
+//
+//    // B_Model*() tests
+//    // ----------------
+//    // X int B_ModelSimulate(char *arg)                              $ModelSimulate per_from per_to equation_list
+//    // X int B_ModelSimulateParms(char* arg)                         $ModelSimulateParms eps relax maxit {Connex | Triang | None } 0 - 4 (starting values) {Yes | no } {yes | No } nbtri
+//    // X int B_ModelExchange(char* arg)                              $ModelExchange eqname1-varname1,eqname2-varname2,...
+//    // X int B_ModelCompile(char* arg)                               $ModelCompile  [eqname1, eqname2, ... ]
+//    // X int B_ModelCalcSCC(char *arg)                               $ModelCalcSCC nbtris prename intername postname [eqs]
+//    // X int B_ModelSimulateSCC(char *arg)                           $ModelSimulateSCC from to pre inter post
+//    // int B_ModelSimulateSaveNIters(char *arg)                    $ModelSimulateSaveNiters varname
+//    // int B_ModelSimulateSaveNorms(char *arg)                     $ModelSimulateSaveNorms varname
+//
+//
+//    U_test_print_title("Tests B_Model*(): simulation parameters and model simulation");
+//    U_test_suppress_kmsg_msgs();
+//    
+//    
+//    // Loads 3 WS and check ok
+//    U_test_load_fun_esv(filename);
+//
+//    // Check
+//    kdbv = KV_WS;
+//    S4ASSERT(kdbv != NULL, "K_interpret(K_VAR, \"%s\")", filename);
+//    kdbs = KS_WS;
+//    S4ASSERT(kdbs != NULL, "K_interpret(K_SCL, \"%s\")", filename);
+//    kdbe = KE_WS;
+//    S4ASSERT(kdbe != NULL, "K_interpret(K_EQS, \"%s\")", filename);
+//    
+//    // B_ModelSimulateParms()
+//    KSIM_START = KV_INIT_TM1;
+//    KSIM_EPS = 0.00001;
+//    KSIM_MAXIT = 1000;
+//    KSIM_RELAX = 1.0;
+//    KSIM_SORT = 0;
+//    KSIM_PASSES = 3; 
+//    KSIM_DEBUG = 1;
+//    rc = B_ModelSimulateParms("0.0001 0.7 100 Both 0 no no 5");
+//    S4ASSERT(rc == 0, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") == 0");
+//    S4ASSERT(KSIM_EPS == 0.0001, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_EPS == 0.0001");
+//    S4ASSERT(KSIM_MAXIT == 100, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_MAXIT == 100");
+//    S4ASSERT(KSIM_RELAX == 0.7, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_RELAX == 0.7");
+//    S4ASSERT(KSIM_DEBUG == 0, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_DEBUG == 0");
+//
+//
+//    // B_ModelSimulate()
+//    rc = B_ModelSimulate("2000Y1 2002Y1");
+//    S4ASSERT(rc == 0, "B_ModelSimulate(\"2000Y1 2002Y1\") == 0");
+//    // TODO: check result of one ENDO
+//    S4ASSERT(U_test_eq(KV_get_at_aper("ACAF", "2002Y1"), -1.274623), "ACAF[2002Y1] = -1.274623");
+//    
+//    // B_ModelExchange()
+//    // Set values of endo UY
+//    KV_set_at_aper("UY", "2000Y1", 650.0);
+//    KV_set_at_aper("UY", "2001Y1", 670.0);
+//    KV_set_at_aper("UY", "2002Y1", 680.0);
+//
+//    // Exchange
+//    rc = B_ModelExchange("UY-XNATY");
+//    S4ASSERT(rc == 0, "B_ModelExchange(\"UY-XNATY\") == 0");
+//    
+//    // Simulate
+//    rc = B_ModelSimulate("2000Y1 2002Y1");
+//    S4ASSERT(rc == 0, "B_ModelSimulate(\"2000Y1 2002Y1\") == 0");
+//
+//    // Check some results
+//    S4ASSERT(KV_get_at_aper("UY", "2000Y1") == 650.0, "Exchange UY-XNATY: UY[2000Y1] == 650.0 unchanged");
+//    S4ASSERT(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.80071), "Exchange UY-XNATY: XNATY[2000Y1] == 0.80071");
+//    
+//    // B_ModelCompile(char* arg)
+//    rc = B_ModelCompile("");
+//    S4ASSERT(rc == 0, "B_ModelCompile(\"\") == 0");
+//
+//    // B_ModelCalcSCC(char *arg) $ModelCalcSCC nbtris prename intername postname [eqs]
+//    rc = B_ModelCalcSCC("5 _PRE2 _INTER2 _POST2");
+//    S4ASSERT(rc == 0, "B_ModelCalcSCC(\"5 _PRE2 _INTER2 _POST2\") == 0");
+//    rc = strcmp(KLPTR("_PRE2"), "BRUGP;DTH1C;EX;ITCEE;ITCR;ITGR;ITI5R;ITIFR;ITIGR;ITMQR;NATY;POIL;PW3;PWMAB;PWMS;PWXAB;PWXS;PXE;QAH;QWXAB;QWXS;QWXSS;SBGX;TFPFHP_;TWG;TWGP;ZZF_;DTH1;PME;PMS;PMT");
+//    S4ASSERT(rc == 0, "_PRE2 == BRUGP;DTH1C;EX;ITCEE;ITCR;ITGR;ITI5R;ITIFR;ITIGR;ITMQR;NATY;POIL;PW3;PWMAB;PWMS;PWXAB;PWXS;PXE;QAH;QWXAB;QWXS;QWXSS;SBGX;TFPFHP_;TWG;TWGP;ZZF_;DTH1;PME;PMS;PMT");
+//
+//    // int B_ModelSimulateSCC(char *arg)                           $ModelSimulateSCC from to pre inter post
+//    //  1. Annuler Exchange
+//    rc = B_ModelExchange("");
+//    S4ASSERT(rc == 0, "B_ModelExchange(\"\") == 0");
+//
+//    //  2. ReLoads 3 WS to reset EXO XNATY to its original value
+//    U_test_load_fun_esv(filename);
+//    
+//    //  3. Simulate & compare
+//    rc = B_ModelSimulateSCC("2000Y1 2002Y1 _PRE2 _INTER2 _POST2");
+//    S4ASSERT(rc == 0, "B_ModelSimulateSCC(\"2000Y1 2002Y1 _PRE2 _INTER2 _POST2\") == 0");
+//    S4ASSERT(U_test_eq(KV_get_at_aper("ACAF", "2002Y1"), -1.274623), "ACAF[2002Y1] = -1.274623");
+//        
+//    // B_ModelSimulateSaveNIters(char *arg)                    $ModelSimulateSaveNiters varname
+//    
+//    
+//
+//    U_test_reset_kmsg_msgs();      
 }
 
+
+void Tests_B_WS()
+{
+    char    fullfilename[256];
+    int     rc, cond;
+    
+// int B_WsLoad(char* arg, int type)                 $WsLoad<type> filename
+// int B_WsSave(char* arg, int type)                 $WsSave<type> filename
+// int B_WsSaveCmp(char* arg, int type)              $WsSaveCmp<type> filename
+// int B_WsExport(char* arg, int type)               $WsExport<type> filename
+// int B_WsImport(char* arg, int type)               $WsImport<type> filename
+// int B_WsSample(char* arg)                         $WsSample period_from period_to
+// int B_WsClear(char* arg, int type)                $WsClear<type> 
+// int B_WsClearAll(char* arg)                       $WsClearAll
+// int B_WsDescr(char* arg, int type)                $WsDescr<type> free text
+// int B_WsName(char* arg, int type)                 Sets the WS name. Obsolete as report function.
+// int B_WsCopy(char* arg, int type)                 $WsCopy<type> fichier;fichier;.. obj1 obj2... or $WsCopyVar file;file;.. [from to] obj1 obj2...
+// int B_WsMerge(char* arg, int type)                $WsMerge<type> filename
+// int B_WsExtrapolate(char* arg)                    $WsExtrapolate [method] from to [variable list]
+// int B_WsAggrChar(char* arg)                       $WsAggrChar char
+// int B_WsAggrSum(char* arg)                        $WsAggrSum pattern filename
+// int B_WsAggrProd(char* arg)                       $WsAggrProd pattern filename
+// int B_WsAggrMean(char* arg)                       $WsAggrMean pattern filename
+// int B_StatUnitRoot(char* arg)                     $StatUnitRoot drift trend order expression
+// int B_CsvSave(char* arg, int type)                $CsvSave<type> file name1 name2 ...
+// int B_CsvNbDec(char *nbdec)                       $CsvNbDec nn
+// int B_CsvSep(char *sep)                           $CsvSep char
+// int B_CsvNaN(char *nan)                           $CsvNaN text
+// int B_CsvAxes(char *var)                          $CsvAxes AxisName
+// int B_CsvDec(char *dec)                           $CsvDec char
+
+//    U_test_print_title("Tests B_Model*(): simulation parameters and model simulation");
+//    U_test_suppress_kmsg_msgs();
+//
+//    // int B_WsLoad(char* arg, int type)                 $WsLoad<type> filename
+//    sprintf(fullfilename,  "%s\\fun", IODE_DATA_DIR);
+//    rc = B_WsLoad(fullfilename, K_VAR);
+//    cond = (rc == 0) && (KV_WS->k_nb == 394); 
+//    S4ASSERT(cond, "B_WsLoad(\"%s\") == 0 -- nb objects=%d", fullfilename, KV_WS->k_nb);
+//    
+//    // int B_WsSave(char* arg, int type)                 $WsSave<type> filename
+//    rc = B_WsSave("fun2", K_VAR);
+//    B_WsClear("", K_VAR);
+//    rc = B_WsLoad("fun2", K_VAR);
+//    cond = (rc == 0) && (KV_WS->k_nb == 394); 
+//    S4ASSERT(cond, "B_WsSave(\"fun2\") == 0 -- nb objects=%d", KV_WS->k_nb);
+//    
+//    // int B_WsSaveCmp(char* arg, int type)              $WsSaveCmp<type> filename
+//    rc = B_WsSaveCmp("fun2cmp", K_VAR);
+//    B_WsClear("", K_VAR);
+//    rc = B_WsLoad("fun2cmp", K_VAR);
+//    cond = (rc == 0) && (KV_WS->k_nb == 394); 
+//    S4ASSERT(cond, "B_WsSaveCmp(\"fun2cmp\") == 0 -- nb objects=%d", KV_WS->k_nb);
+//    
+    
+    
+}
 // ================================================================================================
 
 
@@ -1756,7 +1925,8 @@ int main(int argc, char **argv)
     Tests_B_LTOH();
     Tests_B_HTOL();
     
-    Tests_B_Model();
+    Tests_B_MODEL();
+    Tests_B_WS();
    
     //K_save_iode_ini(); // Suppress that call ? Should only be called on demand, not at the end of each IODE session.
     
@@ -1834,6 +2004,16 @@ X   "wsltohstock",              B_WsLtoHStock,          SB_WsLtoH,          0,
     "wstrendstd",               B_WsTrendStd,           SB_WsTrend,         0,
     
     "wsimporteviews",			B_WsImportEviews,       NULL, 		        0,
+
+    "csvsave",                  B_CsvSave,              NULL,               3,
+    "csvdigits",                B_CsvNbDec,             NULL,               0,
+    "csvsep",                   B_CsvSep,               NULL,               0,
+    "csvdec",                   B_CsvDec,               NULL,               0,
+    "csvnan",                   B_CsvNaN,               NULL,               0,
+    "csvaxes",                  B_CsvAxes,              NULL,               0,
+
+
+
 
 // b_data.c 
 -   "dataedit",                 NULL,                   SB_DataEditScroll,  1,
@@ -1927,13 +2107,13 @@ X   "eqssetcmt",                B_EqsSetCmt,            NULL,               0,
     "printgrall",               B_PrintGr,              SB_ViewPrintGr,     0,
     "printgr",                  B_PrintGr,              SB_ViewPrintGr,     0,
     
-    "modelsimulate",            B_ModelSimulate,        SB_ModelSimulate,   0,
-    "modelsimulateparms",       B_ModelSimulateParms,   NULL,               0,
-    "modelexchange",            B_ModelExchange,        NULL,               0,
-    "modelcompile",             B_ModelCompile, 	    SB_ModelCompile,    0,
+X   "modelsimulate",            B_ModelSimulate,        SB_ModelSimulate,   0,
+X   "modelsimulateparms",       B_ModelSimulateParms,   NULL,               0,
+X   "modelexchange",            B_ModelExchange,        NULL,               0,
+X   "modelcompile",             B_ModelCompile, 	    SB_ModelCompile,    0,
     
-    "modelcalcscc",             B_ModelCalcSCC,         NULL,               0,
-    "modelsimulatescc",         B_ModelSimulateSCC,     NULL,               0,
+X   "modelcalcscc",             B_ModelCalcSCC,         NULL,               0,
+X   "modelsimulatescc",         B_ModelSimulateSCC,     NULL,               0,
 
     "modelsimulatesaveniters",  B_ModelSimulateSaveNIters,  NULL,           0,
     "modelsimulatesavenorms",   B_ModelSimulateSaveNorms,   NULL,           0,
@@ -2013,15 +2193,5 @@ X    "sysoemtoansi",             B_SysOemToAnsi,         NULL,               0,
     "a2mtocsv",                 B_A2mToCsv,             NULL,               0,
     "a2mtortf",                 B_A2mToRtf,             NULL,               0,
     "a2mtoprinter",             B_A2mToPrinter,         NULL,               0,
-                
-    "csvsave",                  B_CsvSave,              NULL,               3,
-    "csvdigits",                B_CsvNbDec,             NULL,               0,
-    "csvsep",                   B_CsvSep,               NULL,               0,
-    "csvdec",                   B_CsvDec,               NULL,               0,
-    "csvnan",                   B_CsvNaN,               NULL,               0,
-    "csvaxes",                  B_CsvAxes,              NULL,               0,
-
-
-
 
 */

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -452,7 +452,7 @@ public:
 	    //  Create a file
 	    U_test_suppress_a2m_msgs();
 	    W_dest(filename, type);
-	    W_printf("This is a paragraph with accents: éàâêë\n\n"); // the current source file (test1.c) is ANSI coded
+	    W_printf("This is a paragraph with accents: éàâêë\n"); // the current source file (test1.c) is ANSI coded
 	    W_close();
 	}
 
@@ -757,14 +757,14 @@ TEST_F(IodeCAPITest, Tests_Simulation)
 
     // Test Endo-exo
 
-    // Version avec échange dans une seule équation
+    // Version with exchange in one equation only
     // endo_exo = SCR_vtoms("UY-NIY", ",; ");
     // rc = K_simul(kdbe, kdbv, kdbs, smpl, endo_exo, NULL);
     // S4ASSERT(rc == 0, "Exchange UY-NIY converges on 2000Y1-2002Y1");
     // S4ASSERT(UY[pos2000] == 650.0, "Exchange UY-NIY: UY[2000Y1] == 650.0");
     // S4ASSERT(fabs(NIY[pos2000] - 658.423) < 0.01, "Exchange UY-NIY: NIY[2000Y1] == 658.423");
 
-    // Version avec échange dans min 2 equations
+    // Version with exchange in at least 2 equations
     // Set values of endo UY
     KV_set_at_aper("UY", "2000Y1", 650.0);
     KV_set_at_aper("UY", "2001Y1", 670.0);
@@ -857,7 +857,7 @@ TEST_F(IodeCAPITest, Tests_Estimation)
     int         rc;
     void        (*kmsg_super_ptr)(char*);
     SAMPLE      *smpl;
-    IODE_REAL   r2;
+    IODE_REAL   r2, *df;
 
     U_test_suppress_a2m_msgs();
     U_test_print_title("Tests Estimation");
@@ -896,7 +896,15 @@ TEST_F(IodeCAPITest, Tests_Estimation)
     SCR_free(smpl);
 
     // Dickey-Fuller test (E_UnitRoot)
-    // TODO: implement a test
+    df = E_UnitRoot("ACAF+ACAG", 0, 0, 0);
+    EXPECT_TRUE(U_test_eq(df[2], -1.602170));
+    df = E_UnitRoot("ACAF+ACAG", 1, 0, 0);
+    EXPECT_TRUE(U_test_eq(df[2], -2.490054));
+    df = E_UnitRoot("ACAF+ACAG", 1, 1, 0);
+    EXPECT_TRUE(U_test_eq(df[2], -2.638717));
+    df = E_UnitRoot("ACAF+ACAG", 0, 0, 1);
+    EXPECT_TRUE(U_test_eq(df[2], -1.300049));
+
 
     // Reset initial kmsg fn
     kmsg_super = kmsg_super_ptr; // Reset initial output to
@@ -965,7 +973,7 @@ TEST_F(IodeCAPITest, Tests_SWAP)
     SW_free(item);
     SW_free(item);
 
-    // test 2 :  on réutilise l'espace freeé
+    // test 2 :  reusing freed space
     item = SW_alloc(15);
     SW_free(item);
     item2 = SW_alloc(10);
@@ -996,7 +1004,7 @@ TEST_F(IodeCAPITest, Tests_B_DATA)
     U_test_CreateObjects();
 
     // B_DataPattern()
-    // Foireux. Faut utiliser des listes (avec A;B au lieu de $AB ça marche pas...) => A changer ? Voir B_DataListSort()
+    // Foireux. Faut utiliser des listes (avec A;B au lieu de $AB ca marche pas...) => A changer ? Voir B_DataListSort()
     B_DataPattern("RC xy $AB $BC", K_VAR);
     lst = KLPTR("RC");
     EXPECT_TRUE(U_cmp_strs(lst, "AB,AC,BB,BC"));
@@ -1387,7 +1395,7 @@ TEST_F(IodeCAPITest, Tests_B_XODE)
     char    rulefile[256];
     char    cmd[512];
     char    trace[] = " ";
-    int     cond, rc;
+    int     rc;
 
     U_test_print_title("Tests XODE: Import ASCII via report function");
     U_test_suppress_kmsg_msgs();
@@ -1510,8 +1518,170 @@ TEST_F(IodeCAPITest, Tests_B_HTOL)
 }
 
 
-TEST_F(IodeCAPITest, Tests_B_Model)
+TEST_F(IodeCAPITest, Tests_B_MODEL)
 {
+//    KDB         *kdbv,
+//                *kdbe,
+//                *kdbs;
+//    SAMPLE      *smpl;
+//    char        *filename = "fun";
+//    U_ch**      endo_exo;
+//    int         rc;
+//    LIS         lst, expected_lst;
+//
+//    // B_Model*() tests
+//    // ----------------
+//    // X int B_ModelSimulate(char *arg)                              $ModelSimulate per_from per_to equation_list
+//    // X int B_ModelSimulateParms(char* arg)                         $ModelSimulateParms eps relax maxit {Connex | Triang | None } 0 - 4 (starting values) {Yes | no } {yes | No } nbtri
+//    // X int B_ModelExchange(char* arg)                              $ModelExchange eqname1-varname1,eqname2-varname2,...
+//    // X int B_ModelCompile(char* arg)                               $ModelCompile  [eqname1, eqname2, ... ]
+//    // X int B_ModelCalcSCC(char *arg)                               $ModelCalcSCC nbtris prename intername postname [eqs]
+//    // X int B_ModelSimulateSCC(char *arg)                           $ModelSimulateSCC from to pre inter post
+//    // int B_ModelSimulateSaveNIters(char *arg)                    $ModelSimulateSaveNiters varname
+//    // int B_ModelSimulateSaveNorms(char *arg)                     $ModelSimulateSaveNorms varname
+//
+//
+//    U_test_print_title("Tests B_Model*(): simulation parameters and model simulation");
+//    U_test_suppress_kmsg_msgs();
+//
+//
+//    // Loads 3 WS and check ok
+//    U_test_load_fun_esv(filename);
+//
+//    // Check
+//    kdbv = KV_WS;
+//    S4ASSERT(kdbv != NULL, "K_interpret(K_VAR, \"%s\")", filename);
+//    kdbs = KS_WS;
+//    S4ASSERT(kdbs != NULL, "K_interpret(K_SCL, \"%s\")", filename);
+//    kdbe = KE_WS;
+//    S4ASSERT(kdbe != NULL, "K_interpret(K_EQS, \"%s\")", filename);
+//
+//    // B_ModelSimulateParms()
+//    KSIM_START = KV_INIT_TM1;
+//    KSIM_EPS = 0.00001;
+//    KSIM_MAXIT = 1000;
+//    KSIM_RELAX = 1.0;
+//    KSIM_SORT = 0;
+//    KSIM_PASSES = 3;
+//    KSIM_DEBUG = 1;
+//    rc = B_ModelSimulateParms("0.0001 0.7 100 Both 0 no no 5");
+//    S4ASSERT(rc == 0, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") == 0");
+//    S4ASSERT(KSIM_EPS == 0.0001, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_EPS == 0.0001");
+//    S4ASSERT(KSIM_MAXIT == 100, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_MAXIT == 100");
+//    S4ASSERT(KSIM_RELAX == 0.7, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_RELAX == 0.7");
+//    S4ASSERT(KSIM_DEBUG == 0, "B_ModelSimulateParms(\"0.0001 0.7 100 Both 0 no no 5\") => KSIM_DEBUG == 0");
+//
+//
+//    // B_ModelSimulate()
+//    rc = B_ModelSimulate("2000Y1 2002Y1");
+//    S4ASSERT(rc == 0, "B_ModelSimulate(\"2000Y1 2002Y1\") == 0");
+//    // TODO: check result of one ENDO
+//    S4ASSERT(U_test_eq(KV_get_at_aper("ACAF", "2002Y1"), -1.274623), "ACAF[2002Y1] = -1.274623");
+//
+//    // B_ModelExchange()
+//    // Set values of endo UY
+//    KV_set_at_aper("UY", "2000Y1", 650.0);
+//    KV_set_at_aper("UY", "2001Y1", 670.0);
+//    KV_set_at_aper("UY", "2002Y1", 680.0);
+//
+//    // Exchange
+//    rc = B_ModelExchange("UY-XNATY");
+//    S4ASSERT(rc == 0, "B_ModelExchange(\"UY-XNATY\") == 0");
+//
+//    // Simulate
+//    rc = B_ModelSimulate("2000Y1 2002Y1");
+//    S4ASSERT(rc == 0, "B_ModelSimulate(\"2000Y1 2002Y1\") == 0");
+//
+//    // Check some results
+//    S4ASSERT(KV_get_at_aper("UY", "2000Y1") == 650.0, "Exchange UY-XNATY: UY[2000Y1] == 650.0 unchanged");
+//    S4ASSERT(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.80071), "Exchange UY-XNATY: XNATY[2000Y1] == 0.80071");
+//
+//    // B_ModelCompile(char* arg)
+//    rc = B_ModelCompile("");
+//    S4ASSERT(rc == 0, "B_ModelCompile(\"\") == 0");
+//
+//    // B_ModelCalcSCC(char *arg) $ModelCalcSCC nbtris prename intername postname [eqs]
+//    rc = B_ModelCalcSCC("5 _PRE2 _INTER2 _POST2");
+//    S4ASSERT(rc == 0, "B_ModelCalcSCC(\"5 _PRE2 _INTER2 _POST2\") == 0");
+//    rc = strcmp(KLPTR("_PRE2"), "BRUGP;DTH1C;EX;ITCEE;ITCR;ITGR;ITI5R;ITIFR;ITIGR;ITMQR;NATY;POIL;PW3;PWMAB;PWMS;PWXAB;PWXS;PXE;QAH;QWXAB;QWXS;QWXSS;SBGX;TFPFHP_;TWG;TWGP;ZZF_;DTH1;PME;PMS;PMT");
+//    S4ASSERT(rc == 0, "_PRE2 == BRUGP;DTH1C;EX;ITCEE;ITCR;ITGR;ITI5R;ITIFR;ITIGR;ITMQR;NATY;POIL;PW3;PWMAB;PWMS;PWXAB;PWXS;PXE;QAH;QWXAB;QWXS;QWXSS;SBGX;TFPFHP_;TWG;TWGP;ZZF_;DTH1;PME;PMS;PMT");
+//
+//    // int B_ModelSimulateSCC(char *arg)                           $ModelSimulateSCC from to pre inter post
+//    //  1. Annuler Exchange
+//    rc = B_ModelExchange("");
+//    S4ASSERT(rc == 0, "B_ModelExchange(\"\") == 0");
+//
+//    //  2. ReLoads 3 WS to reset EXO XNATY to its original value
+//    U_test_load_fun_esv(filename);
+//
+//    //  3. Simulate & compare
+//    rc = B_ModelSimulateSCC("2000Y1 2002Y1 _PRE2 _INTER2 _POST2");
+//    S4ASSERT(rc == 0, "B_ModelSimulateSCC(\"2000Y1 2002Y1 _PRE2 _INTER2 _POST2\") == 0");
+//    S4ASSERT(U_test_eq(KV_get_at_aper("ACAF", "2002Y1"), -1.274623), "ACAF[2002Y1] = -1.274623");
+//
+//    // B_ModelSimulateSaveNIters(char *arg)                    $ModelSimulateSaveNiters varname
+//
+//
+//
+//    U_test_reset_kmsg_msgs();
+}
+
+
+TEST_F(IodeCAPITest, Tests_B_WS)
+{
+    char    fullfilename[256];
+    int     rc, cond;
+
+// int B_WsLoad(char* arg, int type)                 $WsLoad<type> filename
+// int B_WsSave(char* arg, int type)                 $WsSave<type> filename
+// int B_WsSaveCmp(char* arg, int type)              $WsSaveCmp<type> filename
+// int B_WsExport(char* arg, int type)               $WsExport<type> filename
+// int B_WsImport(char* arg, int type)               $WsImport<type> filename
+// int B_WsSample(char* arg)                         $WsSample period_from period_to
+// int B_WsClear(char* arg, int type)                $WsClear<type>
+// int B_WsClearAll(char* arg)                       $WsClearAll
+// int B_WsDescr(char* arg, int type)                $WsDescr<type> free text
+// int B_WsName(char* arg, int type)                 Sets the WS name. Obsolete as report function.
+// int B_WsCopy(char* arg, int type)                 $WsCopy<type> fichier;fichier;.. obj1 obj2... or $WsCopyVar file;file;.. [from to] obj1 obj2...
+// int B_WsMerge(char* arg, int type)                $WsMerge<type> filename
+// int B_WsExtrapolate(char* arg)                    $WsExtrapolate [method] from to [variable list]
+// int B_WsAggrChar(char* arg)                       $WsAggrChar char
+// int B_WsAggrSum(char* arg)                        $WsAggrSum pattern filename
+// int B_WsAggrProd(char* arg)                       $WsAggrProd pattern filename
+// int B_WsAggrMean(char* arg)                       $WsAggrMean pattern filename
+// int B_StatUnitRoot(char* arg)                     $StatUnitRoot drift trend order expression
+// int B_CsvSave(char* arg, int type)                $CsvSave<type> file name1 name2 ...
+// int B_CsvNbDec(char *nbdec)                       $CsvNbDec nn
+// int B_CsvSep(char *sep)                           $CsvSep char
+// int B_CsvNaN(char *nan)                           $CsvNaN text
+// int B_CsvAxes(char *var)                          $CsvAxes AxisName
+// int B_CsvDec(char *dec)                           $CsvDec char
+
+//    U_test_print_title("Tests B_Model*(): simulation parameters and model simulation");
+//    U_test_suppress_kmsg_msgs();
+//
+//    // int B_WsLoad(char* arg, int type)                 $WsLoad<type> filename
+//    sprintf(fullfilename,  "%s\\fun", input_test_dir);
+//    rc = B_WsLoad(fullfilename, K_VAR);
+//    cond = (rc == 0) && (KV_WS->k_nb == 394);
+//    S4ASSERT(cond, "B_WsLoad(\"%s\") == 0 -- nb objects=%d", fullfilename, KV_WS->k_nb);
+//
+//    // int B_WsSave(char* arg, int type)                 $WsSave<type> filename
+//    rc = B_WsSave("fun2", K_VAR);
+//    B_WsClear("", K_VAR);
+//    rc = B_WsLoad("fun2", K_VAR);
+//    cond = (rc == 0) && (KV_WS->k_nb == 394);
+//    S4ASSERT(cond, "B_WsSave(\"fun2\") == 0 -- nb objects=%d", KV_WS->k_nb);
+//
+//    // int B_WsSaveCmp(char* arg, int type)              $WsSaveCmp<type> filename
+//    rc = B_WsSaveCmp("fun2cmp", K_VAR);
+//    B_WsClear("", K_VAR);
+//    rc = B_WsLoad("fun2cmp", K_VAR);
+//    cond = (rc == 0) && (KV_WS->k_nb == 394);
+//    S4ASSERT(cond, "B_WsSaveCmp(\"fun2cmp\") == 0 -- nb objects=%d", KV_WS->k_nb);
+//
+
+
 }
 
 


### PR DESCRIPTION
### api/e_dftest.c:
    - E_UnitRoot():
        - accepts a LEC expression instead of a VAR name
        - computes and deletes the _DF variable
### tests/test1.c:
    - some translation to avoid utf-8 illegible chars
    - Tests_Estimation(): implementation of Dickey-Fuller tests (E_UnitRoot)
    - test_c_api.cpp: regenerated