### PR TITLE
API: improved Var and Cmt import

### DIFF
--- a/api/b_ws.c
+++ b/api/b_ws.c
@@ -136,7 +136,7 @@ int B_WsDump(KDB* kdb, char* filename)
 {
     int     rc = -1, ftype, type = KTYPE(kdb);
 
-    kmsg("Saving %s", filename);
+    // kmsg("Saving %s", filename); // JMP 13/12/2022 (msg already in with K_save_kdb)
     ftype = X_findtype(filename);
 
     if(ftype >= 10 && ftype <= 17)

--- a/api/b_xode.c
+++ b/api/b_xode.c
@@ -8,7 +8,7 @@
  *  List of functions 
  *  -----------------
  *      int B_FileImportCmt(char* arg)  $FileImportCmt format rule infile outfile language [trace]
- *      int B_FileImportVar(char* arg)  $FileImportVar format rule infile outfile from to  [trace]$FileImportVar format rule infile outfile from to  [trace]
+ *      int B_FileImportVar(char* arg)  $FileImportVar format rule infile outfile from to  [trace]
  */
 
 #include "iode.h"

--- a/api/k_graph.c
+++ b/api/k_graph.c
@@ -585,7 +585,7 @@ int V_graph(int view, int mode, int type, int xgrid, int ygrid, int axis, double
 
 
 // =============================================================================================================================
-// API CHART: used in b_api.c but what for ???
+// API CHART: used in b_api.c but for what purpose ???
 // TODO: answer this question...
 // -----------------------------------------------------------------------------------------------------------------------------
 

--- a/api/k_imain.c
+++ b/api/k_imain.c
@@ -226,13 +226,13 @@ err:
  *  @param [in] char*   rule    rule file
  *  @param [in] char*   ode     output IODE file
  *  @param [in] char*   asc     input filename
- *  @param [in] int     fmt     input format: 0=ASCII_CMT, 1=-, 2=-, 3=Bistel_CMT 4=-, 5=-, 6=PRN_CMT, 7=TXT_CMT
+ *  @param [in] int     fmt     input format: 0=ASCII_CMT (=default), 1=-, 2=-, 3=Bistel_CMT 4=-, 5=-, 6=PRN_CMT, 7=TXT_CMT
  *  @param [in] int     lang    0=English, 1=French , 2=Dutch 
- *  @return     int             0 always (TODO: correct this)
+ *  @return     int             0 on success, -1 on error (IMP_InterpretCmt() ==  NULL or K_save() return code)
  */
 static int IMP_RuleImportCmt(char* trace, char* rule, char* ode, char* asc, int fmt, int lang)
 {
-    int     rc = 0;
+    int     rc = -1;
     KDB     *kdb;
     IMPDEF  *impdef;
 
@@ -251,10 +251,7 @@ static int IMP_RuleImportCmt(char* trace, char* rule, char* ode, char* asc, int 
         K_WARN_DUP = 1;
     }
     switch(fmt) {
-        case 0:
-            impdef = &IMP_ASC_CMT;
-            break; /* JMP 11-01-99 */
-        case 1:
+         case 1:
             impdef = NULL;
             break;
         case 2:
@@ -275,16 +272,19 @@ static int IMP_RuleImportCmt(char* trace, char* rule, char* ode, char* asc, int 
         case 7:
             impdef = &IMP_TXT_CMT;
             break;
+        default:        // JMP 05/01/2023         
+            impdef = &IMP_ASC_CMT;
+            break; 
     }
 
     kdb = IMP_InterpretCmt(impdef, rule, asc, lang);
     if(kdb != NULL) {
-        K_save(kdb, ode);
+        rc = K_save(kdb, ode);
         K_free(kdb);
     }
 
     if(IMP_trace) W_close();
-    return(0);
+    return(rc);
 }
 
 
@@ -298,11 +298,11 @@ static int IMP_RuleImportCmt(char* trace, char* rule, char* ode, char* asc, int 
  *  @param [in] char*   from    starting period of the sample to be read
  *  @param [in] char*   to      ending period of the sample
  *  @param [in] int     fmt     input format: 0=ASCII, 1=ROT_ASCII, 2=DIF, 3=Bistel, 4=NIS, 5=GEM, 6=PRN, 7=TXT
- *  @return     int             0 always (TODO: correct this)
+ *  @return     int             0 on success, -1 on error (IMP_InterpretVar() ==  NULL or K_save() return code)
  */
 static int IMP_RuleImportVar(char* trace, char* rule, char* ode, char* asc, char* from, char* to, int fmt)
 {
-    int     rc = 0;
+    int     rc = -1;
     SAMPLE  *smpl;
     KDB     *kdb;
     IMPDEF  *impdef;
@@ -323,9 +323,6 @@ static int IMP_RuleImportVar(char* trace, char* rule, char* ode, char* asc, char
     }
 
     switch(fmt) {
-        case 0:
-            impdef = &IMP_ASC;
-            break;
         case 1:
             impdef = &IMP_RASC;
             break;
@@ -347,6 +344,10 @@ static int IMP_RuleImportVar(char* trace, char* rule, char* ode, char* asc, char
         case 7:
             impdef = &IMP_TXT;
             break;
+        default :
+            impdef = &IMP_ASC;
+            break;
+             
     }
 
     SCR_strip(from);
@@ -358,12 +359,12 @@ static int IMP_RuleImportVar(char* trace, char* rule, char* ode, char* asc, char
 
     kdb = IMP_InterpretVar(impdef, rule, asc, smpl);
     if(kdb != NULL) {
-        K_save(kdb, ode);
+        rc = K_save(kdb, ode);
         K_free(kdb);
     }
 
     if(IMP_trace) W_close();
-    return(0);
+    return(rc);
 }
 
 /**
@@ -378,22 +379,24 @@ static int IMP_RuleImportVar(char* trace, char* rule, char* ode, char* asc, char
  *  @param [in] char*   to      ending period of the sample
  *  @param [in] int     fmt     input format: 0=ASCII, 1=ROT_ASCII, 2=DIF, 3=Bistel, 4=NIS, 5=GEM, 6=PRN, 7=TXT
  *  @param [in] int     lang    0=English, 1=French , 2=Dutch  
- *  @return     int             0 always (TODO: correct this)
+ *  @return     int             0 on success, -1 on error
  */
 int IMP_RuleImport(int type, char* trace, char* rule, char* ode, char* asc, char* from, char* to, int fmt, int lang)
 {
+    int     rc = -1;
+    
     switch(type) {
         case K_CMT   :
-            IMP_RuleImportCmt(trace, rule, ode, asc, fmt, lang);
+            rc = IMP_RuleImportCmt(trace, rule, ode, asc, fmt, lang);
             break;
 
         case K_VAR   :
-            IMP_RuleImportVar(trace, rule, ode, asc, from, to, fmt);
+            rc = IMP_RuleImportVar(trace, rule, ode, asc, from, to, fmt);
             break;
 
         default :
             break;
     }
     K_WARN_DUP = 0;
-    return(0);
+    return(rc);
 }

--- a/api/per.c
+++ b/api/per.c
@@ -312,6 +312,7 @@ err:
     return(smpl);
 }
 
+
 /**
  *  Returns a new allocated SAMPLE build on two given PERIOD.
  *  
@@ -341,9 +342,6 @@ fin:
     return(smpl);
 }
 
-/*
-    Converts the sample into a string
-*/
 
 /**
  *  Writes a SAMPLE in a string.
@@ -361,6 +359,7 @@ char *PER_smpltoa(SAMPLE* smpl, char* text)
             PER_pertoa(&(smpl->s_p2), b2));
     return(text);
 }
+
 
 /**
  *  Retrieves the number of periods in one year in a period.

--- a/tests/test_c_api/test1.c
+++ b/tests/test_c_api/test1.c
@@ -1610,7 +1610,7 @@ void Tests_IMP_EXP()
     S4ASSERT(cond == 1, "EXP_RuleExport(\" \", \"%s\", \"%s\", \"%s\", \"%s\", \"1995Y1\", \"2005Y1\", \"#N/A\", \";\", EXP_RCSV)", rulefile, outfile, varfile, cmtfile);
 
 
-    U_test_print_title("Tests IMP: Import Ascii");
+    U_test_print_title("Tests IMP VAR: Import Ascii Variables");
     
     sprintf(reffile, "%s\\fun_xode.av.ref", IODE_DATA_DIR);
     sprintf(outfile, "%s\\fun_xode.var", IODE_OUTPUT_DIR);
@@ -1619,10 +1619,22 @@ void Tests_IMP_EXP()
     
     KV_RWS = KV_WS = K_interpret(K_VAR, outfile);  
     U_test_lec("ACAF[2002Y1]", "ACAF[2002Y1]", 0, -0.92921251);
+
+
+    U_test_print_title("Tests IMP CMT: Import Ascii Comments");
+   
+    sprintf(reffile, "%s\\fun_xode.ac.ref", IODE_DATA_DIR);
+    sprintf(outfile, "%s\\fun_xode.cmt", IODE_OUTPUT_DIR);
+    rc = IMP_RuleImport(K_CMT, trace, rulefile, outfile, reffile, NULL, NULL, IMP_FMT_ASCII, 0);
+    S4ASSERT(rc == 0, "IMP_RuleImport(K_CMT, trace, \"%s\", \"%s\", \"%s\", NULL, NULL, IMP_FMT_ASCII, 0)", rulefile, outfile, reffile);
     
+    if(rc == 0) {
+        KC_RWS = KC_WS = K_interpret(K_CMT, outfile);  
+        cond = (KC_WS != NULL) && U_cmp_strs(KCPTR("KK_AF"), "Ondernemingen: ontvangen kapitaaloverdrachten.");
+        S4ASSERT(cond == 1, "KK_AF == \"Ondernemingen: ontvangen kapitaaloverdrachten.\"");
+    }
     
     U_test_reset_kmsg_msgs(); 
-
 }
 
 

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -1835,7 +1835,7 @@ TEST_F(IodeCAPITest, Tests_IMP_EXP)
     EXPECT_EQ(cond, 1);
 
 
-    U_test_print_title("Tests IMP: Import Ascii");
+    U_test_print_title("Tests IMP VAR: Import Ascii Variables");
 
     sprintf(reffile, "%s\\fun_xode.av.ref", IODE_DATA_DIR);
     sprintf(outfile, "%s\\fun_xode.var", IODE_OUTPUT_DIR);
@@ -1846,8 +1846,20 @@ TEST_F(IodeCAPITest, Tests_IMP_EXP)
     U_test_lec("ACAF[2002Y1]", "ACAF[2002Y1]", 0, -0.92921251);
 
 
-    U_test_reset_kmsg_msgs();
+    U_test_print_title("Tests IMP CMT: Import Ascii Comments");
 
+    sprintf(reffile, "%s\\fun_xode.ac.ref", IODE_DATA_DIR);
+    sprintf(outfile, "%s\\fun_xode.cmt", IODE_OUTPUT_DIR);
+    rc = IMP_RuleImport(K_CMT, trace, rulefile, outfile, reffile, NULL, NULL, IMP_FMT_ASCII, 0);
+    EXPECT_EQ(rc, 0);
+
+    if(rc == 0) {
+        KC_RWS = KC_WS = K_interpret(K_CMT, outfile);
+        cond = (KC_WS != NULL) && U_cmp_strs(KCPTR("KK_AF"), "Ondernemingen: ontvangen kapitaaloverdrachten.");
+        EXPECT_EQ(cond, 1);
+    }
+
+    U_test_reset_kmsg_msgs();
 }
 
 


### PR DESCRIPTION
### CMT and VAR Import 

api/k_imain.c:
    - IMP_RuleImportCmt(): returns -1 on error (input file not found, error in saving result file), 0 on success
    - IMP_RuleImportCmt(): default fmt set to ASCII_CMT (there was no default)
    - IMP_RuleImport():  same return code as IMP_RuleImportCmt()
    - IMP_RuleImportVar(): returns -1 on error (input file not found, error in saving result file), 0 on success
    - IMP_RuleImportVar(): default fmt set to ASCII_CMT (there was no default)
    - IMP_RuleImport():  return code of IMP_RuleImportCmt() or IMP_RuleImportVar()

### Tests
tests/test_c_api/test1.c:
    - Tests_IMP_EXP(): added new call to IMP_RuleImport() for CMT with rule file data/rules.txt and input file data/fun_xode.ac.ref

### Minor changes
api/b_ws.c: B_WsDump(): message Saving ... deleted.
api/k_graph.c, per.c, b_xode.c: typos in comments
