### PR TITLE
C/C++ API: added C and C++ functions get_last_error() to transform C error messages into C++ exceptions

### DIFF
--- a/api/b_errors.c
+++ b/api/b_errors.c
@@ -9,6 +9,7 @@
  *      char *B_msg(int n)                  Returns a static buffer containing the message n from file iode.msg. 
  *      void B_seterror(char* fmt, ...)     Formats an error message and adds the text of the message to the global table of last errors.
  *      void B_seterrn(int n, ...)          Formats a message found in iode.msg and adds the result to the list of last errors.
+ *      void B_get_last_error()             Returns the last recorded errors (in B_ERROR_MSG).
  *      void B_display_last_error()         Displays the last recorded errors (in B_ERROR_MSG) using kmsgbox().
  *      void B_print_last_error()           Displays or prints the last recorded errors (in B_ERROR_MSG) using W_printf().
  *      void B_clear_last_error()           Resets the list of last messages (B_ERROR_MSG and B_ERROR_NB).
@@ -167,6 +168,33 @@ void B_seterrn(int n, ...)
     va_end(myargs);
 }
 
+
+/**
+ *  Returns the last recorded errors (in B_ERROR_MSG).
+ *  Reset B_ERROR_MSG after having displayed its content.
+ *  This function is intended to be called from a C++ code which will wrap 
+ *  the returned char array into a C++ exception. 
+ *  The returned vector char* must be freed using SCR_free() by the caller.
+ *  
+ *  @global [in, out] B_ERROR_NB  int       number of records errors
+ *  @global [in, out] B_ERROR_MSG char**    recorded error messages
+ *  @return char**                          recorded error messages
+ */
+char* B_get_last_error()
+{
+    char* errors = NULL;
+
+    if(B_ERROR_NB == 0) return errors;
+    
+    // Adds a null pointer to close B_ERROR_MSG
+    SCR_add_ptr(&B_ERROR_MSG, &B_ERROR_NB, NULL);
+
+    errors = SCR_mtov(B_ERROR_MSG, '\n');
+
+    B_clear_last_error();
+
+    return errors;
+}
 
 /**
  *  Displays the last recorded errors (in B_ERROR_MSG) using kmsgbox().

--- a/api/iodebase.h
+++ b/api/iodebase.h
@@ -807,6 +807,7 @@ extern void B_IodeMsgPath();
 extern void B_seterror(char *,...);
 extern void B_seterrn(int , ...);
 
+extern char* B_get_last_error(void);
 extern void B_display_last_error(void);
 extern void B_print_last_error(void);
 extern void B_clear_last_error(void);

--- a/cpp_api/KDB/kdb_abstract.cpp
+++ b/cpp_api/KDB/kdb_abstract.cpp
@@ -312,8 +312,12 @@ void KDBAbstract::copy_into(const std::string& input_file, const std::string obj
 
     int res = B_WsCopy(const_cast<char*>(buf.c_str()), k_type);
 
-    if(res < 0) 
-        B_display_last_error();
+    if(res < 0)
+    {
+        std::string msg = "Cannot copy content of file '" + input_file + "' into the " + vIodeTypes[k_type] + " database.\n";
+        msg += get_last_error();
+        throw std::runtime_error(msg);
+    }
 }
 
 // TODO JMP: please provide input values to test B_WsMerge()

--- a/cpp_api/KDB/kdb_global.cpp
+++ b/cpp_api/KDB/kdb_global.cpp
@@ -148,11 +148,7 @@ void export_as(const std::string& var_file, const std::string cmt_file, const st
         error_msg += "Comments file " + cmt_file_;
         dbc = K_interpret(K_CMT, to_char_array(cmt_file));
         if(dbc == NULL)
-        {
-            IodeExceptionInvalidArguments error(error_msg);
-            error.add_argument("Comment file", cmt_file);
-            throw error;
-        }
+            throw std::invalid_argument(error_msg + "\n" + "Comment file: '" + cmt_file + "'");
     } 
 
     KDB* dbv;
@@ -163,11 +159,7 @@ void export_as(const std::string& var_file, const std::string cmt_file, const st
         error_msg += "Variables file " + var_file_;
         dbv = K_interpret(K_VAR, to_char_array(var_file));
         if(dbv == NULL)
-        {
-            IodeExceptionInvalidArguments error(error_msg);
-            error.add_argument("Variable file", var_file);
-            throw error;
-        }
+            throw std::invalid_argument(error_msg + "\n" + "Variable file: '" + var_file + "'");
         
         if(smpl != NULL) 
             KV_sample(dbv, smpl);
@@ -222,7 +214,7 @@ void export_as(const std::string& var_file, const std::string cmt_file, const st
     K_WARN_DUP = 0;
 
     if(res != 0) 
-        B_display_last_error();
+        throw std::runtime_error(get_last_error());
 }
 
 void low_to_high(const EnumIodeLtoH type, const char method, const std::string& filepath, const std::string& var_list)

--- a/cpp_api/KDB/kdb_identities.cpp
+++ b/cpp_api/KDB/kdb_identities.cpp
@@ -64,7 +64,8 @@ void KDBIdentities::execute_identities(const Period& from, const Period& to, con
 
     int rc = B_IdtExecuteIdts(&sample, idts);
     SCR_free_tbl((unsigned char**) idts);
-    if (rc != 0) B_display_last_error();
+    if (rc != 0) 
+        throw std::runtime_error("Cannot execute identities '" + identities_list + "'\n" + get_last_error());
 }
 
 void KDBIdentities::execute_identities(const std::string& from, const std::string& to, const std::string& identities_list, 

--- a/cpp_api/KDB/kdb_variables.cpp
+++ b/cpp_api/KDB/kdb_variables.cpp
@@ -329,7 +329,12 @@ void KDBVariables::copy_into(const std::string& input_file, const std::string& f
 
         int res = B_WsCopy(const_cast<char*>(buf.c_str()), I_VARIABLES);
 
-        if (res < 0) B_display_last_error();
+        if (res < 0)
+		{
+			std::string msg = "Cannot copy the content of file '" + input_file + "' into the Variables database.\n";
+			msg += get_last_error();
+			throw std::runtime_error(msg);
+		}
 }
 
 void KDBVariables::copy_into(const std::string& input_file, const Period* from, const Period* to, 

--- a/cpp_api/compute/estimation.cpp
+++ b/cpp_api/compute/estimation.cpp
@@ -282,7 +282,12 @@ void EditAndEstimateEquations::estimate()
     if(res == 0)        
         estimation_done = true;
     else
-        B_display_last_error();
+    {
+        std::string msg = "Cannot proceed estimation.\n";
+        msg += "equations: " + boost::algorithm::join(v_equations, ";") + "\n";
+        msg += get_last_error();
+        throw std::runtime_error(msg);
+    }
 }
 
 std::vector<std::string> EditAndEstimateEquations::save(const std::string& from, const std::string& to)

--- a/cpp_api/compute/estimation.h
+++ b/cpp_api/compute/estimation.h
@@ -261,8 +261,7 @@ public:
             {
                 this->instruments = "";
                 B_seterrn(213, to_char_array(instr), L_error());
-                B_display_last_error();
-                return;
+                throw std::runtime_error(get_last_error());
             }
         }
 

--- a/cpp_api/utils/utils.h
+++ b/cpp_api/utils/utils.h
@@ -320,6 +320,14 @@ inline char** vector_to_double_char(const std::vector<std::string>& vec)
     return c_table;
 }
 
+inline std::string get_last_error()
+{
+    char* c_errors = B_get_last_error();
+    std::string msg(c_errors);
+    SCR_free(c_errors);
+    return msg;
+} 
+
 
 inline std::vector<std::string> get_scalars_from_clec(CLEC* clec)
 {

--- a/tests/test_cpp_api/test_estimation.cpp
+++ b/tests/test_cpp_api/test_estimation.cpp
@@ -365,6 +365,12 @@ TEST_F(EstimationTest, Estimate)
     // -- line 1
     EXPECT_DOUBLE_EQ(round(1e6 * m_corr3.get_value(1, 0)) / 1e6, -0.042291);
     EXPECT_DOUBLE_EQ(m_corr3.get_value(1, 1), 1.);
+
+    // Error
+    est.set_block("ACAF");
+    est.update_scalars();
+    Variables.clear();
+    EXPECT_THROW(est.estimate(), std::runtime_error);
 }
 
 TEST_F(EstimationTest, DynamicAdjustment)

--- a/tests/test_cpp_api/test_kdb_identities.cpp
+++ b/tests/test_cpp_api/test_kdb_identities.cpp
@@ -385,6 +385,11 @@ TEST_F(KDBIdentitiesTest, ExecuteIdentities)
 
     EXPECT_DOUBLE_EQ(computed_gap2[9], expected_gap2[9]);
     EXPECT_DOUBLE_EQ(computed_gap_[9], expected_gap_[9]);
+
+    // Error
+    Variables.clear();
+    EXPECT_THROW(Identities.execute_identities(std::to_string(y_from)+"Y1", std::to_string(y_to)+"Y1", 
+                 identities_list), std::runtime_error);
 }
 
 TEST_F(KDBIdentitiesTest, Merge)


### PR DESCRIPTION
The purpose is to be able to rely on the C++ exceptions and the C++ `try/catch` mechanism. 

@jmpplan For your information, I added the C function `get_last_error()` (which returns a char*) in the source file `b_error.c`
 