### PR TITLE
GUI: Fixed issues #398 and #404

### DIFF
--- a/doc/changelog/versions/v7.0-beta.5.rst.inc
+++ b/doc/changelog/versions/v7.0-beta.5.rst.inc
@@ -26,6 +26,8 @@ Fixed Bugs 🛠️
   * (GUI) Fixed opening an IODE data file when the path to that file contains special characters (#382) 
   * (GUI) Fixed interface crashing at launch when the path to a file previously opened in a tab 
           has been modified when the interface was closed (#397)
+  * (GUI) Fixed IODE objects tabs displaying the wrong filename when the filter is used (#398)
+  * (GUI) Fixed interface crashing when the user tries to clear a KDB while the filter is used (#404) 
 
 
 Miscellaneous 🤷‍♀️

--- a/gui/iode_objs/models/abstract_table_model.cpp
+++ b/gui/iode_objs/models/abstract_table_model.cpp
@@ -134,8 +134,10 @@ void IodeTemplateTableModel<K>::filter(const QString& pattern, const bool silent
 template <class K>
 bool IodeTemplateTableModel<K>::load(const QString& filepath, const bool forceOverwrite)
 {
+	K* kdb_ = kdb_global ? kdb_global : kdb_external;
+
 	std::string s_filepath = filepath.toLocal8Bit().toStdString();
-	int type_ = kdb ? kdb->get_iode_type() : get_iode_file_type(s_filepath);
+	int type_ = kdb_ ? kdb_->get_iode_type() : get_iode_file_type(s_filepath);
 
 	if (type_ < 0 || type_ > I_VARIABLES) 
 		return false;
@@ -168,16 +170,19 @@ bool IodeTemplateTableModel<K>::load(const QString& filepath, const bool forceOv
 template <class K>
 QString IodeTemplateTableModel<K>::save(const QDir& projectDir, const QString& filepath)
 {
-	if(!kdb)
+	// NOTE: we don't simply use kdb since it may point to kdb_filter
+	K* kdb_ = kdb_global ? kdb_global : kdb_external;
+
+	if(!kdb_)
 		return "";
 
-	if (kdb->count() == 0) 
+	if (kdb_->count() == 0) 
 		return ""; 
 
-	EnumIodeType iodeType = (EnumIodeType) kdb->get_iode_type();
+	EnumIodeType iodeType = (EnumIodeType) kdb_->get_iode_type();
 	
 	// if not provided as argument, get path to the file associated with KDB of objects of type iodeType
-	std::string std_filepath = filepath.isEmpty() ? kdb->get_filename() : filepath.toLocal8Bit().toStdString();
+	std::string std_filepath = filepath.isEmpty() ? kdb_->get_filename() : filepath.toLocal8Bit().toStdString();
 
 	// if KDB not linked to any file, ask the user to give/create a file to save in.
 	// Otherwise, check the filepath 
@@ -197,9 +202,9 @@ QString IodeTemplateTableModel<K>::save(const QDir& projectDir, const QString& f
 
 	try
 	{
-		kdb->set_filename(fullPath.toStdString());
+		kdb_->set_filename(fullPath.toStdString());
 		std::string full_path = fullPath.toStdString();
-		kdb->save(full_path);
+		kdb_->save(full_path);
 	}
 	catch (const IodeException& e)
 	{
@@ -213,10 +218,13 @@ QString IodeTemplateTableModel<K>::save(const QDir& projectDir, const QString& f
 template <class K>
 QString IodeTemplateTableModel<K>::saveAs(const QDir& projectDir)
 {
-	if(!kdb)
+	// NOTE: we don't simply use kdb since it may point to kdb_filter
+	K* kdb_ = kdb_global ? kdb_global : kdb_external;
+
+	if(!kdb_)
 		return "";
 
-	if (kdb->count() == 0) 
+	if (kdb_->count() == 0) 
 		return ""; 
 	
 	// ask user for new filepath
@@ -224,7 +232,7 @@ QString IodeTemplateTableModel<K>::saveAs(const QDir& projectDir)
 	// call the save method
 	filepath = save(projectDir, filepath);
 	// update KDB filename
-	if (!filepath.isEmpty()) kdb->set_filename(filepath.toStdString());
+	if (!filepath.isEmpty()) kdb_->set_filename(filepath.toStdString());
 	return filepath;
 }
 

--- a/gui/iode_objs/models/abstract_table_model.h
+++ b/gui/iode_objs/models/abstract_table_model.h
@@ -50,6 +50,8 @@ public:
 		return columnNames.size();
 	}
 
+	virtual int getNbObjects() const = 0;
+
 	virtual QString getFilepath() const = 0;
 
 protected:
@@ -129,9 +131,18 @@ public:
 		return kdb ? kdb->count() : 0;
 	}
 
+	int getNbObjects() const override
+	{
+		// NOTE: we don't simply use kdb since it may point to kdb_filter
+		K* kdb_ = kdb_global ? kdb_global : kdb_external;
+		return kdb_ ? kdb_->count() : 0;
+	}
+
 	QString getFilepath() const
 	{
-		return kdb ? QString::fromStdString(kdb->get_filename()) : "";
+		// NOTE: we don't simply use kdb since it may point to kdb_filter
+		K* kdb_ = kdb_global ? kdb_global : kdb_external;
+		return kdb_ ? QString::fromStdString(kdb_->get_filename()) : "";
 	}
 
 	Qt::ItemFlags flags(const QModelIndex& index) const override;
@@ -146,7 +157,13 @@ public:
 
 	void filter(const QString& pattern, const bool silent = false) override;
 
-	void clearKDB() { kdb->clear(); }
+	void clearKDB() 
+	{
+		// NOTE: we don't simply use kdb since it may point to kdb_filter
+		K* kdb_ = kdb_global ? kdb_global : kdb_external;
+		if(kdb_)
+			kdb_->clear();
+	}
 
 	bool load(const QString& filepath, const bool forceOverwrite);
 
@@ -213,10 +230,13 @@ private:
 
 	QString askFilepathDialog(const QDir& projectDir)
 	{
-		if(!kdb)
+		// NOTE: we don't simply use kdb since it may point to kdb_filter
+		K* kdb_ = kdb_global ? kdb_global : kdb_external;
+
+		if(!kdb_)
 			return "";
 		
-		int iodeType = kdb->get_iode_type();
+		int iodeType = kdb_->get_iode_type();
 		QString iodeTypeAsString = QString::fromStdString(vIodeTypes[iodeType]);
 
 		QString defaultFilename = QString(I_DEFAULT_FILENAME) + "." + QString::fromStdString(v_binary_ext[iodeType]);

--- a/gui/tabs/iode_objs/tab_database_abstract.h
+++ b/gui/tabs/iode_objs/tab_database_abstract.h
@@ -251,7 +251,7 @@ public:
             return tabPrefix[fileType] + QString(I_DEFAULT_FILENAME) + "." + ext + " [0]*";
         }
         else
-            return IodeAbstractWidget::getTabText() + " [" + QString::number(objmodel->rowCount()) + "]";
+            return IodeAbstractWidget::getTabText() + " [" + QString::number(objmodel->getNbObjects()) + "]";
     }
 
     QString getTooltip() const
@@ -259,7 +259,7 @@ public:
         if(isUnsavedDatabase())
             return prefixUnsavedDatabase + " " + QString::fromStdString(vIodeTypes[iodeType]) + " Database [0]";
         else
-            return IodeAbstractWidget::getTooltip() + " [" + QString::number(objmodel->rowCount()) + "]";
+            return IodeAbstractWidget::getTooltip() + " [" + QString::number(objmodel->getNbObjects()) + "]";
     }
 
     M* get_model() const 


### PR DESCRIPTION
  * Fixed IODE objects tabs displaying the wrong filename when the filter is used (#398)
  * Fixed interface crashing when the user tries to clear a KDB while the filter is used (#404)
  