### PR TITLE
GITHUB ACTIONS: Simplify build_cython job + upload resulting files as artifact

### DIFF
--- a/.github/workflows/github-actions-iode.yml
+++ b/.github/workflows/github-actions-iode.yml
@@ -188,7 +188,15 @@ jobs:
         run: cmake --preset ${{ env.PRESET_CONFIG }}
       - name: Build Keyboard Shortcuts PDF
         run: cmake --build --preset ${{ env.PRESET_CONFIG }} --target keyboard_shortcuts
+      - name: Upload documentation files
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: iode-doc
+          path: "${{ github.workspace }}/out/build/${{ env.PRESET_CONFIG }}/doc/build/"
+          if-no-files-found: error    # 'warn' or 'ignore' are also available, defaults to `warn`
 
+  
   build_nsis:
     name: Build installer using NSIS
     if: contains(github.head_ref, 'nsis')

--- a/.github/workflows/github-actions-iode.yml
+++ b/.github/workflows/github-actions-iode.yml
@@ -158,6 +158,13 @@ jobs:
       - name: Build Python IODE
         shell: bash -el {0}
         run: cmake --build --preset ${{ matrix.build-config }} --target pyiode 
+      - name: Upload PyIode compiled files
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: iode-pyiode
+          path: "${{ github.workspace }}/out/build/${{ matrix.build-config }}/pyiode/py3${{ matrix.python-minor-version }}/"
+          if-no-files-found: error    # 'warn' or 'ignore' are also available, defaults to `warn`
 
           
   build_doc:

--- a/.github/workflows/github-actions-iode.yml
+++ b/.github/workflows/github-actions-iode.yml
@@ -105,7 +105,9 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        build-config: [windows-debug]
+        python-minor-version: ["9", "10", "11"]
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -120,6 +122,7 @@ jobs:
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - name: Install dependencies on windows
         if: runner.os == 'Windows'
+        shell: bash
         run: |
           choco install ninja
           ninja --version
@@ -129,52 +132,34 @@ jobs:
         # See https://github.com/marketplace/actions/enable-developer-command-prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:
-            arch: x64
-      - uses: conda-incubator/setup-miniconda@v2
+          arch: x64
+      - name: Configure Conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
           # channels: conda-forge, defaults
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.${{ matrix.python-minor-version }}"
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: true
       - name: Check conda
-        shell: bash -l {0}
-        run: |
-          conda info
+        shell: bash -el {0}
+        run: conda info
       - name: Install Python libraires - numpy, pandas and cython
         shell: bash -el {0}
-        run: |
-          conda install numpy pandas cython 
-      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-      # Note: use $env:GITHUB_ENV instead of $GITHUB_ENV on Windows OS
-      - name: Preset config for Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo "PRESET_CONFIG=windows-debug" >> $env:GITHUB_ENV
-      - name: Preset config for Linux
-        if: runner.os == 'Linux'
-        run: |
-          echo "PRESET_CONFIG=linux-debug" >> $GITHUB_ENV
-      - name: Print preset config
-        run: echo "${{ env.PRESET_CONFIG }}"
+        run: conda install numpy pandas cython 
       - name: Configure CMake
+        shell: bash -el {0}
         # cmake --preset <configurePreset> where <configurePreset> is the name of the active Configure Preset.
         # see CMakePresets.json file
         # for more details about cmake preset:
         #   - https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
         #   - https://docs.microsoft.com/en-us/cpp/build/cmake-presets-vs?view=msvc-170
-        run: cmake --preset ${{ env.PRESET_CONFIG }}
-      - name: Build SCR4
-        # cmake --build --preset <buildPreset> where <buildPreset> is the name of the active Build Preset.
-        # see CMakePresets.json file
-        run: cmake --build --preset ${{ env.PRESET_CONFIG }} --target scr4iode 
-      - name: Build C IODE API
-        run: cmake --build --preset ${{ env.PRESET_CONFIG }} --target iodeapi 
+        run: cmake --preset ${{ matrix.build-config }}
       - name: Build Python IODE
         shell: bash -el {0}
-        run: |
-          cmake --build --preset ${{ env.PRESET_CONFIG }} --target pyiode 
+        run: cmake --build --preset ${{ matrix.build-config }} --target pyiode 
 
+          
   build_doc:
     name: Build user documentation
     if: contains(github.head_ref, 'release')

--- a/.github/workflows/github-actions-iode.yml
+++ b/.github/workflows/github-actions-iode.yml
@@ -169,7 +169,7 @@ jobs:
           
   build_doc:
     name: Build user documentation
-    if: contains(github.head_ref, 'release')
+    if: contains(github.head_ref, 'doc')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code

--- a/.github/workflows/github-actions-iode.yml
+++ b/.github/workflows/github-actions-iode.yml
@@ -42,7 +42,7 @@ jobs:
 
   test_sanitize:
     name: Run Tests With Sanitize Option
-    if: ${{ !(contains(github.head_ref, 'gui') || contains(github.head_ref, 'doc')) }}
+    if: ${{ !(contains(github.head_ref, 'gui') || contains(github.head_ref, 'cython') || contains(github.head_ref, 'doc')) }}
     strategy:
       matrix:
         # os: [windows-latest, ubuntu-latest]


### PR DESCRIPTION
For artifacts, see [Storing workflow data as artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts).