### PR TITLE
API: synchonisation iode-dos 6.70 api -> iode 7.0 api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 ﻿# CMakeList.txt : Top-level CMake project file, do global configuration
 # and include sub-projects here.
 #
+
+# VISUAL STUDIO 2019 => CMake 3.20
+#cmake_minimum_required (VERSION 3.20)
+
+# VISUAL STUDIO > 2019 => CMake 3.24
 cmake_minimum_required (VERSION 3.24)
 
 # List of CMAKE variables: https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html
@@ -128,14 +133,38 @@ else()
   set(IODE_DEBUG_INFO_FLAG "-g")
 endif()
 
+# VISUAL STUDIO 2019 vs 2022 
+# --------------------------
+# Some code in the C++ API requires C++ 20.
 # C++20 (required for the module std format) makes the compiler MSVC 
 # much more strict by default when passing a string literal 
-# "string" value for a char* argument of a C function.
+# "string" value for a char* argument of a C function: the string "string" 
+# is considered as "const char*" and cannot be converted to "char*").
+#
 # The option /Zc:strictStrings with the minus at the end deactivates 
-# this behavior of the MSVC compiler
+# this behavior of the MSVC compiler.
+
+# In VStudio 2019, set(CMAKE_CXX_STANDARD 20) generates a compiler parameter "-std:c++latest" which
+# takes precedence on "/Zc:strictStrings-". 
+# The equivalent in VStudio 2019 is "/std:c++latest" (note the / instead of a -).
+# Therefore, in Visual Studio 2019, the first block below must be commented out and the next block uncommented.
+
+# VISUAL STUDIO > 2019
+# --------------------
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# VISUAL STUDIO <= 2019 
+# ---------------------
+#if(MSVC)
+#  add_compile_options("/std:c++latest")
+#endif()
+
+# All versions of VS
 if(MSVC)
   add_compile_options("/Zc:strictStrings-")
 endif()
+
 
 # global flags
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
@@ -147,9 +176,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_options(${IODE_DEBUG_INFO_FLAG})
 endif()
 
-# some code in the C++ API requires C++ 20
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ---- preprocessor ----
 if(MSVC)

--- a/api/iode.h
+++ b/api/iode.h
@@ -50,9 +50,9 @@
 //#include "o_objs.h" // JMP 8/12/2011
 
 /******************************* DEFINES **********************************/
-#define IODE_VERSION "IODE Modeling Software 7.0 - (c) 1990-2023 Federal Planning Bureau - Brussels"
-#define IODE_VERSION_MAJOR 7
-#define IODE_VERSION_MINOR 0
+#define IODE_VERSION "IODE Modeling Software 6.70 - (c) 1990-2023 Federal Planning Bureau - Brussels"
+#define IODE_VERSION_MAJOR 6
+#define IODE_VERSION_MINOR 70
 #define K_VERSION  "1.0"
 #define OK_MAX_NAME  10
 #define K_MAX_NAME   20  /* IODE64K */
@@ -1076,10 +1076,10 @@ typedef struct _token {
 	char    tk_name[L_MAX_NAME + 1];
 } TOKEN;
 
-typedef struct _lstack {        /* stack of operators used by L_analyse */
-    unsigned ls_op      : 8;    /* operator */
-    //unsigned ls_nb_args : 8;  /* nb of arguments */
-    unsigned ls_nb_args;        /* nb of arguments : 16 bits instead of 8 to allow checking max 255 args
+typedef struct _lstack {        // stack of operators used by L_analyse 
+    unsigned ls_op      : 8;    // operator 
+    //unsigned ls_nb_args : 8;  // nb of arguments 
+    unsigned ls_nb_args;        // nb of arguments : 16 bits instead of 8 to allow checking max 255 args
 } LSTACK;
 
 
@@ -1090,7 +1090,7 @@ typedef struct _lstack {        /* stack of operators used by L_analyse */
 // REPFILE contains a report to be interpreted and the current line during interpretation
 typedef struct _repfile_ {
     char                *filename;      // Source file for report file (*.rep) or
-					// Proc name and position for procedures (PROCDEF)
+                                        // Proc name and position for procedures (PROCDEF)
     unsigned char       **tbl;          // Lines of the report
     int                 curline,        // Current line (during execution)
 			nblines;        // Total number of lines in the report

--- a/api/iode.h
+++ b/api/iode.h
@@ -119,7 +119,6 @@
 #define KMAGIC(kdb)  ((kdb)->k_magic)
 #define KTYPE(kdb)   ((kdb)->k_type)
 #define KMODE(kdb)   ((kdb)->k_mode)
-//#define KNAME(kdb)   ((kdb)->k_name) Supprim� pour �viter les oublis
 #define KNAMEPTR(kdb)((kdb)->k_nameptr) // 6.44
 #define KDESC(kdb)   ((kdb)->k_desc)
 #define KDATA(kdb)   ((kdb)->k_data)
@@ -844,14 +843,14 @@ typedef struct _sample {
 } SAMPLE;
 
 typedef struct _lname_ {
-    ONAME   name;       // scalar or variable name
+    ONAME   name;   // scalar or variable name
 	char    pad[3];
-    long    pos; /* SWHDL */ /* IODE64K */
+    long    pos;    // SWHDL 
 } LNAME;
 
 typedef struct _clec_ {
-    long    tot_lg,        /* JMP 20-05-00 */ /* IODE64K */
-		exec_lg;       /* JMP 20-05-00 */ /* IODE64K */
+    long    tot_lg,      
+		exec_lg;       
     short   nb_names;   // number of scalar and variables names
     char    dupendo;
     char    pad;
@@ -973,15 +972,15 @@ typedef struct _col_ {
 
     /*   {{v00, v01},{v10,v11}}
 
-		    |             |
-		    |   file1     |   file2
+            |             |
+            |   file1     |   file2
     --------|-------------|------------
     period1 |    v00      |    v01
-		    | cl_val[0,0] | cl_val[0,1]    v.. = valeur
+            | cl_val[0,0] | cl_val[0,1]    v.. = valeur
     --------|-------------|------------
     period2 |    v10      |    v11
-		    | cl_val[1,0] | cl_val[1,1]
-		    |             |
+            | cl_val[1,0] | cl_val[1,1]
+            |             |
     */
     IODE_REAL    cl_res;        // computed value (v00 opp v10) opf (v01 opp v11)
 } COL;
@@ -1079,8 +1078,8 @@ typedef struct _token {
 
 typedef struct _lstack {        /* stack of operators used by L_analyse */
     unsigned ls_op      : 8;    /* operator */
-    //unsigned ls_nb_args : 8;    /* nb of arguments */
-    unsigned ls_nb_args;        /* nb of arguments */ // 16 bits pour permettre de v�rifier si plus de 255 arguments
+    //unsigned ls_nb_args : 8;  /* nb of arguments */
+    unsigned ls_nb_args;        /* nb of arguments : 16 bits instead of 8 to allow checking max 255 args
 } LSTACK;
 
 
@@ -1188,6 +1187,9 @@ extern int          KSIM_MAXIT,             // Simulation: max number of iterati
 		    KSIM_NEWTON_MAXIT,      // Newton-Raphson: max number of iterations of the Newton-Raphson sub algorithm.
 		    KSIM_SORT,              // Simulation: reordering option : SORT_NONE, SORT_CONNEX or SORT_BOTH
 		    KSIM_START;             // Simulation: endogenous initial values
+
+
+
 extern char         **KSIM_EXO;
 
 /*-------------- MESSAGES -----------------------*/
@@ -1323,18 +1325,23 @@ extern MAT  *E_RHS,
        *E_DEV;
 
 /************************* SIMULATION *************************************/
-extern int          KSIM_MAXIT;
-extern int          *KSIM_NITERS;
-extern IODE_REAL    *KSIM_NORMS;
+extern int          KSIM_MAXIT;     // Maximum number of iteration to reach a solution
+extern int          *KSIM_NITERS;   // Numbers of iterations needed for each simulation period
+extern long         *KSIM_CPUS;     // Elapsed time for each simulation period
+extern IODE_REAL    *KSIM_NORMS;    // Convergence threshold reached at the end of each simulation period
+
+extern int          KSIM_CPU_SCC;   // Elapsed time to compute SCC
+extern int          KSIM_CPU_SORT;  // Elapsed time to sort interdep block
 
 // EQUATION ORDERING
-extern int  KSIM_PRE;
-extern int  KSIM_INTER;
-extern int  KSIM_POST;
+extern int  KSIM_PRE;               // number of equations in the "prolog" block
+extern int  KSIM_INTER;             // number of equations in the "interdep" block
+extern int  KSIM_POST;              // number of equations in the "epilog"
 //extern int  *KSIM_ORDER;
 //extern char *KSIM_ORDERED;
-extern int  KSIM_MAXDEPTH;
-extern int  *KSIM_POSXK;
+extern int  KSIM_MAXDEPTH;          // Number of equations in the model
+extern int  *KSIM_POSXK;            // Position in KSIM_DBV of the endo variable of equation "KSIM_DBE[i]"
+extern int  *KSIM_POSXK_REV;        // Position in KSIM_DBE of the equation whose endo is "KSIM_DBV[i]" (reverse of KSIM_POSXK)
 
 /*********************** FUNCTIONS DECLARATIONS ***************************/
 // NEW FOR IODECOM (JMP 1/23/2018)

--- a/api/iode.h
+++ b/api/iode.h
@@ -45,14 +45,14 @@
 #define MAXFLOAT  FLT_MAX
 #define MINFLOAT  FLT_MIN
 #endif
-
+ 
 
 //#include "o_objs.h" // JMP 8/12/2011
 
 /******************************* DEFINES **********************************/
-#define IODE_VERSION "IODE Modeling Software 6.70 - (c) 1990-2023 Federal Planning Bureau - Brussels"
-#define IODE_VERSION_MAJOR 6
-#define IODE_VERSION_MINOR 70
+#define IODE_VERSION "IODE Modeling Software 7.0 - (c) 1990-2023 Federal Planning Bureau - Brussels"
+#define IODE_VERSION_MAJOR 7
+#define IODE_VERSION_MINOR 0
 #define K_VERSION  "1.0"
 #define OK_MAX_NAME  10
 #define K_MAX_NAME   20  /* IODE64K */

--- a/api/iodeapi.h
+++ b/api/iodeapi.h
@@ -62,7 +62,16 @@ extern int IodeSetVector(char *la_name, double *la_values, int la_pos, int ws_po
 extern int IodeEstimate(char* veqs, char* afrom, char* ato);
 
 extern int IodeModelSimulate(char *per_from, char *per_to, char *eqs_list, char *endo_exo_list, double eps, double relax, int maxit, int init_values, int sort_algo, int nb_passes, int debug, double newton_eps, int newton_maxit, int newton_debug);
-
+extern int IodeModelCalcSCC(int nbtris, char* pre_listname, char* inter_listname, char* post_listname, char *eqs_list);
+extern int IodeModelSimulateSCC(char *per_from, char *per_to, 
+                         char *pre_eqlist, char *inter_eqlist, char* post_eqlist,
+                         double eps, double relax, int maxit, 
+                         int init_values, int debug, 
+                         double newton_eps, int newton_maxit, int newton_debug);
+extern double IodeModelSimNorm(char* period);
+extern int IodeModelSimNIter(char* period);
+extern int IodeModelSimCpu(char* period);                         
+                         
 extern int IodeExecArgs(char *filename, char **args);
 extern int IodeExec(char *filename);
 

--- a/api/iodebase.h
+++ b/api/iodebase.h
@@ -930,7 +930,8 @@ extern int RP_goto_label(char *command, char *parm);
 extern int RP_goto(char* arg);
 extern int RP_message(char* arg);
 extern int RP_warning(char* arg);
-extern int RP_beep();
+extern int RP_silent(char* arg);
+extern int RP_beep(char* arg);
 extern int RP_ask(char* arg);
 extern int B_ReportPrompt(char* arg);
 extern int RP_setdebug(char* arg);
@@ -949,6 +950,7 @@ extern int B_Sleep(char* arg);
 extern int B_GraphDefault(char* type);
 
 /* b_rep_fns.c */ 
+extern U_ch *RPF_IodeVersion();
 extern U_ch *RPF_take(U_ch** args);
 extern U_ch *RPF_drop(U_ch** args);
 extern U_ch *RPF_replace(U_ch** args);
@@ -994,12 +996,27 @@ extern U_ch *RPF_lexpand(U_ch **args);
 extern U_ch *RPF_sexpand(U_ch **args);
 extern U_ch *RPF_texpand(U_ch **args);
 extern U_ch *RPF_vexpand(U_ch **args);
+
 extern int RPF_CalcPeriod(U_ch** args);
-extern U_ch *RPF_SimNorm(U_ch** args);
-extern U_ch *RPF_SimNIter(U_ch** args);
 extern U_ch *RPF_SimMaxit();
 extern U_ch *RPF_SimEps();
 extern U_ch *RPF_SimRelax();
+extern U_ch* RPF_SimSortNbPasses();
+extern U_ch* RPF_SimSortAlgo();
+extern U_ch* RPF_SimInitValues();
+
+extern IODE_REAL RPF_SimNormReal(U_ch** args);
+extern U_ch *RPF_SimNorm(U_ch** args);
+
+extern int RPF_SimNIterInt(U_ch** args);
+extern U_ch *RPF_SimNIter(U_ch** args);
+
+extern int RPF_SimCpuInt(U_ch** args);
+extern U_ch* RPF_SimCpu(U_ch** args);
+
+extern U_ch* RPF_SimCpuSCC();
+extern U_ch* RPF_SimCpuSort();
+
 extern U_ch *RPF_vtake(U_ch** args);
 extern U_ch *RPF_vdrop(U_ch** args);
 extern U_ch *RPF_vcount(U_ch** args);
@@ -1087,7 +1104,8 @@ extern int (*B_ScrollVTW0_super)(char *arg);
 extern int (*B_ScrollVTN_super )(char *arg);
 
 extern int (*ODE_scroll_super) (KDB *kdb, char **lst);
-extern int (*T_view_tbl_super) (char* name, char *smpl, char** vars_names);
+extern int (*T_view_tbl_super) (TBL *tbl, char *smpl, char* name);
+// extern int (*T_view_tbl_super) (char* name, char *smpl, char** vars_names); // TEMP version for IODE-QT
 
 /* b_rep_super.c - function declarations */
 extern int SB_FileDelete       ();
@@ -1152,7 +1170,8 @@ extern int B_ScrollVTW0(char* arg);
 extern int B_ScrollVTN (char* arg);
 
 extern int ODE_scroll(KDB *kdb, char **lst);
-extern int T_view_tbl(char* name, char *smpl, char** vars_names);
+extern int T_view_tbl(TBL *tbl, char *smpl, char* name);
+// extern int T_view_tbl(char* name, char *smpl, char** vars_names); // Temp version for IODE-QT
 
 
 /* b_data.c */
@@ -1784,7 +1803,6 @@ extern int T_alloc_val(TBL *,char *);
 extern int T_free_val(TBL *);
 extern int T_name_inline(TCELL *,int ,char *);
 extern int T_calc_val(TBL *,char *);
-extern int T_view_tbl(char *,char *, char **);
 extern int T_calc_line(TBL *,int ,COLS *,int *);
 extern int VT_files(void);
 
@@ -1918,6 +1936,7 @@ extern int W_EndDisplay(char *title,int x,int y,int w,int h);
 extern int W_printf(char *fmt,...);
 extern int W_printfDbl(char* fmt, ...);
 extern int W_printfRepl(char* fmt, ...);
+extern int W_printfReplEsc(char* fmt, ...);
 extern int W_printfEx(int dup, int ch1, int ch2, char *fmt, va_list args);
 
 // interface

--- a/api/lec/l_link.c
+++ b/api/lec/l_link.c
@@ -168,12 +168,12 @@ static void L_link1_endos(KDB* dbe, CLEC* cl)
 
     for (i = 0; i < cl->nb_names; i++) {
         if (L_ISCOEF(cl->lnames[i].name))
-            cl->lnames[i].pos = 0; // On s'en tape pour le calcul des SCC
+            cl->lnames[i].pos = 0;  // For the SCC construction, we do not need the coefficients (scalars)
         else
             cl->lnames[i].pos = K_find(dbe, cl->lnames[i].name);
 
-        if (cl->lnames[i].pos < 0) // Non trouvé -> exo
-            cl->lnames[i].pos = KNB(dbe); // exo : on s'en tape aussi
+        if (cl->lnames[i].pos < 0)  // Not found => exogenous var
+            cl->lnames[i].pos = -1; // For the SCC construction, we do not need the exogenous vars positions 
     }
 }
 

--- a/api/objs/k_tbl.c
+++ b/api/objs/k_tbl.c
@@ -281,7 +281,7 @@ char* T_div_cont_tbl(TBL* tbl, int col, int mode)
  *  @param [in, out] tbl     TBL*    TBL where a new line must be inserted
  *  @param [in]      nbr     int     reference position of the new line in TBL (see param where below)
  *  @param [in]      type    int     TLINE type (KT_CELL, KT_TITLE...)
- *  @param [in]      where   int     1 to insert before line nbr, 0 to insert after line nbr
+ *  @param [in]      where   int     0 to insert before line nbr, 1 to insert after line nbr
  *  @return                  int     position of the new line in TBL
  *  **TODO: Check where definition 
  */

--- a/api/report/commands/b_model.c
+++ b/api/report/commands/b_model.c
@@ -424,7 +424,10 @@ static int B_CreateVarFromVecOfInts(char *name, int *vec)
     // Create var and get Ptr
     B_CreateEmptyVar(name);
     x = B_GetVarPtr(name);
-    if(x == 0) return(-1);
+    if(x == 0) {
+        B_seterror("B_CreateVarFromVecOfInts %s failed", name);
+        return(-1);
+    }
 
     // Copy values
     if(vec) {

--- a/api/report/commands/b_xode.c
+++ b/api/report/commands/b_xode.c
@@ -29,8 +29,9 @@
 int B_FileImportCmt(char* arg)
 {
     int     rc = 0, nb_args, format, lang;
-    char    **args = NULL, *trace, *rule, *infile, *oufile;
+    char    **args = NULL, *trace, *rule, *infile, *oufile, empty_buf[1];
 
+    empty_buf[0] = 0;
     args = B_ainit_chk(arg, NULL, 0);
     nb_args = SCR_tbl_size(args);
     if(nb_args < 5) {
@@ -46,10 +47,10 @@ int B_FileImportCmt(char* arg)
     lang   = B_argpos("EFD", args[4][0]);
 
     if(nb_args == 6) trace = args[5];
-    else             trace = "";
+    else             trace = empty_buf;
 
     rc = IMP_RuleImport(K_CMT, trace, rule, oufile, infile,
-                      "", "", format, lang);
+                      empty_buf, empty_buf, format, lang);
 
 fin:
     A_free(args);
@@ -74,8 +75,9 @@ fin:
 int B_FileImportVar(char* arg)
 {
     int     rc = 0, nb_args, format;
-    char    **args = NULL, *trace, *rule, *from, *to,*infile, *oufile;
+    char    **args = NULL, *trace, *rule, *from, *to,*infile, *oufile, empty_buf[1];
 
+    empty_buf[0] = 0;
     args = B_ainit_chk(arg, NULL, 0);
     nb_args = SCR_tbl_size(args);    /* JMP 16-12-93 */
     if(nb_args < 6) {
@@ -92,7 +94,7 @@ int B_FileImportVar(char* arg)
     to     = args[5];
 
     if(nb_args == 7) trace = args[6];
-    else             trace = "";
+    else             trace = empty_buf;
 
     rc = IMP_RuleImport(K_VAR, trace, rule, oufile, infile,
                       from, to, format, 0);

--- a/api/report/engine/b_rep_cmds.c
+++ b/api/report/engine/b_rep_cmds.c
@@ -41,6 +41,7 @@
  *      int RP_goto(char* arg)                           $goto label [value]
  *      int RP_message(char* arg)                        $show message
  *      int RP_warning(char* arg)                        $msg text
+ *      int RP_silent(char* arg)                         $silent {0|1|N|n|Y|y]
  *      int RP_beep()                                    $beep
  *      int RP_ask(char* arg)                            $ask <label> <question>
  *      int B_ReportPrompt(char* arg)                    #prompt <macro_name> <question>
@@ -316,18 +317,39 @@ int RP_message(char* arg)
     return(0);
 }
 
+
 // $msg text
 int RP_warning(char* arg)            
 {
     if(arg == NULL || arg[0] == 0) return(0); /* JMP 11-07-96 */
 
     if(strlen(arg) > 512) arg[512] = 0;
-    kwarning("%s", arg);
+    kwarning("%s", arg); 
+    return(0);
+}
+
+// $silent {0|1|n|N|Y|y}
+int RP_silent(char* arg)   
+{  
+     int     ch;
+    
+    ch = SCR_upper_char(arg[0]);
+    switch(ch) {
+        case '0' :
+        case 'n':
+        case 'N':
+            kmsg_toggle(1);
+            break;
+
+        default :
+            kmsg_toggle(0);
+            break;
+    }
     return(0);
 }
 
 // $beep
-int RP_beep()
+int RP_beep(char* arg)
 {
     kbeep();
     return(0);

--- a/api/report/engine/b_rep_super.c
+++ b/api/report/engine/b_rep_super.c
@@ -98,7 +98,8 @@ int (*B_ScrollVTN_super )(char *arg);
 
 /* b_view.c */
 int (*ODE_scroll_super) (KDB *kdb, char **lst);
-int (*T_view_tbl_super) (char* name, char *smpl, char** vars_names);
+int (*T_view_tbl_super) (TBL *tbl, char *smpl, char* name);
+// int (*T_view_tbl_super) (char* name, char *smpl, char** vars_names); // TEMP version for IODE-QT
 
 // Default implementation 
 int SB_FileDelete       () {if(SB_FileDelete_super) return((*SB_FileDelete_super)()); return(0);}   
@@ -164,4 +165,5 @@ int B_ScrollVTW0(char* arg) {if(B_ScrollVTW0_super       ) return(*B_ScrollVTW0_
 int B_ScrollVTN (char* arg) {if(B_ScrollVTN_super        ) return(*B_ScrollVTN_super       )(arg); else return(0);}
 
 int ODE_scroll  (KDB *kdb, char **lst)             {if(ODE_scroll_super         ) return(*ODE_scroll_super        )(kdb, lst);         else return(0);}
-int T_view_tbl  (char* name, char *smpl, char** vars_names) {if(T_view_tbl_super         ) return(*T_view_tbl_super        )(name, smpl, vars_names);  else return(0);}
+int T_view_tbl  (TBL *tbl, char *smpl, char* name) {if(T_view_tbl_super         ) return(*T_view_tbl_super        )(tbl, smpl, name);  else return(0);}
+// int T_view_tbl  (char* name, char *smpl, char** vars_names) {if(T_view_tbl_super         ) return(*T_view_tbl_super        )(name, smpl, vars_names);  else return(0);} // TEMP version for IODE-QT

--- a/api/report/engine/b_rep_syntax.c
+++ b/api/report/engine/b_rep_syntax.c
@@ -50,6 +50,8 @@ BFNS B_fns[] = {
     "onerror",                "onerror",                  RP_onerror,             RP_onerror,         0,        0,
     "return",                 "return",                   RP_return,              RP_return,          0,        0,
     "show",                   "show",                     RP_message,             RP_message,         0,        0,
+    "silent",                 "silent",                   RP_silent,              RP_silent,          0,        0,
+    //"showoff",                "showoff",                  RP_message_off,         RP_message_off,     0,        0,
     "msg",                    "msg",                      RP_warning,             RP_warning,         0,        0,
     "beep",                   "beep",                     RP_beep,                RP_beep,            0,        0,
     "system",                 "system",                   RP_system,              RP_system,          0,        0,
@@ -364,8 +366,16 @@ RPFN RP_FNS[] = {
     "simeps",		RPF_SimEps,
     "simmaxit",		RPF_SimMaxit,
     "simrelax",		RPF_SimRelax,
+    "simsortnbpasses", RPF_SimSortNbPasses,
+    "simsortalgo",    RPF_SimSortAlgo,
+    "siminitvalues", RPF_SimInitValues,
+
     "simnorm",		RPF_SimNorm,
     "simniter",		RPF_SimNIter,
+    "simcpu",		RPF_SimCpu,
+    "simcpuscc",    RPF_SimCpuSCC,
+    "simcpusort",   RPF_SimCpuSort,
+    
 
     //"vseps",		RPF_vseps,
     "vtake",		RPF_vtake,
@@ -378,6 +388,8 @@ RPFN RP_FNS[] = {
     "rmdir",        RPF_rmdir,  // 9/4/2019
 
     "void",         RPF_void,   // 9/4/2019
+    "version",      RPF_IodeVersion, 
+    
     0, 0
 };
 

--- a/api/report/undoc/b_view.c
+++ b/api/report/undoc/b_view.c
@@ -55,7 +55,7 @@ int B_PrintVar(char* arg)
 int B_ViewPrintVar(char* arg, int mode)
 {
     int     rc = 0, nb, i;
-    char    *smpl, *ptr, *name;
+    char    *smpl, *ptr;
     U_ch    **args;
     TBL     *tbl;
     char    *oldseps = A_SEPS, *lst;  /* JMP 14-07-96 */
@@ -89,16 +89,16 @@ int B_ViewPrintVar(char* arg, int mode)
             ptr = args[i + 50];
             args[i + 50] = 0;
         }
+        tbl = T_create(2);
         if(mode == 0) {
-            name = "_TMP_TBL_";
-            rc = T_view_tbl(name, smpl, args + i);
+            T_default(tbl, 0L, args + i, args + i, 0, 0, 0);
+            rc = T_view_tbl(tbl, smpl, "of series");
         }
         else {
-            tbl = T_create(2);
             T_default(tbl, 0L, args + i, args + i, 1, 1, 1);
             rc = T_print_tbl(tbl, smpl);
-            T_free(tbl);
         }
+        T_free(tbl);
         if(i + 50 < nb) args[i + 50] = ptr;
         if(rc) break;
     }
@@ -168,15 +168,15 @@ int B_ViewPrintTbl_1(char* name, char* smpl)
         return(-1);
     }
 
+    tbl = KTVAL(K_WS[K_TBL], pos);
     if(B_viewmode == 0)
-        rc = T_view_tbl(name, smpl, NULL);
-    else {
-        tbl = KTVAL(K_WS[K_TBL], pos);
+        rc = T_view_tbl(tbl, smpl, name);
+    else
         rc = T_print_tbl(tbl, smpl);
-        T_free(tbl);
-    }
 
     if(rc < 0) B_seterrn(81, name);
+
+    T_free(tbl);
     return(rc);
 }
 

--- a/api/simulation/k_sim_exo2endo.c
+++ b/api/simulation/k_sim_exo2endo.c
@@ -78,7 +78,7 @@
  */
 static int KE_findpath(int posendo, int posexo, int* depth)
 {
-    int         j, poseq, posseq, rc = -1;
+    int         j, poseq, posseq, posvar, rc = -1;
     CLEC        *clec = NULL, *eclec;
     extern char *KSIM_PATH;
     extern KDB  *KSIM_DBE;
@@ -93,6 +93,7 @@ static int KE_findpath(int posendo, int posexo, int* depth)
         if(L_ISCOEF(clec->lnames[j].name)) continue;
         if((clec->lnames[j]).pos == posexo) {
             KSIM_POSXK[poseq] = posexo;
+            KSIM_POSXK_REV[posexo] = poseq;
             return(0);
         }
     }
@@ -125,8 +126,10 @@ static int KE_findpath(int posendo, int posexo, int* depth)
         /*      fprintf(stdout, "%s <- ", clec->lnames[j].name); */
         // Path found
         // Replace the endo of the KSIM_POSXK[poseq] by the j'd varname in current clec
-        KSIM_POSXK[poseq] = (clec->lnames[j]).pos;
-
+        posvar = (clec->lnames[j]).pos;
+        KSIM_POSXK[poseq] = posvar;
+        KSIM_POSXK_REV[posvar] = poseq;
+        
         // decrease the depth by 1
         (*depth) --;
         

--- a/api/simulation/k_sim_scc.c
+++ b/api/simulation/k_sim_scc.c
@@ -131,8 +131,10 @@ static int K_simul_SCC_init(KDB* dbe, KDB* dbv, KDB* dbs, SAMPLE* smpl)
     // NE PAS FREEER KSIM_NORMS ni KSIM_NITERS CAR UTILISES POUR LE REPORTING A POSTERIORI !!
     SCR_free(KSIM_NORMS);
     SCR_free(KSIM_NITERS);
+    SCR_free(KSIM_CPUS);
     KSIM_NORMS = (IODE_REAL *) SCR_malloc(sizeof(IODE_REAL) * KSMPL(dbv)->s_nb);
     KSIM_NITERS = (int *) SCR_malloc(sizeof(int) * KSMPL(dbv)->s_nb);
+    KSIM_CPUS = (long *) SCR_malloc(sizeof(long) * KSMPL(dbv)->s_nb);
 
     /* LINK EQUATIONS + SAVE ENDO POSITIONS */
     kmsg("Linking equations ....");

--- a/api/simulation/k_sim_scc.c
+++ b/api/simulation/k_sim_scc.c
@@ -60,12 +60,18 @@ int KE_ModelCalcSCC(KDB* dbe, int tris, char* pre, char* inter, char* post)
     else         KSIM_SORT = SORT_CONNEX;
 
     // KSIM_POSXK[i] = num dans dbv de la var endogène de l'équation i
+    // KSIM_POSXK_REV[i] = pos in KSIM_DBE of the eq whose endo is var[i] 
     KSIM_POSXK = (int *) SW_nalloc((int)(sizeof(int) * KNB(dbe)));
-
+    KSIM_POSXK_REV = (int *) SW_nalloc((int)(sizeof(int) * KNB(dbe)));
+    for(i = 0 ; i < KNB(dbe); i++) {
+        KSIM_POSXK_REV[i] = -1;  
+    }
+    
     // PSEUDO LINK EQUATIONS ie set num endo = num eq
     kmsg("Pseudo-linking equations ....");
     for(i = 0 ; i < KNB(dbe); i++) {
         KSIM_POSXK[i] = i;
+        KSIM_POSXK_REV[i] = i;
         L_link_endos(dbe, KECLEC(dbe, i));
     }
 
@@ -74,8 +80,9 @@ int KE_ModelCalcSCC(KDB* dbe, int tris, char* pre, char* inter, char* post)
     K_lstorder(pre, inter, post);
 
     SW_nfree(KSIM_POSXK);
+    SW_nfree(KSIM_POSXK_REV);
     SW_nfree(KSIM_ORDER);
-    KSIM_POSXK = KSIM_ORDER = NULL;
+    KSIM_POSXK = KSIM_POSXK_REV = KSIM_ORDER = NULL;
     KSIM_PASSES = opasses;
     KSIM_SORT = osort;
     return(0);
@@ -136,7 +143,7 @@ static int K_simul_SCC_init(KDB* dbe, KDB* dbv, KDB* dbs, SAMPLE* smpl)
             rc = -1;
             goto fin;
         }
-
+        
         rc = L_link(dbv, dbs, KECLEC(dbe, i));
         if(rc) {
             B_seterrn(113, KONAME(dbe, i));

--- a/cpp_api/compute/simulation.cpp
+++ b/cpp_api/compute/simulation.cpp
@@ -114,7 +114,7 @@ void Simulation::model_simulate(const std::string& from, const std::string& to, 
 }
 
 /**
- * Same as B_ModelCalcSCC()
+ * Same as IodeModelCalcSCC() (defined in b_api.c)
  */
 void Simulation::model_calculate_SCC(const int nb_iterations, const std::string& pre_name, const std::string& inter_name, const std::string& post_name, const std::string& list_eqs)
 {
@@ -166,7 +166,11 @@ void Simulation::model_calculate_SCC(const int nb_iterations, const std::string&
 }
 
 /**
- * Same as B_ModelSimulateSCC()
+ * Mostly same function as IodeModelSimulateSCC() (defined in b_api.c).
+ * Unlike in IodeModelSimulateSCC(), the following global parameters are not passed to this function: 
+ *    eps, relax, maxit,  init_values, debug, newton_eps, newton_maxit, newton_debug.
+ * 
+ * TODO: add these parameters as optional arguments
  */
 void Simulation::model_simulate_SCC(const std::string& from, const std::string& to, const std::string& pre_name, const std::string& inter_name, const std::string& post_name)
 {

--- a/cpp_api/compute/simulation.h
+++ b/cpp_api/compute/simulation.h
@@ -142,4 +142,12 @@ public:
 
     void model_simulate_SCC(const std::string& from, const std::string& to, const std::string& pre_name = "_PRE", 
         const std::string& inter_name = "_INTER", const std::string& post_name = "_POST");
+
+    // TODO: add the functions below (giving simulation/reordering informations (see b_api.c)
+    //  double IodeModelSimNorm(char* period); 
+    //  int IodeModelSimNIter(char* period);
+    //  int IodeModelSimCpu(char* period);
+    // TODO: consider adding new fns to return the elapsed time for the last SCC decomposition (KSIM_CPU_SCC) and Reordering (KSIM_CPU_SORT)
+
+
 };

--- a/tests/test_c_api/test1.c
+++ b/tests/test_c_api/test1.c
@@ -82,12 +82,16 @@
 
 void Syntax() 
 {
-    printf("Syntax: test1 [-v] [-v-] [-x] [-x-] [-h]\n");
+    printf("Syntax: test1 [-v] [-v-] [-x] [-x-] [-h] [-vc64]\n");
     printf("  [-v]  : verbose (default)\n");
     printf("  [-v-] : silent\n");
     printf("  [-x]  : exit on error (default)\n");
     printf("  [-x-] : continue on error\n");
+    printf("  [-data_dir] : data directory (default ..\\data)\n");
+    printf("  [-output_dir] : output directory (default ..\\output)\n");
     printf("  [-h]  : display syntax\n");
+    printf("Example: test1 -data_dir ..\\..\\data -output_dir ..\\..\\output\n");
+    
     exit(0);
 }
 
@@ -856,6 +860,8 @@ void Tests_Simulation()
     int         rc;
     LIS         lst, expected_lst;
     void        (*kmsg_super_ptr)(char*);
+    double      XNATY_2000Y1;
+    
     
     U_test_print_title("Tests Simulation");
 
@@ -932,7 +938,9 @@ void Tests_Simulation()
     // Check result
     S4ASSERT(rc == 0, "Exchange UY-XNATY converges on 2000Y1-2002Y1");
     S4ASSERT(KV_get_at_aper("UY", "2000Y1") == 650.0, "Exchange UY-XNATY: UY[2000Y1] == 650.0 unchanged");
-    S4ASSERT(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.80071), "Exchange UY-XNATY: XNATY[2000Y1] == 0.80071");
+    XNATY_2000Y1 = KV_get_at_aper("XNATY", "2000Y1"); 
+    //printf("XNATY_2000Y1 = %lg\n", XNATY_2000Y1);
+    S4ASSERT(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.800703), "Exchange UY-XNATY: XNATY[2000Y1] == 0.800703");
 
     // Cleanup
     SCR_free_tbl(endo_exo);
@@ -1875,7 +1883,8 @@ void Tests_B_MODEL()
                 *kdbs;
     char        *filename = "fun";
     int         rc;
-
+    double      XNATY_2000Y1;
+    
     // B_Model*() tests
     // ----------------
     // X int B_ModelSimulate(char *arg)                              $ModelSimulate per_from per_to equation_list
@@ -1945,7 +1954,9 @@ void Tests_B_MODEL()
 
     // Check some results
     S4ASSERT(KV_get_at_aper("UY", "2000Y1") == 650.0, "Exchange UY-XNATY: UY[2000Y1] == 650.0 unchanged");
-    S4ASSERT(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.8006766), "Exchange UY-XNATY: XNATY[2000Y1] == 0.80069");
+    XNATY_2000Y1 = KV_get_at_aper("XNATY", "2000Y1"); 
+    //printf("XNATY_2000Y1 = %lg\n", XNATY_2000Y1);
+    S4ASSERT(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.800673), "Exchange UY-XNATY: XNATY[2000Y1] == 0.800673");
     
     // B_ModelCompile(char* arg)
     rc = B_ModelCompile("");
@@ -2763,8 +2774,18 @@ int main(int argc, char **argv)
         if(strcmp(argv[i], "-x-") == 0) S4ASSERT_EXIT_ON_ERROR = 0;
         if(strcmp(argv[i], "-x") == 0)  S4ASSERT_EXIT_ON_ERROR = 1;
         if(strcmp(argv[i], "-h") == 0)   Syntax();
+
+        if(strcmp(argv[i], "-data_dir") == 0) {    
+            IODE_DATA_DIR   = argv[i + 1];
+            i++;
+        }    
+        if(strcmp(argv[i], "-output_dir") == 0) {    
+            IODE_OUTPUT_DIR = argv[i + 1];
+            i++;
+        }    
     }
     
+   
     // Initialises super functions / empty WS / error messages
     U_test_init();
     

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -1865,11 +1865,7 @@ TEST_F(IodeCAPITest, Tests_IMP_EXP)
 }
 
 
-#if defined(DEBUG)
-TEST_F(IodeCAPITest, DISABLED_Tests_B_XODE)
-#else
 TEST_F(IodeCAPITest, Tests_B_XODE)
-#endif
 {
     char    outfile[256];
     char    reffile[256];

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -1131,6 +1131,8 @@ TEST_F(IodeCAPITest, Tests_Simulation)
     int         rc;
     LIS         lst, expected_lst;
     void        (*kmsg_super_ptr)(char*);
+    double      XNATY_2000Y1;
+
 
     U_test_print_title("Tests Simulation");
 
@@ -1207,7 +1209,9 @@ TEST_F(IodeCAPITest, Tests_Simulation)
     // Check result
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(KV_get_at_aper("UY", "2000Y1"), 650.0);
-    EXPECT_TRUE(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.80071));
+    XNATY_2000Y1 = KV_get_at_aper("XNATY", "2000Y1");
+    //printf("XNATY_2000Y1 = %lg\n", XNATY_2000Y1);
+    EXPECT_TRUE(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.800703));
 
     // Cleanup
     SCR_free_tbl(endo_exo);
@@ -2002,6 +2006,7 @@ TEST_F(IodeCAPITest, Tests_B_MODEL)
                 *kdbs;
     char        *filename = "fun";
     int         rc;
+    double      XNATY_2000Y1;
 
     // B_Model*() tests
     // ----------------
@@ -2072,7 +2077,9 @@ TEST_F(IodeCAPITest, Tests_B_MODEL)
 
     // Check some results
     EXPECT_EQ(KV_get_at_aper("UY", "2000Y1"), 650.0);
-    EXPECT_TRUE(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.8006766));
+    XNATY_2000Y1 = KV_get_at_aper("XNATY", "2000Y1");
+    //printf("XNATY_2000Y1 = %lg\n", XNATY_2000Y1);
+    EXPECT_TRUE(U_test_eq(KV_get_at_aper("XNATY", "2000Y1"), 0.800673));
 
     // B_ModelCompile(char* arg)
     rc = B_ModelCompile("");

--- a/tests/test_cpp_api/test_simulation.cpp
+++ b/tests/test_cpp_api/test_simulation.cpp
@@ -87,7 +87,7 @@ TEST_F(SimulationTest, Simulation)
 
     // Check result
     EXPECT_DOUBLE_EQ(Variables.get_var("UY", "2000Y1"), 650.0);
-    EXPECT_DOUBLE_EQ(round(Variables.get_var("XNATY", "2000Y1") * 10e5) / 10e5, 0.80071);
+    EXPECT_DOUBLE_EQ(round(Variables.get_var("XNATY", "2000Y1") * 10e5) / 10e5, 0.8007030);
     
     // TODO : check with list of equations
 }


### PR DESCRIPTION
# Synchonisation iode-dos 6.70 api -> iode 7.0 api

## Reports functions

- new command `$silent`
- new function `@version()` 
- command `$msg`: bug fixed
- new `@functions` related to simulations:
```
    @SimSortNbPasses()  Last "nbtri" parameter
    @SimSortAlgo()      Last sort parameter: "Connex", "Triangulation" or "None"
    @SimInitValues()    Last starting values parameter
    @SimCpuScc()        Time in ms spent to compute Connex Components
    @SimCpuSort()       Time in ms spent to reorder the interdependent block of the model
    @SimCpu(period)     Time in ms elapsed during last simulation of the specified period
    @SimNorm(period)    Convergence criterion reached for the given period during last simulation
    @SimNIter(period    Number of iteration needed to reach a solution for the given period during last simulation
```

## Endo-Exo bug fixed

In a simulation, when an exchange endo-exo is required, if one of the vars does not exist,
an error message is now provided. In the previous versions, IODE crashed if that was the case.

-> Fix #330

## Simulation algorithm

The method for decomposing models into strongly connex components has been revised and greatly improved
for large models.

## FileImportVar and FileImportCmt
-> Fix #292. 