### PR TITLE
GUI: Use QString::fromLocal8Bit() and QString::toLocal8Bit() to handle paths with special characters in Windows

### DIFF
--- a/doc/changelog/versions/v7.0-beta.5.rst.inc
+++ b/doc/changelog/versions/v7.0-beta.5.rst.inc
@@ -30,6 +30,7 @@ Fixed Bugs 🛠️
   * (GUI) Fixed interface crashing when the user tries to clear a KDB while the filter is used (#404) 
   * (GUI) Fixed copy/paste variables from Excel returning an error when the variable's name contains 
           leading and/or trailing spaces (#414)
+  * (GUI) Fixed running an IODE report when the path or the filename contains special characters (#415)
 
 
 Miscellaneous 🤷‍♀️

--- a/gui/iode_objs/models/abstract_table_model.h
+++ b/gui/iode_objs/models/abstract_table_model.h
@@ -142,7 +142,10 @@ public:
 	{
 		// NOTE: we don't simply use kdb since it may point to kdb_filter
 		K* kdb_ = kdb_global ? kdb_global : kdb_external;
-		return kdb_ ? QString::fromStdString(kdb_->get_filename()) : "";
+		if(!kdb)
+			return "";
+		QString filepath = QString::fromLocal8Bit(QByteArray(kdb_->get_filename().c_str())); 
+		return filepath;
 	}
 
 	Qt::ItemFlags flags(const QModelIndex& index) const override;

--- a/gui/tabs/iode_objs/tab_database_abstract.h
+++ b/gui/tabs/iode_objs/tab_database_abstract.h
@@ -118,7 +118,7 @@ public:
     {
         if(checkNewFilepath(filepath))
         {
-            set_kdb_filename(K_WS[fileType], filepath.toStdString());
+            set_kdb_filename(K_WS[fileType], filepath.toLocal8Bit().toStdString());
             modified = false;
             emit tabDatabaseModified(iodeType, false);
             return true;

--- a/gui/tabs/tab_abstract.h
+++ b/gui/tabs/tab_abstract.h
@@ -51,7 +51,7 @@ protected:
         }
 
         // check if correct extension
-        if(get_iode_file_type(filepath.toStdString()) != fileType)
+        if(get_iode_file_type(filepath.toLocal8Bit().toStdString()) != fileType)
         {
             QString filename = fileInfo.fileName(); 
             QString ext = fileInfo.suffix();

--- a/gui/text_edit/report_editor.cpp
+++ b/gui/text_edit/report_editor.cpp
@@ -36,7 +36,7 @@ void IodeReportEditor::run(const QString& filepath, const QString& parameters, c
         QDir::setCurrent(QFileInfo(filepath).absolutePath());
 
         // executes IODE report
-        execute_report(filepath.toStdString(), parameters.toStdString());
+        execute_report(filepath.toLocal8Bit().toStdString(), parameters.toStdString());
 
         // reset current directory execution to project directory (chdir)
         QDir::setCurrent(currentProjectDir);

--- a/gui/text_edit/report_editor.cpp
+++ b/gui/text_edit/report_editor.cpp
@@ -36,7 +36,7 @@ void IodeReportEditor::run(const QString& filepath, const QString& parameters, c
         QDir::setCurrent(QFileInfo(filepath).absolutePath());
 
         // executes IODE report
-        execute_report(filepath.toLocal8Bit().toStdString(), parameters.toStdString());
+        execute_report(filepath.toLocal8Bit().toStdString(), parameters.toLocal8Bit().toStdString());
 
         // reset current directory execution to project directory (chdir)
         QDir::setCurrent(currentProjectDir);


### PR DESCRIPTION
Fix issue #415