### PR TITLE
SCR4 + C API: compile without option Z1 (use default alignment)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,13 +119,6 @@ else()
   set(IODE_DEBUG_INFO_FLAG "-g")
 endif()
 
-# Alignement flag
-if(MSVC)
-  set(IODE_ALIGNEMENT_FLAG "-Zp1")
-else()
-  set(IODE_ALIGNEMENT_FLAG "-fpack-struct=1")
-endif()
-
 # C++20 (required for the module std format) makes the compiler MSVC 
 # much more strict by default when passing a string literal 
 # "string" value for a char* argument of a C function.

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -26,8 +26,5 @@ target_sources(iode_c_api PRIVATE b_a2mini.c) # A2M
 
 target_sources(iode_c_api PUBLIC iode.h iodebase.h iodeapi.h)
 
-# NOTE: use PRIVATE to NOT propagate compile options to other lib/executable depending on iode_c_api.
-#       Option ${IODE_ALIGNEMENT_FLAG} makes compilation of the Google Test lib to fail
-target_compile_options(iode_c_api PRIVATE ${IODE_ALIGNEMENT_FLAG})
 target_link_libraries(iode_c_api PUBLIC "iode_scr4")
 target_include_directories(iode_c_api PRIVATE "../scr4" ${CMAKE_CURRENT_SOURCE_DIR})

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -1,11 +1,8 @@
 ﻿# CMakeList.txt : CMake project for ${IODE_CLI_TARGET}
 
-
-# NOTE: use PRIVATE to NOT propagate compile options to other lib/executable depending on iode_c_api.
-#       Option ${IODE_ALIGNEMENT_FLAG} makes compilation of the Google Test lib to fail
 file(INSTALL ${PROJECT_SOURCE_DIR}/iode.msg DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(${IODE_CLI_TARGET} "iodecmd.c")
-target_compile_options(${IODE_CLI_TARGET} PRIVATE ${IODE_ALIGNEMENT_FLAG})
+
 target_link_libraries(${IODE_CLI_TARGET} PUBLIC iode_scr4 iode_c_api)
 target_include_directories(${IODE_CLI_TARGET} PUBLIC "../api")

--- a/cpp_api/CMakeLists.txt
+++ b/cpp_api/CMakeLists.txt
@@ -60,11 +60,5 @@ add_library(iode_cpp_api STATIC
             ${CPP_LEGACY}
             )
 
-set_source_files_properties(objects/equation.cpp objects/table.cpp 
-                            KDB/kdb_global.cpp 
-                            gsample/gsample.cpp
-                            gsample/gsample_graph.cpp
-                            report/rep_list.cpp
-                            PROPERTIES COMPILE_FLAGS ${IODE_ALIGNEMENT_FLAG})
 target_include_directories(iode_cpp_api PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(iode_cpp_api PUBLIC iode_c_api)

--- a/cpp_api/KDB/kdb_global.cpp
+++ b/cpp_api/KDB/kdb_global.cpp
@@ -58,7 +58,6 @@ char** filter_kdb_names(const EnumIodeType iode_type, const std::string& pattern
     }
 }
 
-// WARNING: copying content of k_nameptr requires ${IODE_ALIGNEMENT_FLAG} compiler option 
 KDB* hard_copy_kdb(KDB* source_kdb, char** names)
 {
     short iode_type = source_kdb->k_type;

--- a/cpp_api/KDB/kdb_global.h
+++ b/cpp_api/KDB/kdb_global.h
@@ -44,9 +44,6 @@ char** filter_kdb_names(const EnumIodeType iode_type, const std::string& pattern
 // QUESTION FOR JMP: is there a K function that already create a hard copy of subset of a KDB ?
 KDB* hard_copy_kdb(KDB* source_kdb, char** names=NULL);
 
-// require to be compiled using ${IODE_ALIGNEMENT_FLAG} option 
-// std::string get_kdb_filename(KDB* kdb); (replaced by C API function K_get_kdb_nameptr())
-
 void set_kdb_filename(KDB* kdb, const std::string& filename);
 
 /**

--- a/doc/changelog/versions/v7.0-beta.4.rst.inc
+++ b/doc/changelog/versions/v7.0-beta.4.rst.inc
@@ -28,3 +28,4 @@ Fixed Bugs 🛠️
 Miscellaneous 🤷‍♀️
 ----------------
 
+  * Compile the C API using the default alignment for the C structs (#350)

--- a/scr4/CMakeLists.txt
+++ b/scr4/CMakeLists.txt
@@ -62,7 +62,4 @@ set (SCR_IODE
 # Add source to this project's executable.
 add_library (iode_scr4 STATIC ${HEADER_IODE} ${SCR_IODE})
 
-# NOTE: use PRIVATE to NOT propagate compile options to other lib/executable depending on iode_scr4.
-#       Option ${IODE_ALIGNEMENT_FLAG} makes compilation of the Google Test lib to fail
-target_compile_options(iode_scr4 PRIVATE ${IODE_ALIGNEMENT_FLAG})
 target_include_directories (iode_scr4 PUBLIC ".")

--- a/tests/sandbox/CMakeLists.txt
+++ b/tests/sandbox/CMakeLists.txt
@@ -2,6 +2,13 @@
 add_executable(sanbox_Z1 main.cpp)
 add_executable(sanbox_exe main.cpp)
 
+# Alignement flag
+if(MSVC)
+  set(IODE_ALIGNEMENT_FLAG "-Zp1")
+else()
+  set(IODE_ALIGNEMENT_FLAG "-fpack-struct=1")
+endif()
+
 # NOTE: use PRIVATE to NOT propagate compile options to other lib/executable depending on iode_c_api.
 #       Option ${IODE_ALIGNEMENT_FLAG} makes compilation of the Google Test lib to fail
 target_compile_options(sanbox_Z1 PRIVATE ${IODE_ALIGNEMENT_FLAG})

--- a/tests/sandbox/CMakeLists.txt
+++ b/tests/sandbox/CMakeLists.txt
@@ -2,6 +2,9 @@
 add_executable(sanbox_Z1 main.cpp)
 add_executable(sanbox_exe main.cpp)
 
+add_executable(testalign_Z1 testalign.c)
+add_executable(testalign testalign.c)
+
 # Alignement flag
 if(MSVC)
   set(IODE_ALIGNEMENT_FLAG "-Zp1")
@@ -14,10 +17,15 @@ endif()
 target_compile_options(sanbox_Z1 PRIVATE ${IODE_ALIGNEMENT_FLAG})
 target_compile_definitions(sanbox_Z1 PRIVATE ALIGN1)
 
+target_compile_options(testalign_Z1 PRIVATE ${IODE_ALIGNEMENT_FLAG})
+
 # target_link_libraries(sandbox_Z1 PUBLIC iode_c_api)
 # target_link_libraries(sandbox_exe PUBLIC iode_c_api)
 
 target_include_directories(sanbox_Z1 PRIVATE "../../scr4" ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(sanbox_exe PRIVATE "../../scr4" ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_include_directories(testalign_Z1 PRIVATE "../../scr4" "../../api")
+target_include_directories(testalign PRIVATE "../../scr4" "../../api")
 
 file(INSTALL ${PROJECT_SOURCE_DIR}/iode.msg DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/sandbox/testalign.c
+++ b/tests/sandbox/testalign.c
@@ -1,0 +1,26 @@
+#include "iode.h"
+
+int main(int argc, char *argv[])
+{
+   KDB              kdb1;
+   TLINE            tline;
+   EQ               eq;
+   unsigned long    addr_tline, addr_tl_graph, addr_tl_pad,
+                    addr_eq, addr_eq_method, addr_eq_smpl;
+
+   addr_tline = &tline;
+   addr_tl_graph = &(tline.tl_graph);
+   addr_tl_pad = &(tline.tl_pad);
+   addr_eq = &(eq);
+   addr_eq_method = &(eq.method);
+   addr_eq_smpl = &(eq.smpl);
+   // addr_tl_axis = &(tline.tl_axis); // illegal address
+
+   printf("sizeof(KDB)      = %ld\n", sizeof(KDB));
+   printf("sizeof(TLINE)    = %ld\n", sizeof(TLINE));
+   printf("sizeof(EQ)       = %ld\n", sizeof(EQ));
+   printf("pos of tl_graph  = %ld\n", addr_tl_graph - addr_tline);    
+   printf("pos of tl_pad    = %ld\n", addr_tl_pad - addr_tline);    
+   printf("pos of eq_method = %ld\n", addr_eq_method - addr_eq);    
+   printf("pos of eq_smpl   = %ld\n", addr_eq_smpl - addr_eq);    
+} 

--- a/tests/test_c_api/CMakeLists.txt
+++ b/tests/test_c_api/CMakeLists.txt
@@ -4,12 +4,10 @@ file(INSTALL ${PROJECT_SOURCE_DIR}/iode.msg DESTINATION ${CMAKE_CURRENT_BINARY_D
 add_executable(test1 "test1.c")
 target_link_libraries(test1 iode_c_api iode_scr4)
 target_include_directories(test1 PUBLIC "../../scr4" "../../api")
-target_compile_options(test1 PRIVATE ${IODE_ALIGNEMENT_FLAG})
 
 add_executable(test1cpp "test1cpp.cpp")
 target_link_libraries(test1cpp iode_c_api iode_scr4)
 target_include_directories(test1cpp PUBLIC "../../scr4" "../../api")
-target_compile_options(test1cpp PRIVATE ${IODE_ALIGNEMENT_FLAG})
 
 enable_testing()
 


### PR DESCRIPTION
@jmpplan Surprisingly, just removing the compile option `Z1` didn't raised any error from the C and C++ tests and from running the report from the folder `tests\cmd`. 
You told me it would be complicated to get rid of the alingment on 1 byte. 
Seems it does not ?!?
Did I miss something ?