### PR TITLE
GUI: Fixed user interface crashing when deleting an IODE object while a subset of the IODE database is displayed (issue 473)

### DIFF
--- a/doc/changelog/versions/v7.0.0-beta.6.rst.inc
+++ b/doc/changelog/versions/v7.0.0-beta.6.rst.inc
@@ -32,6 +32,9 @@ Fixed Bugs 🛠️
   * (GUI) Fixed use the shortcut CTRL (+ ALT) + F1...F7 more than once (cascading) (#464)
   * (GUI) Fixed missing field 'Name' when editing an IODE object (#467)  
   * (GUI) Fixed new object not appearing in the list of IODE objects when the filter is active (#468) 
+  * (GUI) Fixed user interface crashing when deleting an IODE object via the IODE command line or by 
+          executing an IODE report while a subset of the IODE database is displayed 
+          (via the Filter field) (#473)   
 
 
 Miscellaneous 🤷‍♀️

--- a/gui/main_widgets/iode_command.cpp
+++ b/gui/main_widgets/iode_command.cpp
@@ -86,6 +86,7 @@ void IodeCommandLine::run_command()
     }
     catch(const std::exception& e)
     {
+        success = false;
         error_msg = QString::fromStdString(e.what());
         QMessageBox::warning(nullptr, "WARNING", error_msg + "\n");
     }

--- a/gui/main_window.cpp
+++ b/gui/main_window.cpp
@@ -706,7 +706,7 @@ void MainWindow::update_tab_and_completer(const int iodeType)
         for(int i = 0; i < I_NB_TYPES; i++)
             tabWidget_IODE_objs->updateObjectTab((EnumIodeType) i);
 
-        // update the list of Iode object names available for auto-complemention
+        // update the list of Iode object names available for autocomplete
         completer->updateIodeOjectsListNames();
         // show corresponding tab
         tabWidget_IODE_objs->showTab(index);

--- a/gui/tabs/iode_objs/tab_database_abstract.h
+++ b/gui/tabs/iode_objs/tab_database_abstract.h
@@ -155,7 +155,15 @@ public slots:
     void setModified(bool modified) override
     {
         this->modified = modified;
-        if(modified) resetModel(); 
+        if(modified)
+        {
+            // we need to recompute the subset database in the IodeTemplateTableModel class if the filter is active 
+            // -> executing a command line or an IODE report may have renamed, added or removed IODE objects and 
+            //    then made the subset database invalid (remember that the subset database in the 
+            //    IodeTemplateTableModel class is a shallow copy of a subset of a global IODE database)  
+		    filter(true);
+            resetModel(); 
+        }
         emit tabDatabaseModified(iodeType, modified);
     }
 


### PR DESCRIPTION
This could also fix issue #416