### PR TITLE
PYTHON: (nanobind) added the get_var_as_ndarray() function

### DIFF
--- a/cpp_api/KDB/kdb_variables.cpp
+++ b/cpp_api/KDB/kdb_variables.cpp
@@ -38,6 +38,17 @@ IODE_REAL KDBVariables::get_var(const int pos, const Period& period, const EnumI
 	return get_var(pos, t, mode);
 }
 
+IODE_REAL* KDBVariables::get_var_ptr(const int pos)
+{
+	if(get_nb_periods() == 0)
+		return NULL;
+
+	// throw exception if object with passed position is not valid
+	get_name(pos);
+
+	return KVVAL(get_KDB(), pos, 0);
+}
+
 IODE_REAL KDBVariables::get_var(const std::string& name, const int t, const EnumIodeVarMode mode) const
 {
 	// throw exception if object with passed name does not exist
@@ -55,6 +66,13 @@ IODE_REAL KDBVariables::get_var(const std::string& name, const Period& period, c
 {
 	int t = get_sample().get_period_position(period);
 	return get_var(name, t, mode);
+}
+
+IODE_REAL* KDBVariables::get_var_ptr(const std::string& name)
+{
+	// throw exception if object with passed name does not exist
+	int pos = get_position(name);
+	return get_var_ptr(pos);
 }
 
 void KDBVariables::set_var(const int pos, const int t, const IODE_REAL value, const EnumIodeVarMode mode)

--- a/cpp_api/KDB/kdb_variables.h
+++ b/cpp_api/KDB/kdb_variables.h
@@ -45,11 +45,27 @@ public:
 
     IODE_REAL get_var(const int pos, const Period& period, const EnumIodeVarMode mode = I_VAR_MODE_LEVEL) const;
 
+    /**
+     *  Returns a pointer to the first value of the Variable. 
+     *  
+     *  @param    pos   int        Variable position in the workspace   
+     *  @return         double*    pointer to the Variable values
+     */
+    IODE_REAL* get_var_ptr(const int pos);
+
     IODE_REAL get_var(const std::string& name, const int t, const EnumIodeVarMode mode = I_VAR_MODE_LEVEL) const;
 
     IODE_REAL get_var(const std::string& name, const std::string& period, const EnumIodeVarMode mode = I_VAR_MODE_LEVEL) const;
 
     IODE_REAL get_var(const std::string& name, const Period& period, const EnumIodeVarMode mode = I_VAR_MODE_LEVEL) const;
+
+    /**
+     *  Returns a pointer to the first value of the Variable. 
+     *  
+     *  @param    name   std::string   variable name   
+     *  @return          double*       pointer to the Variable values
+     */
+    IODE_REAL* get_var_ptr(const std::string& name);
 
     void set_var(const int pos, const int t, const IODE_REAL value, const EnumIodeVarMode mode = I_VAR_MODE_LEVEL);
 

--- a/python_api/CMakeLists.txt
+++ b/python_api/CMakeLists.txt
@@ -22,7 +22,7 @@ if(Python_FOUND)
     if(nanobind_FOUND)
         message(CHECK_PASS "found")
         
-        nanobind_add_module(iode py_sample.h py_ws.h pyiode.cpp)
+        nanobind_add_module(iode py_sample.h py_ws.h py_numpy.h pyiode.cpp)
 
         target_link_libraries(iode PRIVATE iode_cpp_api)
 

--- a/python_api/py_numpy.h
+++ b/python_api/py_numpy.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "cpp_api/iode_cpp_api.h"
+#include <nanobind/ndarray.h>
+
+/*
+ * nanobind supports zero-copy exchange using two protocols:
+ * - The classic buffer protocol.
+ * - DLPack, a GPU-compatible generalization of the buffer protocol.
+ * 
+ * see https://nanobind.readthedocs.io/en/latest/ndarray.html for documentation
+ */
+
+using numpy_var = nb::ndarray<nb::numpy, IODE_REAL, nb::ndim<1>>;
+
+/** Get an IODE variable in a numpy ndarray
+ * see https://nanobind.readthedocs.io/en/latest/ndarray.html#binding-functions-that-return-arrays 
+ *     https://nanobind.readthedocs.io/en/latest/ndarray.html#constraint-types 
+ *     https://nanobind.readthedocs.io/en/latest/api_extra.html#array-annotations 
+ */
+numpy_var get_var_as_ndarray(const std::string& name)
+{
+    size_t nb_obs = (size_t) Variables.get_nb_periods();
+    if(nb_obs == 0)
+        return numpy_var(NULL, { 0 });
+
+    IODE_REAL* var_ptr = Variables.get_var_ptr(name);
+    return numpy_var(var_ptr, { nb_obs });
+}

--- a/python_api/pyiode.cpp
+++ b/python_api/pyiode.cpp
@@ -8,6 +8,7 @@ namespace nb = nanobind;
 #include "cpp_api/iode_cpp_api.h"
 #include "py_ws.h"
 #include "py_sample.h"
+#include "py_numpy.h"
 
 
 NB_MODULE(iode, m) 
@@ -133,6 +134,11 @@ NB_MODULE(iode, m)
       // m.def("get_scl", [](const std::string& name) { return Scalars.get(name); }, nb::arg("name"),        "get an IODE scalar");
       // m.def("get_tbl", [](const std::string& name) { return Tables.get(name); }, nb::arg("name"),         "get an IODE table");
       m.def("get_var", [](const std::string& name) { return Variables.get(name); }, nb::arg("name"),         "get an IODE variable");
+
+      m.def("get_var_as_ndarray", &get_var_as_ndarray, nb::rv_policy::reference, nb::arg("name"), 
+            "Get an IODE variable in a numpy ndarray");
+      m.def("get_var_as_ndarray_copy", &get_var_as_ndarray, nb::rv_policy::copy, nb::arg("name"), 
+            "Get a copy of an IODE variable in a numpy ndarray");
 
       // IODE objects delete
 

--- a/tests/test_nanobind/test_iode.py
+++ b/tests/test_nanobind/test_iode.py
@@ -321,10 +321,18 @@ def test_iode_set_scl():
     iode.set_scl(py_myscl)
     i_myscl = iode.get_scl(name)
     assert repr(i_myscl) == repr(py_myscl)
-
+"""
 
 # VARIABLES IODE <-> PYTHON LISTS AND NDARRAYS
 # --------------------------------------------
+
+# TODO: find how to add get_var_as_ndarray() with the copy argument 
+#       in the iode module compiled with nanobind
+def get_var_as_ndarray(name, copy=True):
+    if copy:
+        return iode.get_var_as_ndarray_copy(name)
+    else:
+        return iode.get_var_as_ndarray(name)
 
 def test_iode_get_var_as_ndarray():
     '''
@@ -340,27 +348,25 @@ def test_iode_get_var_as_ndarray():
     name = "A"
 
     # x points to KV_WS["A"] because get_var_as_ndarray(..., 0)
-    x = iode.get_var_as_ndarray(name, 0)
+    x = get_var_as_ndarray(name, 0)
     x[2] = 22222 # Modifies the variable A in KV_WS
     A = iode.get_var("A")
     assert A[2] == 22222.0
 
     # y is a deep copy of KV_WS["A"] because get_var_as_ndarray(..., 0) => memory leak ?
-    y = iode.get_var_as_ndarray(name, 1)
+    y = get_var_as_ndarray(name, 1)
     y[2] = 33333 # Does not modify the variable A in KV_WS
     A = iode.get_var("A")
     assert A[2] == 22222.0
 
     # XYY does not exist in KV_WS => new allocation ? 
     # TODO: check this + does XYY exist in KV_WS ?
-    z = iode.get_var_as_ndarray("XYY", 1)
-    XYY = iode.get_var_as_ndarray("XYY", 1)
-    print("XYY : ", XYY)
+    with pytest.raises(RuntimeError):
+        XYY = get_var_as_ndarray("XYY", 1)
 
     # Saving a copy of the modified KV_WS
     iode.ws_save_var(str(IODE_OUTPUT_DIR / "a_mod.var"))
 
-"""
 def test_iode_get_var():
 
     varfile = str(IODE_DATA_DIR / "a.var")
@@ -370,8 +376,8 @@ def test_iode_get_var():
     A = iode.get_var("A")
     B = [0.0, 1.0, 2]
     assert A == B
-"""
 
+"""
 def test_iode_set_var():
 
     nbvars = iode.ws_load_var(str(IODE_DATA_DIR / "a.var"))

--- a/tests/test_python/test_iode.py
+++ b/tests/test_python/test_iode.py
@@ -14,8 +14,8 @@ import pandas as pd
 from pathlib import Path
 
 # GLOBALS
-IODE_DATA_DIR = Path("../data")
-IODE_OUTPUT_DIR = Path("../output")
+IODE_DATA_DIR = Path("../data").absolute()
+IODE_OUTPUT_DIR = Path("../output").absolute()
 IODE_VERBOSE = 1
 
 


### PR DESCRIPTION
@jmpplan You may be interested to see in how `nanobind` deals with Numpy arrays by looking at the present PR.

Note that I also modified the `test_iode.py` file in the `tests/test_python` folder (folder to test the iode Python module compiled with `cython`)

See [here](https://nanobind.readthedocs.io/en/latest/ndarray.html) for more details.