### PR TITLE
PYIODE: prepare to bind with C++ code 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -408,6 +408,7 @@ keyboard_shortcuts.*
 /api/version.h
 /tests/**/*.ini
 /pyiode/iode.c
+/pyiode/iode.cpp
 /pyiode/cythonize_iode.py
 /tests/output
 /doc/src/iode1.mif

--- a/pyiode/cythonize_iode.py.in
+++ b/pyiode/cythonize_iode.py.in
@@ -9,23 +9,27 @@ except ImportError:
 import numpy as np
 
 # Visual Studio dir structure
-build_dir         = '${CMAKE_BINARY_DIR}'
+build_dir          = '${CMAKE_BINARY_DIR}'
 
-scr4_incl_dir     = '${CMAKE_SOURCE_DIR}/scr4'
-iode_incl_dir     = '${CMAKE_SOURCE_DIR}/api'
+scr4_incl_dir      = '${CMAKE_SOURCE_DIR}/scr4'
+iode_incl_dir      = '${CMAKE_SOURCE_DIR}/api'
+iode_cpp_incl_dir  = '${CMAKE_SOURCE_DIR}/cpp_api'
 
-scr4_lib_dir      = f'{build_dir}/scr4'
-iode_lib_dir      = f'{build_dir}/api'
+scr4_lib_dir       = f'{build_dir}/scr4'
+iode_lib_dir       = f'{build_dir}/api'
+iode_cpp_lib_dir   = f'{build_dir}/cpp_api'
 
 scr4_obj_dir      = f'{build_dir}/scr4/CMakeFiles/iode_scr4.dir'
 iode_obj_dir      = f'{build_dir}/api/CMakeFiles/iode_c_api.dir'
+iode_cpp_obj_dir  = f'{build_dir}/api/CMakeFiles/iode_cpp_api.dir'
+
 #extra_link_args_ = '-debug'
 
 # Cythonize iode.pyx, compile generated file (iode.c) and link with appropriated libs
 iodemodule = Extension('iode',
-    include_dirs = [np.get_include(), scr4_incl_dir, iode_incl_dir],
-    library_dirs = [scr4_lib_dir, scr4_obj_dir, iode_lib_dir, iode_obj_dir],
-    libraries = ['iode_scr4', 'iode_c_api', 'odbc32', 'odbccp32', 'ws2_32', 'gdi32', 
+    include_dirs = [np.get_include(), scr4_incl_dir, iode_incl_dir, iode_cpp_incl_dir],
+    library_dirs = [scr4_lib_dir, scr4_obj_dir, iode_lib_dir, iode_obj_dir, iode_cpp_lib_dir, iode_cpp_obj_dir],
+    libraries = ['iode_scr4', 'iode_c_api', 'iode_cpp_api', 'odbc32', 'odbccp32', 'ws2_32', 'gdi32', 
                  'user32', 'advapi32', 'shell32', 'comdlg32', 'comctl32', 'Winspool', 'legacy_stdio_definitions'],
 	extra_compile_args=${IODE_CYTHON_FLAGS},				
     sources = ["iode.pyx", "s_iode.c"],

--- a/pyiode/cythonize_iode.py.in
+++ b/pyiode/cythonize_iode.py.in
@@ -9,22 +9,24 @@ except ImportError:
 import numpy as np
 
 # Visual Studio dir structure
-build_dir = '${CMAKE_BINARY_DIR}'
-iode_incl_dir = '${CMAKE_SOURCE_DIR}/api'
-scr4_incl_dir = '${CMAKE_SOURCE_DIR}/scr4'
-iode_lib_dir = f'{build_dir}/api'
-iode_obj_dir = f'{build_dir}/api/CMakeFiles/iode_c_api.dir'
-scr4_lib_dir = f'{build_dir}/scr4'
-scr4_obj_dir = f'{build_dir}/scr4/CMakeFiles/iode_scr4.dir'
+build_dir         = '${CMAKE_BINARY_DIR}'
+
+scr4_incl_dir     = '${CMAKE_SOURCE_DIR}/scr4'
+iode_incl_dir     = '${CMAKE_SOURCE_DIR}/api'
+
+scr4_lib_dir      = f'{build_dir}/scr4'
+iode_lib_dir      = f'{build_dir}/api'
+
+scr4_obj_dir      = f'{build_dir}/scr4/CMakeFiles/iode_scr4.dir'
+iode_obj_dir      = f'{build_dir}/api/CMakeFiles/iode_c_api.dir'
 #extra_link_args_ = '-debug'
 
 # Cythonize iode.pyx, compile generated file (iode.c) and link with appropriated libs
 iodemodule = Extension('iode',
-    include_dirs = [np.get_include(), iode_incl_dir, scr4_incl_dir],
+    include_dirs = [np.get_include(), scr4_incl_dir, iode_incl_dir],
     library_dirs = [scr4_lib_dir, scr4_obj_dir, iode_lib_dir, iode_obj_dir],
-    libraries = ['iode_c_api', 'iode_scr4', 'odbc32', 'odbccp32', 'ws2_32', 'gdi32', 
-                 'user32', 'advapi32', 'shell32', 'comdlg32', 'comctl32', 'Winspool', 
-                 'legacy_stdio_definitions'],
+    libraries = ['iode_scr4', 'iode_c_api', 'odbc32', 'odbccp32', 'ws2_32', 'gdi32', 
+                 'user32', 'advapi32', 'shell32', 'comdlg32', 'comctl32', 'Winspool', 'legacy_stdio_definitions'],
 	extra_compile_args=${IODE_CYTHON_FLAGS},				
     sources = ["iode.pyx", "s_iode.c"],
     depends = [ "iode.pxy", "s_iode.c", "iode.pxi", 
@@ -33,6 +35,7 @@ iodemodule = Extension('iode',
                 "pyiode_model.pyx", "pyiode_objs.pyx", "pyiode_print.pyx", 
                 "pyiode_reports.pyx", "pyiode_sample.pyx", "pyiode_util.pyx",  
                 "pyiode_ws.pyx"],
+    language="c++",
     # extra_link_args = [extra_link_args_],
     define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
 )           

--- a/pyiode/iode.pxi
+++ b/pyiode/iode.pxi
@@ -18,9 +18,18 @@ import cython
 import larray as la
 import pandas as pd
  
+# C libraries
 from libc.stdlib cimport free, malloc
 from libc.stdio cimport printf
+
+# C++ libraries
+from libcpp.string cimport string
+from libcpp.vector cimport vector
+
+# Cython libraries
 from cpython cimport PyObject, Py_INCREF
+
+# Python libraries
 from typing import Union, List, Tuple
 
 #from enum import Enum
@@ -163,9 +172,7 @@ cdef extern from "iode.h":
     cdef void   W_print_pg_footer(char* arg)
 
     # SCR4 functions
-    cdef int    SCR_free_tbl(char **tbl)
     cdef int    SCR_free(void *ptr)
-
 
     # TO Check
     cdef int    PyIodePrint(char*name, void* values, int lg)
@@ -173,6 +180,8 @@ cdef extern from "iode.h":
     cdef void   IodeResetMsgs()
     cdef int    ODE_assign_super_PYIODE()
 
+cdef extern from "s_iode.c":
+    cdef int   free_tbl(char** tbl)
 
 
 # IODE OBJECT CLASS DECLARATIONS 

--- a/pyiode/iode.pyx
+++ b/pyiode/iode.pyx
@@ -71,6 +71,9 @@
 # PYIODE API
 # ----------
 
+# The line below is to indicate to Cython that this .pyx file has to be compiled to C++.
+# distutils: language = c++
+
 include "iode.pxi" 
 
 # Included modules by topic

--- a/pyiode/pyiode_sample.pyx
+++ b/pyiode/pyiode_sample.pyx
@@ -114,7 +114,7 @@ def ws_sample_to_list(per_from: str = "", per_to: str = "", as_floats: bool = Fa
             smpl = IodeCreateSampleAsPeriods(cstr(per_from), cstr(per_to))
     
         lst = pylist(smpl)
-        SCR_free_tbl(smpl)
+        free_tbl(smpl)
         return lst 
         
 

--- a/pyiode/pyiode_ws.pyx
+++ b/pyiode/pyiode_ws.pyx
@@ -126,7 +126,7 @@ def ws_content(pattern: str = '*', objtype: int = 6) -> List[str]:
             res[nb] = pystr(s)
             nb = nb + 1
 
-    SCR_free_tbl(cnt)
+    free_tbl(cnt)
 
     return res
 

--- a/pyiode/s_iode.c
+++ b/pyiode/s_iode.c
@@ -60,3 +60,8 @@ int A2mGIF_HTML(A2MGRF *go, U_ch* filename)
 {
     return(0);
 } 
+
+int free_tbl(char** tbl)
+{
+    return SCR_free_tbl((unsigned char**) tbl);
+}


### PR DESCRIPTION
@jmpplan I have adapted the current pyiode `cythonize_iode.py.in` file + some `.pyx` files so that `pyiode` can bind with C++ code. See commit messages below.

Commit messages:
- GITIGNORE: ignore generated file /pyiode/iode.cpp
- PYIODE: prepare pyiode for C++
        (cythonize_iode.py.in)
        - ask Cython to compile pyiode using the C++ compiler
          instead of the C compiler
        (iode.pyx)
        - include C++ std libraries <string> and <vector>
        (s_iode.c)
        - added free_tbl(char** tbl) function for compatibility with C++
        (pyiode_sample.pyx)
        - replaced SCR_free_tbl() by free_tbl()
        (pyiode_ws.pyx)
        - replaced SCR_free_tbl() by free_tbl()
- PYIODE: (cythonize_iode.py.in)
        - added the IODE C++ API to the libraries to link with