### PR TITLE
jmp_doc_typos

### DIFF
--- a/doc/src/lec.m
+++ b/doc/src/lec.m
@@ -527,8 +527,8 @@ voici la liste :
     s‚rie expr2 comme s‚rie apparent‚e par une m‚thode g‚om‚trique
 &EN dapp(expr1, expr2) : fournit par diff‚rences une valeur … expr1 en t en
     utilisant la s‚rie expr2 comme s‚rie apparent‚e
-&EN hp([[from,]to],expr)        : filtre Hodrick-Prescott avec passage au ~clog~C de ~cexpr~C
-&EN hpstd([[from,]to],expr)     : calcul sans passage au ~clog~C de ~cexpr~C
+&EN hp([ [from,]to],expr)        : filtre Hodrick-Prescott avec passage au ~clog~C de ~cexpr~C
+&EN hpstd([ [from,]to],expr)     : calcul sans passage au ~clog~C de ~cexpr~C
 &EN appdif(expr1, expr2) : alias de dapp()
 
 
@@ -998,8 +998,8 @@ m‚thode d'Hodrick-Prescot d‚crite ici : <Hodrick-Prescott Filter>.
 
 
 &CO
-    hp([[from,]to],expr)     : calcul sur base du logarithme de ~cexpr~C
-    hpstd([[from,]to],expr)  : calcul sans passage au logarithme de ~cexpr~C
+    hp([ [from,]to],expr)     : calcul sur base du logarithme de ~cexpr~C
+    hpstd([ [from,]to],expr)  : calcul sans passage au logarithme de ~cexpr~C
 &TX
 Les paramŠtres sont :
 &EN from : p‚riode de d‚part du calcul, premiŠre ann‚e par d‚faut

--- a/doc/src/readme.m
+++ b/doc/src/readme.m
@@ -32,9 +32,9 @@ dor‚navant tronqu‚ … 10K.
 L'impression de certains objet de taille importante pouvait g‚n‚rer un arrˆt de IODE. Le texte g‚n‚r‚ est 
 dor‚navant tronqu‚ … 10K. 
 
-&TI $WsCopyVar and $CsvSave*
+&TI WsCopyVar and CsvSave*
 ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
-Les virgules sont accept‚es comme s‚parateurs entre les noms des objets … copier ($WsCopyVar) ou … sauver ($CsvSaveVar par exemple).
+Les virgules sont accept‚es comme s‚parateurs entre les noms des objets … copier (WsCopyVar) ou … sauver (CsvSaveVar par exemple).
 
 
 >
@@ -528,7 +528,7 @@ est plus en ligne avec les r‚sultats obtenus avec les logiciels standard comme s
 &IT Nouvel op‚rateur LEC
 ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ
 &CO
-    hpstd([[from,]to],expr)  : calcul sans passage au logarithme de ~cexpr~C
+    hpstd([ [from,]to],expr)  : calcul sans passage au logarithme de ~cexpr~C
 &TX
 
 Les paramŠtres sont :
@@ -3920,7 +3920,7 @@ plantait...
 ÄÄÄ
     Deux nouvelles fonctions dans le langage LEC :
 &CO
-	hp([[from,]to],expr) : filtre Hodrick-Prescott
+	hp([ [from,]to],expr) : filtre Hodrick-Prescott
 	appdif(expr1, expr2) : complŠte la s‚rie expr1 sur base de la s‚rie
 			       apparent‚e expr2 en tenant compte des
 			       diff‚rences au lieu des taux de croissance
@@ -5323,12 +5323,12 @@ Exemples :
 	- lsum(expr1, expr2, ...) : calcule la somme d'une liste
 	  de s‚ries
 
-	- index([[from,] to,] valeur, expr) : retourne la premiŠre p‚riode
+	- index([ [from,] to,] valeur, expr) : retourne la premiŠre p‚riode
 	  o— valeur apparaŒt dans la s‚rie expr entre les p‚riodes
 	  from et to. Si la valeur n'apparaŒt pas dans expr, -- est
 	  retourn‚.
 
-	- acf([[from,] to,] valeur, expr) : retourne la fonction
+	- acf([ [from,] to,] valeur, expr) : retourne la fonction
 	  d'auto-correlation de degr‚ valeur de l'expression expr
 	  sur le sample from … to.
 

--- a/doc/src/start.txt
+++ b/doc/src/start.txt
@@ -49,51 +49,30 @@ Note that a **"New installation"** requires Administrator rights (file associati
   * 6.58 (20/01/2019) -> [[version_6dot_58|View log]]
     *{{:download:iode658.exe|New installation}}
     *{{:download:iode658upd.exe|Upgrade }}
-  * 6.57 (02/03/2018) -> [[version_6dot_57|View log]]
-    *{{:download:iode657.exe|New installation}}
-    *{{:download:iode657upd.exe|Upgrade }}
-  * 6.56 (27/01/2017) -> [[version_6dot_56|View log]]
-    *{{:download:iode656.exe|New installation}}
-    *{{:download:iode656upd.exe|Upgrade }}
-  * 6.55 (05/01/2017) -> [[version_6dot_55|View log]]
-    *{{:download:iode655.exe|New installation}}
-    *{{:download:iode655upd.exe|Upgrade }}
-  * 6.54 (22/08/2016) -> [[version_6dot_54|View log]]
-    *{{:download:iode654.exe|New installation}}
-    *{{:download:iode654upd.exe|Upgrade }}
-  * 6.53 (18/07/2016) -> [[version_6dot_53|View log]]
-    *{{:download:iode653.exe|New installation}}
-    *{{:download:iode653upd.exe|Upgrade }}
-  * 6.52 (21/06/2016) -> [[version_6dot_52|View log]]
-    *{{:download:iode652.exe|New installation}}
-    *{{:download:iode652upd.exe|Upgrade }}
-  * 6.51 (04/04/2016) -> [[version_6dot_51|View log]]
-  * 6.50 (25/01/2016) -> [[version_6dot_50|View log]]
-    *{{:download:iode650.exe|New installation}}
-    *{{:download:iode650upd.exe|Upgrade }}
 
 -> [[notes_techniques|View all logs]]
 
-===== IODE uses =====
+===== IODE implementations =====
 
-IODE is available for different usages :
-| iodecmd        | win32 software w/o interface : command line for running IODE scripts|
-| iode           | win32 software with graphic user interface |
-| PlanningCorner | restricted simulation software based on IODE objects with Windows interface|
-| iodecom        | COM object (for Excel, APL, VBA, ...)  |
-| wintramoseats  | VB.net software for seasonal adjustment  |
+IODE is available for different environments :
+| iode.exe       | win32 software with graphic user interface |
+| iodecmd.exe    | win32 software w/o interface : command line for running IODE scripts|
+| iodecmd64.exe  | win64 version of iodecmd |
+| iodecom.exe    | COM object (for Excel, APL, VBA, ...)  |
+| iode.pyd       | Python module to manipulate IODE objects and execute IODE commands |
 
 ===== IODE for python =====
 Note : these modules are only available for the latest IODE version.
   *{{:download:py39:iode.pyd|iode.pyd for python3.9}}
   *{{:download:py310:iode.pyd|iode.pyd for python3.10}}
 
+===== IODE 64 bits =====
+Compiled with the latest IODE version.
+  *{{:download:iodecmd64.exe|iodecmd64.exe = 64 bit version of iodecmd }}
+  
 ===== Syntax highlighter for .rep files =====
   * {{:download:npp_iode.xml|Notepad++ : .rep files Syntax highlighter}}
   * {{:download:ioderep.syn|TextPad : .rep files}}
 
 ===== Tips & Tricks =====
     * [[what_is_changed|What has changed]]: check what has changed after a simulation
-
-
-


### PR DESCRIPTION
## jmp_doc_typos

- doc/src/lec.m: a (single) space is added between 2 brackets for dokuwiki compatibility (in the dokuwiki syntax, '[[' indicates the beginning of a internal link)

- doc/src/readme.m: '$' sign removed from "$WsCopyVar" and "$CsvSave*" to avoid misinterpretation by the Dokuwiki parser.

- doc/start.txt:
    - pre-2019 installers removed
    - new section for iodecmd64.exe
    - section IODE implementions (previously "IODE uses") reformulated