### PR TITLE
PYTHON (NANOBIND): Exported the C++ class Equation + enabled get_eqs() and set_eqs()

### DIFF
--- a/cpp_api/KDB/kdb_equations.cpp
+++ b/cpp_api/KDB/kdb_equations.cpp
@@ -58,6 +58,15 @@ int KDBEquations::add(const std::string& name, const std::string& lec, const std
     return pos;
 }
 
+void KDBEquations::update(const std::string& name, const Equation& obj)
+{
+    char* c_name = to_char_array(name);
+
+    Equation eq(obj);
+
+    KDBTemplate::update(name, static_cast<EQ*>(&eq), c_name);
+}
+
 void KDBEquations::update(const std::string& name, const std::string& lec, const std::string& method, const std::string& from, 
     const std::string& to, const std::string& comment, const std::string& instruments, const std::string& block, const bool date)
 {

--- a/cpp_api/KDB/kdb_equations.h
+++ b/cpp_api/KDB/kdb_equations.h
@@ -27,6 +27,8 @@ public:
     int add(const std::string& name, const std::string& lec, const std::string& method = "LSQ", const std::string& from = "", const std::string& to = "", 
         const std::string& comment = "", const std::string& instruments = "", const std::string& block = "", const bool date = true);
 
+    void update(const std::string& name, const Equation& obj);
+
     void update(const std::string& name, const std::string& lec, const std::string& method = "LSQ", const std::string& from = "", const std::string& to = "", 
         const std::string& comment = "", const std::string& instruments = "", const std::string& block = "", const bool date = false);
 

--- a/cpp_api/objects/equation.cpp
+++ b/cpp_api/objects/equation.cpp
@@ -323,6 +323,14 @@ std::array<float, EQS_NBTESTS> Equation::get_tests() const
     return tests;
 }
 
+float Equation::get_test(const EnumIodeEquationTest t) const
+{
+    if(t < 0 || t >= EQS_NBTESTS)
+        throw std::invalid_argument("get_test: the passed value must be in range [0, " + 
+            std::to_string(EQS_NBTESTS-1) + "]");
+    return this->tests[t];
+}
+
 void Equation::set_tests(const std::array<float, EQS_NBTESTS> tests)
 {
     for(int i = 0; i < EQS_NBTESTS; i++) 

--- a/cpp_api/objects/equation.h
+++ b/cpp_api/objects/equation.h
@@ -137,6 +137,8 @@ public:
 
     std::array<float, EQS_NBTESTS> get_tests() const;
 
+    float get_test(const EnumIodeEquationTest t) const;
+
     void set_tests(const std::array<float, EQS_NBTESTS> tests);
 
     // -- misc --

--- a/cpp_api/objects/equation.h
+++ b/cpp_api/objects/equation.h
@@ -139,6 +139,16 @@ public:
 
     float get_test(const EnumIodeEquationTest t) const;
 
+    float get_test_stdev() const { return this->tests[IE_STDEV]; }
+    float get_test_meany() const { return this->tests[IE_MEANY]; }
+    float get_test_ssres() const { return this->tests[IE_SSRES]; }
+    float get_test_stderr() const { return this->tests[IE_STDERR]; }
+    float get_test_fstat() const { return this->tests[IE_FSTAT]; }
+    float get_test_r2() const { return this->tests[IE_R2]; }
+    float get_test_r2adj() const { return this->tests[IE_R2ADJ]; }
+    float get_test_dw() const { return this->tests[IE_DW]; }
+    float get_test_loglik() const { return this->tests[IE_LOGLIK]; }
+
     void set_tests(const std::array<float, EQS_NBTESTS> tests);
 
     // -- misc --

--- a/python_api/py_constants.cpp
+++ b/python_api/py_constants.cpp
@@ -25,6 +25,19 @@ void init_constants(nb::module_ &m)
       m.attr("E_GLS")            = (int) IE_GLS;
       m.attr("E_MAX_LIKELIHOOD") = (int) IE_MAX_LIKELIHOOD;
 
+      // test values
+      m.attr("IE_CORR")    = (int) IE_CORR;
+      m.attr("IE_STDEV")   = (int) IE_STDEV;
+      m.attr("IE_MEANY")   = (int) IE_MEANY; 
+      m.attr("IE_SSRES")   = (int) IE_SSRES; 
+      m.attr("IE_STDERR")  = (int) IE_STDERR;
+      m.attr("IE_STDERRP") = (int) IE_STDERRP;
+      m.attr("IE_FSTAT")   = (int) IE_FSTAT; 
+      m.attr("IE_R2")      = (int) IE_R2;
+      m.attr("IE_R2ADJ")   = (int) IE_R2ADJ; 
+      m.attr("IE_DW")      = (int) IE_DW;
+      m.attr("IE_LOGLIK")  = (int) IE_LOGLIK;
+
       // Simulation parameters
       m.attr("SORT_CONNEX") = (int) SORT_CONNEX;
       m.attr("SORT_BOTH")   = (int) SORT_BOTH;

--- a/python_api/py_constants.cpp
+++ b/python_api/py_constants.cpp
@@ -18,6 +18,13 @@ void init_constants(nb::module_ &m)
       m.attr("I_TBL") = (int) I_TABLES;
       m.attr("I_VAR") = (int) I_VARIABLES;
 
+      // Methods to estimation equations
+      m.attr("E_LSQ")            = (int) IE_LSQ;
+      m.attr("E_ZELLNER")        = (int) IE_ZELLNER;
+      m.attr("E_INSTRUMENTAL")   = (int) IE_INSTRUMENTAL;
+      m.attr("E_GLS")            = (int) IE_GLS;
+      m.attr("E_MAX_LIKELIHOOD") = (int) IE_MAX_LIKELIHOOD;
+
       // Simulation parameters
       m.attr("SORT_CONNEX") = (int) SORT_CONNEX;
       m.attr("SORT_BOTH")   = (int) SORT_BOTH;

--- a/python_api/py_objs.cpp
+++ b/python_api/py_objs.cpp
@@ -15,6 +15,7 @@ void init_iode_objs(nb::module_ &m)
         .def(nb::init<const std::string&>())
         .def(nb::init<const IODE_REAL, const IODE_REAL, const IODE_REAL>())
         .def(nb::self == nb::self)
+        .def("__str__", &Scalar::to_string)
         .def("__repr__", &Scalar::to_string);
 
     // IODE objects getters

--- a/python_api/py_objs.cpp
+++ b/python_api/py_objs.cpp
@@ -8,6 +8,39 @@ void init_iode_objs(nb::module_ &m)
     // Read https://nanobind.readthedocs.io/en/latest/classes.html#classes 
     // to see how to export C++ classes to Python
 
+    // NOTE: attributes 'solved', 'date' and 'tests' have been set as read-only in Python
+    nb::class_<Equation>(m, "Equation")
+    .def_prop_rw("lec", &Equation::get_lec, &Equation::set_lec)
+    .def_prop_ro("solved", &Equation::get_solved)
+    .def_prop_rw("method", &Equation::get_method, nb::overload_cast<const int>(&Equation::set_method))
+    .def_prop_rw("block", &Equation::get_block, &Equation::set_block)
+    .def_prop_rw("sample", &Equation::get_sample, &Equation::set_sample)
+    .def_prop_rw("comment", &Equation::get_comment, &Equation::set_comment)
+    .def_prop_rw("instruments", &Equation::get_instruments, &Equation::set_instruments)
+    .def_prop_ro("date", &Equation::get_date_as_string)
+    .def("update_date", &Equation::update_date)
+    .def_prop_ro("tests", &Equation::get_tests)
+    .def_prop_ro("e_stdev",  &Equation::get_test_stdev)
+    .def_prop_ro("e_meany",  &Equation::get_test_meany)
+    .def_prop_ro("e_ssres",  &Equation::get_test_ssres)
+    .def_prop_ro("e_stderr", &Equation::get_test_stderr)
+    .def_prop_ro("e_fstat",  &Equation::get_test_fstat)
+    .def_prop_ro("e_r2",     &Equation::get_test_r2)
+    .def_prop_ro("e_r2adj",  &Equation::get_test_r2adj)
+    .def_prop_ro("e_dw",     &Equation::get_test_dw)
+    .def_prop_ro("e_loglik", &Equation::get_test_loglik)
+    .def(nb::init<const std::string&>())
+    .def(nb::init<const std::string&, const std::string&, const int, const std::string&, const std::string&, 
+                    const std::string&, const std::string&, const std::string&, const bool>())
+    .def(nb::init<const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, 
+                    const std::string&, const std::string&, const std::string&, const bool>())
+    .def("get_coefficients_list", &Equation::get_coefficients_list, nb::arg("create_if_not_exit") = true)
+    .def("get_variables_list", &Equation::get_variables_list, nb::arg("create_if_not_exit") = true)
+    .def("split_equation", &Equation::split_equation)
+    .def(nb::self == nb::self)
+    .def("__str__", &Equation::to_string)
+    .def("__repr__", &Equation::to_string);
+
     nb::class_<Scalar>(m, "Scalar")
         .def_rw("value", &Scalar::val)
         .def_rw("relax", &Scalar::relax)

--- a/python_api/py_objs.cpp
+++ b/python_api/py_objs.cpp
@@ -54,7 +54,7 @@ void init_iode_objs(nb::module_ &m)
     // IODE objects getters
 
     m.def("get_cmt", [](const std::string& name) { return Comments.get(name); }, nb::arg("name"), "Get an IODE comment");
-    // m.def("get_eqs", [](const std::string& name) { return Equations.get(name); }, nb::arg("name"), "Get an IODE equation");
+    m.def("get_eqs", [](const std::string& name) { return Equations.get(name); }, nb::arg("name"), "Get an IODE equation");
     m.def("get_idt", [](const std::string& name) { return Identities.get_lec(name); }, nb::arg("name"),"Get an IODE identity");
     m.def("get_lst", [](const std::string& name) { return Lists.get(name); }, nb::arg("name"), "Get an IODE list");
     m.def("get_scl", [](const std::string& name) { return Scalars.get(name); }, nb::arg("name"), "Get an IODE scalar");
@@ -67,10 +67,14 @@ void init_iode_objs(nb::module_ &m)
                 if(!Comments.contains(name)) Comments.add(name, cmt); 
                 else Comments.update(name, cmt); 
         }, nb::arg("name"), nb::arg("cmt"), "Add or create an IODE comment");
-    // m.def("set_eqs", [](const std::string& name, const Equation& eq) { 
-    //            if(!Equations.contains(name)) Equations.add(name, eq); 
-    //            else Equations.update(name, eq); 
-    //      }, nb::arg("name"), nb::arg("eq"), "Get an IODE equation");
+    m.def("set_eqs", [](const std::string& name, const std::string& lec) { 
+               if(!Equations.contains(name)) Equations.add(name, lec); 
+               else Equations.update(name, lec); 
+         }, nb::arg("name"), nb::arg("lec"), "Add or create an IODE equation");
+    m.def("set_eqs", [](const std::string& name, const Equation& eq) { 
+               if(!Equations.contains(name)) Equations.add(name, eq); 
+               else Equations.update(name, eq); 
+         }, nb::arg("name"), nb::arg("eq"), "Add or create an IODE equation");
     m.def("set_idt", [](const std::string& name, const std::string& idt) { 
                 if(!Identities.contains(name)) Identities.add(name, idt); 
                 else Identities.update(name, idt); 

--- a/python_api/py_objs.h
+++ b/python_api/py_objs.h
@@ -8,6 +8,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/array.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/operators.h>

--- a/tests/test_nanobind/test_iode.py
+++ b/tests/test_nanobind/test_iode.py
@@ -234,7 +234,7 @@ def test_iode_set_eqs():
 
     # Test error
     py_A = "(grt A"
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         iode.set_eqs("A", py_A)
 
 # IODE IDENTITIES <-> PYTHON STRINGS

--- a/tests/test_nanobind/test_iode.py
+++ b/tests/test_nanobind/test_iode.py
@@ -206,7 +206,6 @@ def test_iode_get_eqs_lec():
     print(f"lec_BVY = '{lec_BVY}'")
     assert lec_BVY == "BVY:=YN+YK"
 
-"""
 def test_iode_get_eqs():
 
     iode.ws_load_eqs(str(IODE_DATA_DIR / "fun.eqs"))
@@ -237,7 +236,6 @@ def test_iode_set_eqs():
     py_A = "(grt A"
     with pytest.raises(RuntimeError):
         iode.set_eqs("A", py_A)
-"""
 
 # IODE IDENTITIES <-> PYTHON STRINGS
 # ----------------------------------


### PR DESCRIPTION
@jmpplan Please take a look of

- the change I made in the file `test_iode.py` -> commit abc441d3ec47e189207a3764231613b77a131ec1 
- how my C++ class Equation is exported to Python -> files [equation.h](https://github.com/plan-be/iode/blob/master/cpp_api/objects/equation.h) and [equation.cpp](https://github.com/plan-be/iode/blob/master/cpp_api/objects/equation.cpp) + commit 4500283d3e6dfd4a5041850795e7559e17b30e8a
- how the Python methods `get_eqs()` and `set_eqs()` are defined -> method [KDBEquations::add](https://github.com/plan-be/iode/blob/master/cpp_api/KDB/kdb_equations.cpp#L26) + global C++ variable [Equations](https://github.com/plan-be/iode/blob/master/cpp_api/KDB/kdb_equations.h#L60) + commit e886ec130316b8a6d5d333c562d0d63db9c193ec

Note that in the KDBEquations::add() method, I call the C API `K_add()` function (via the `KDBTemplate` class) by [casting the C++ Equation object obj as an EQ object](https://github.com/plan-be/iode/blob/master/cpp_api/KDB/kdb_equations.cpp#L38):
```C
int pos = KDBTemplate::add(name, static_cast<EQ*>(&eq), c_name);
```
I can do that because the C++ class `Equation` inherits from the C struct `EQ` (see [here](https://github.com/plan-be/iode/blob/master/cpp_api/objects/equation.h#L61)) and I do NOT add any additional attribute. 
Especially, the C++ class `Equation` does not add an attribute such as `name` or `endo`.
If any attribute is added to the C++ class `Equation`, casting an `Equation` object to an `EQ` object is no longer possible and then I can no longer pass an `Equation` object to a C API function taking a parameter of type `EQ`.
That's why I'm asking to either add the `name`/`endo` to the `EQ` struct or to remove `name` for the Python Equation class.

See also the test function [EquationTest::Equivalence_C_CPP](https://github.com/plan-be/iode/blob/master/tests/test_cpp_api/test_equation.cpp#L24) where I check that I can use an `Equation` as an `EQ` object.
Especially check the lines:
```C
Equation eq(name, lec, method, from, to, comment, instruments, block, true);
K_add(KE_WS, c_name, static_cast<EQ*>(&eq), c_name);
(...)
// eq = Equation object, c_eq = EQ object
memcpy(c_eq, &eq, sizeof(EQ));
(...)
boost::hash<EQ> eq_hasher;
std::size_t cpp_hash = eq_hasher(static_cast<EQ>(eq));
```
Every things above are no longer possible if `Equation` contains a additional `name`/`endo` attribute and so exchanges between the C API and the C++ API become more complicated (and with an higher cost maintenance).
So either we add a `name`/`endo` attribute to both `EQ` and `Equation` or we don't.