### PR TITLE
JMP - BUG in report example.ldo fixed

### DIFF
--- a/api/report/engine/b_rep_cmds.c
+++ b/api/report/engine/b_rep_cmds.c
@@ -322,7 +322,7 @@ int RP_warning(char* arg)
     if(arg == NULL || arg[0] == 0) return(0); /* JMP 11-07-96 */
 
     if(strlen(arg) > 512) arg[512] = 0;
-    kwarning(arg);
+    kwarning("%s", arg);
     return(0);
 }
 


### PR DESCRIPTION
The report function `RP_warning()` now calls `kwarning("%s", arg)` instead of `kwarning(arg)` to avoid crashes if arg contains `%`  