### PR TITLE
C++ API: added clec_deep_copy() utility function

### DIFF
--- a/cpp_api/lec/lec.cpp
+++ b/cpp_api/lec/lec.cpp
@@ -1,6 +1,26 @@
 #include "lec.h"
 
 
+CLEC* clec_deep_copy(const CLEC* other)
+{
+    // NOTE : see end of function L_cc2() from l_cc2.c to calculate tot_lg (= len)
+    CLEC* copy = (CLEC*) SW_nalloc(other->tot_lg);
+
+    copy->tot_lg = other->tot_lg,      
+	copy->exec_lg = other->exec_lg;       
+    copy->nb_names = other->nb_names;
+    copy->dupendo = other->dupendo;
+    copy->pad = '\0';
+    for(int i = 0; i < other->nb_names; i++)
+    {
+        strncpy(copy->lnames[i].name, other->lnames[i].name, sizeof(ONAME) / sizeof(char));
+        memset(copy->lnames[i].pad, '\0', sizeof(LNAME::pad) / sizeof(char));
+        copy->lnames[i].pos = other->lnames[i].pos;
+    }
+
+    return copy;
+}
+
 /**
  *  Compile and link the LEC expression with the current Scalars and Variables workspaces.
  *  

--- a/cpp_api/lec/lec.h
+++ b/cpp_api/lec/lec.h
@@ -8,6 +8,15 @@
 #include "time/period.h"
 #include "KDB/kdb_variables.h"
 
+/**
+ * @brief 
+ * 
+ * @param other 
+ * @return CLEC* 
+ * 
+ * @note 
+ */
+CLEC* clec_deep_copy(const CLEC* other);
 
 /**
  *  Evaluate the LEC expression for a specific period t.

--- a/cpp_api/objects/equation.cpp
+++ b/cpp_api/objects/equation.cpp
@@ -5,11 +5,14 @@
 EQ* create_equation_deep_copy(EQ* original_equation)
 {
     EQ* copy_eq = (EQ*) SW_nalloc(sizeof(EQ));
+    // NOTE : we do not use memcpy() because memcpy() actually makes  
+    //        a shallow copy of a struct instead of a deep copy
+    copy_eq->clec = clec_deep_copy(original_equation->clec);
     copy_eq->lec = copy_char_array(original_equation->lec);
-    copy_eq->clec = (CLEC*) SW_nalloc(sizeof(CLEC));
-    memcpy(copy_eq->clec, original_equation->clec, sizeof(CLEC));
     copy_eq->solved = original_equation->solved;
     copy_eq->method = original_equation->method;
+    // NOTE : we can use memcpy() on SAMPLE because SAMPLE does 
+    //        not contain attributes which are pointers
     memcpy(&copy_eq->smpl, &original_equation->smpl, sizeof(SAMPLE));
     copy_eq->cmt = copy_char_array(original_equation->cmt);
     copy_eq->blk = copy_char_array(original_equation->blk);

--- a/cpp_api/objects/equation.h
+++ b/cpp_api/objects/equation.h
@@ -3,6 +3,8 @@
 #include "utils/utils.h"
 #include "time/period.h"
 #include "time/sample.h"
+#include "lec/lec.h"
+
 #include <boost/functional/hash.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/cpp_api/objects/scalar.cpp
+++ b/cpp_api/objects/scalar.cpp
@@ -58,7 +58,7 @@ Scalar::Scalar(const Scalar& scalar)
     this->std = scalar.std;
 }
 
-std::string Scalar::to_string()
+std::string Scalar::to_string() const
 {
     return "Scalar(" + std::to_string(val) + ", " + std::to_string(relax) + ", " + std::to_string(std) + ")";
 }

--- a/cpp_api/objects/scalar.h
+++ b/cpp_api/objects/scalar.h
@@ -17,7 +17,7 @@ public:
 
     Scalar(const Scalar& scalar);
 
-    std::string to_string();
+    std::string to_string() const;
 
     // required to be used in std::map
     Scalar& operator=(const Scalar& scalar);


### PR DESCRIPTION
For info, `memcpy()` makes a shallow copy, not a deep copy !