### PR TITLE
TESTS PYTHON: fixed test_iode_model_simulate_exchange() (due to PR #373)

### DIFF
--- a/tests/test_nanobind/test_iode.py
+++ b/tests/test_nanobind/test_iode.py
@@ -512,7 +512,7 @@ def test_iode_model_simulate_exchange():
     UY = iode.get_var("UY")
     XNATY = iode.get_var("XNATY")
     assert iode.exec_lec("UY[2000Y1]")[0] == 650.0
-    assert round(iode.exec_lec("XNATY[2000Y1]")[0], 7) == 0.8006767
+    assert round(iode.exec_lec("XNATY[2000Y1]")[0], 7) == 0.8006734
 
     iode.reset_msgs()
 

--- a/tests/test_python/test_iode.py
+++ b/tests/test_python/test_iode.py
@@ -511,7 +511,7 @@ def test_iode_model_simulate_exchange():
     UY = iode.get_var("UY")
     XNATY = iode.get_var("XNATY")
     assert iode.exec_lec("UY[2000Y1]")[0] == 650.0
-    assert round(iode.exec_lec("XNATY[2000Y1]")[0], 7) == 0.8006767
+    assert round(iode.exec_lec("XNATY[2000Y1]")[0], 7) == 0.8006734
 
     iode.reset_msgs()
 


### PR DESCRIPTION
@jmpplan Please repeat the change made in this PR in the private iode repository.
See [issue 5](https://github.com/plan-be/iode_dos/issues/5) from the private iode repository.