### PR TITLE
Synchronize API between iode_dos and iode qt 

### DIFF
--- a/api/estimation/e_dftest.c
+++ b/api/estimation/e_dftest.c
@@ -266,27 +266,27 @@ void E_PrintDF(char* lec, IODE_REAL* res, int drift, int trend, int order)
              lec, drift, trend, order, res[2]);
 
     W_print_tb("Coefficients and tests", 4);
-    W_printf("&1C &1CValue&1CStandard Error&1CT-Statistic\n");
+    W_printfRepl("&1C &1CValue&1CStandard Error&1CT-Statistic\n");
     W_printf(".tl\n");
 
-    W_printf("&1L%s&1D%lf&1D%lf&1D%lf\n",
+    W_printfRepl("&1L%s&1D%lf&1D%lf&1D%lf\n",
              "ADF", res[pos], res[pos + 1], res[pos + 2]);
     pos += 3;
 
     if(drift) {
-        W_printf("&1L%s&1D%lf&1D%lf&1D%lf\n",
+        W_printfRepl("&1L%s&1D%lf&1D%lf&1D%lf\n",
                  "Drift", res[pos], res[pos + 1], res[pos + 2]);
         pos += 3;
     }
 
     if(trend) {
-        W_printf("&1L%s&1D%lf&1D%lf&1D%lf\n",
+        W_printfRepl("&1L%s&1D%lf&1D%lf&1D%lf\n",
                  "Trend", res[pos], res[pos + 1], res[pos + 2]);
         pos += 3;
     }
 
     for(i = 1 ; i <= order ; i++) {
-        W_printf("&1LOrder %d&1D%lf&1D%lf&1D%lf\n",
+        W_printfRepl("&1LOrder %d&1D%lf&1D%lf&1D%lf\n",
                  i, res[pos], res[pos + 1], res[pos + 2]);
         pos += 3;
     }

--- a/api/estimation/e_print.c
+++ b/api/estimation/e_print.c
@@ -11,9 +11,6 @@
 
 #include "iode.h"
 
-#define E_printf   W_printf
-#define E_BeginTbl W_print_tb
-
 // Declarations
 static void E_print_parms();
 static void E_print_eqs();
@@ -35,21 +32,21 @@ static void E_print_parms()
 {
     char    from[20], to[20];
 
-    E_BeginTbl("Parameters", 2);
+    W_print_tb("Parameters", 2);
 
     PER_pertoa(&(E_SMPL->s_p1), from);
     PER_pertoa(&(E_SMPL->s_p2), to);
 
-    E_printf("&1NEstimation period        &1L%s:%s\n", from, to);
-    E_printf("&1NEstimation method        &1L%c\n", "LZIG"[E_MET]);
-    E_printf("&1LNumber of observations   &1L%d\n", E_T);
-    E_printf("&1LNumber of equations      &1L%d\n", E_NEQ);
-    E_printf("&1LNumber of coefficients   &1L%d\n", E_NCE);
-    E_printf("&1LNumber of instruments    &1L%d\n", E_NINSTR);
-    E_printf("&1LMax number of iterations &1L%d\n", E_MAXIT);
-    E_printf("&1LConvergence limit        &1L%lf\n", (double)E_EPS);
+    W_printfRepl("&1NEstimation period        &1L%s:%s\n", from, to);
+    W_printfRepl("&1NEstimation method        &1L%c\n", "LZIG"[E_MET]);
+    W_printfRepl("&1LNumber of observations   &1L%d\n", E_T);
+    W_printfRepl("&1LNumber of equations      &1L%d\n", E_NEQ);
+    W_printfRepl("&1LNumber of coefficients   &1L%d\n", E_NCE);
+    W_printfRepl("&1LNumber of instruments    &1L%d\n", E_NINSTR);
+    W_printfRepl("&1LMax number of iterations &1L%d\n", E_MAXIT);
+    W_printfRepl("&1LConvergence limit        &1L%lf\n", (double)E_EPS);
 
-    E_printf(".te\n");
+    W_printf(".te\n");
 }
 
 /**
@@ -60,10 +57,10 @@ static void E_print_eqs()
     int     i;
 
     W_print_tit(2);
-    E_printf("Equations\n");
+    W_printf("Equations\n");
     for(i = 0 ; i < E_NEQ ; i++) {
         W_print_enum(2);
-        E_printf("%s\n", E_LECS[i]);
+        W_printf("%s\n", E_LECS[i]);
     }
 }
 
@@ -77,10 +74,10 @@ static void E_print_instrs()
 
     if(E_NINSTR == 0 || E_MET == 0 || E_MET == 1) return;
     W_print_tit(2);
-    E_printf("Instruments\n");
+    W_printf("Instruments\n");
     for(i = 0 ; i < E_NINSTR ; i++) {
         W_print_enum(2);
-        E_printf("%s\n", E_INSTRS[i]);
+        W_printf("%s\n", E_INSTRS[i]);
     }
 }
 
@@ -94,20 +91,20 @@ static void E_print_coefs()
     int     i;
     SCL     *scl;
 
-    E_BeginTbl("Coefficients and tests", 5);
-    E_printf("&1CName&1CValue&1CStandard Error&1CT-Statistic&1CRelax\n");
-    E_printf(".tl\n");
+    W_print_tb("Coefficients and tests", 5);
+    W_printfRepl("&1CName&1CValue&1CStandard Error&1CT-Statistic&1CRelax\n");
+    W_printf(".tl\n");
     for(i = 0 ; i < E_NC ; i++) {
         scl = KSVAL(E_DBS, E_C_NBS[i]);
         //   if(scl->relax == 0) continue; /* JMP 12-03-98 */
-        E_printf("&1L%s&1D%lf&1D%lf&1D%lf&1D%lf\n",
+        W_printfRepl("&1L%s&1D%lf&1D%lf&1D%lf&1D%lf\n",
                  KONAME(E_DBS, E_C_NBS[i]),
                  (double) scl->val,
                  (double) scl->std,
                  (double) E_div_0(scl->val, scl->std),
                  (double) scl->relax);
     }
-    E_printf(".te\n");
+    W_printf(".te\n");
 }
 
 
@@ -118,26 +115,26 @@ static void E_print_mcorr()
 {
     int     i, j, ic, jc;
 
-    E_BeginTbl("Correlation matrix of coefficients", E_NCE + 1);
+    W_print_tb("Correlation matrix of coefficients", E_NCE + 1);
     // E_printf(".twidth 2 2\n"); // JMP 06/07/2022 => to keep .twidth empty as long as possible :-)
 
-    E_printf("&1C ");
+    W_printfRepl("&1C ");
     for(i = 0 ; i < E_NC ; i++)
-        if(MATE(E_SMO, i, 0)) E_printf("&1C%s", KONAME(E_DBS, E_C_NBS[i]));
+        if(MATE(E_SMO, i, 0)) W_printfRepl("&1C%s", KONAME(E_DBS, E_C_NBS[i]));
 
-    E_printf("\n.tl\n");
+    W_printf("\n.tl\n");
     for(i = 0, ic = 0 ; i < E_NC ; i++) {
         if(MATE(E_SMO, i, 0) == 0) continue;
-        E_printf("&1L%s", KONAME(E_DBS, E_C_NBS[i]));
+        W_printfRepl("&1L%s", KONAME(E_DBS, E_C_NBS[i]));
         for(j = 0, jc = 0 ; j < E_NC ; j++) {
             if(MATE(E_SMO, j, 0) == 0) continue;
-            E_printf("&1D%lf", (double) MATE(E_MCORR, ic, jc));
+            W_printfRepl("&1D%lf", (double) MATE(E_MCORR, ic, jc));
             jc++;
         }
-        E_printf("\n");
+        W_printf("\n");
         ic++;
     }
-    E_printf(".te\n");
+    W_printf(".te\n");
 }
 
 
@@ -148,17 +145,17 @@ static void E_print_mcorru()
 {
     int     i, j;
 
-    E_BeginTbl("Correlation of residuals", E_NEQ + 1);
+    W_print_tb("Correlation of residuals", E_NEQ + 1);
 
-    E_printf("&1C ");
-    for(i = 0 ; i < E_NEQ ; i++) E_printf("&1C%s", E_ENDOS[i]);
-    E_printf("\n.tl\n");
+    W_printfRepl("&1C ");
+    for(i = 0 ; i < E_NEQ ; i++) W_printfRepl("&1C%s", E_ENDOS[i]);
+    W_printfRepl("\n.tl\n");
     for(i = 0 ; i < E_NEQ ; i++) {
-        E_printf("&1L%s", E_ENDOS[i]);
-        for(j = 0 ; j < E_NEQ ; j++) E_printf("&1D%lf", (double) MATE(E_MCORRU, i, j));
-        E_printf("\n");
+        W_printfRepl("&1L%s", E_ENDOS[i]);
+        for(j = 0 ; j < E_NEQ ; j++) W_printfRepl("&1D%lf", (double) MATE(E_MCORRU, i, j));
+        W_printfRepl("\n");
     }
-    E_printf(".te\n");
+    W_printfRepl(".te\n");
     /* JMP 13-07-96 */
 }
 
@@ -170,28 +167,28 @@ static void E_print_mcorru()
  */
 static void E_print_eqres_1(int eq_nb)
 {
-    E_BeginTbl("", 2);
+    W_print_tb("", 2);
 
-    E_printf("&1C &1CValue\n");
-    E_printf(".tl\n");
-    E_printf("&1LNumber of coefficients      &1D%d\n", (int)MATE(E_NBCE, 0, eq_nb));
-    E_printf("&1LNumber of observations      &1D%d\n", E_T);
-    E_printf("&1LStandard deviation on YOBS  &1D%lf\n", (double) MATE(E_STDEV, 0, eq_nb));
-    E_printf("&1LMean of YOBS                &1D%lf\n", (double) MATE(E_MEAN_Y, 0, eq_nb));
-    E_printf(".tl\n");
+    W_printfRepl("&1C &1CValue\n");
+    W_printfRepl(".tl\n");
+    W_printfRepl("&1LNumber of coefficients      &1D%d\n", (int)MATE(E_NBCE, 0, eq_nb));
+    W_printfRepl("&1LNumber of observations      &1D%d\n", E_T);
+    W_printfRepl("&1LStandard deviation on YOBS  &1D%lf\n", (double) MATE(E_STDEV, 0, eq_nb));
+    W_printfRepl("&1LMean of YOBS                &1D%lf\n", (double) MATE(E_MEAN_Y, 0, eq_nb));
+    W_printfRepl(".tl\n");
 
-    E_printf("&1CTests&1CValue\n");
-    E_printf(".tl\n");
-    E_printf("&1LSum of square of residuals  &1D%lf\n", (double) MATE(E_SSRES, 0, eq_nb));
-    E_printf("&1LStandard error              &1D%lf\n", (double) MATE(E_STDERR, 0, eq_nb));
-    E_printf("&1LStandard error in %%        &1D%lf\n", (double) MATE(E_STD_PCT, 0, eq_nb));
-    E_printf("&1LF-Stat                      &1D%lf\n", (double) MATE(E_FSTAT, 0, eq_nb));
-    E_printf("&1LR2                          &1D%lf\n", (double) MATE(E_RSQUARE, 0, eq_nb));
-    E_printf("&1LR2 adjusted                 &1D%lf\n", (double) MATE(E_RSQUARE_ADJ, 0, eq_nb));
-    E_printf("&1LDurbin-Watson test          &1D%lf\n", (double) MATE(E_DW, 0, eq_nb));
-    E_printf("&1LLog likelihood              &1D%lf\n", (double) MATE(E_LOGLIK, 0, eq_nb));
-    E_printf(".tl\n");
-    E_printf(".te\n");
+    W_printfRepl("&1CTests&1CValue\n");
+    W_printfRepl(".tl\n");
+    W_printfRepl("&1LSum of square of residuals  &1D%lf\n", (double) MATE(E_SSRES, 0, eq_nb));
+    W_printfRepl("&1LStandard error              &1D%lf\n", (double) MATE(E_STDERR, 0, eq_nb));
+    W_printfRepl("&1LStandard error in %%        &1D%lf\n", (double) MATE(E_STD_PCT, 0, eq_nb));
+    W_printfRepl("&1LF-Stat                      &1D%lf\n", (double) MATE(E_FSTAT, 0, eq_nb));
+    W_printfRepl("&1LR2                          &1D%lf\n", (double) MATE(E_RSQUARE, 0, eq_nb));
+    W_printfRepl("&1LR2 adjusted                 &1D%lf\n", (double) MATE(E_RSQUARE_ADJ, 0, eq_nb));
+    W_printfRepl("&1LDurbin-Watson test          &1D%lf\n", (double) MATE(E_DW, 0, eq_nb));
+    W_printfRepl("&1LLog likelihood              &1D%lf\n", (double) MATE(E_LOGLIK, 0, eq_nb));
+    W_printfRepl(".tl\n");
+    W_printfRepl(".te\n");
     /* JMP 13-07-96 */
 }
 
@@ -209,14 +206,14 @@ static void E_print_eqres_2(int eq_nb)
     PERIOD  *per;
     double  respct;
 
-    E_BeginTbl("Actual and fitted values", 5);
-    E_printf("&1CPeriod&1CObservations&1CFitted Values&1CResiduals&1CResiduals (%%)\n");
-    E_printf(".tl\n");
+    W_print_tb("Actual and fitted values", 5);
+    W_printfRepl("&1CPeriod&1CObservations&1CFitted Values&1CResiduals&1CResiduals (%%)\n");
+    W_printfRepl(".tl\n");
     for(i = 0 ; i < E_T ; i++) {
         per = PER_addper(&(E_SMPL->s_p1), i);
         PER_pertoa(per, c_date);
         respct = 100 * E_div_0(MATE(E_U, eq_nb, i), MATE(E_LHS, eq_nb, i));
-        E_printf("&1L%s&1C%lf&1C%lf&1C%lf&1C%lf\n",
+        W_printfRepl("&1L%s&1C%lf&1C%lf&1C%lf&1C%lf\n",
                  c_date,
                  (double) MATE(E_LHS, eq_nb, i),
                  (double) MATE(E_RHS, eq_nb, i),
@@ -224,7 +221,7 @@ static void E_print_eqres_2(int eq_nb)
                  respct);
     }
 
-    E_printf(".te\n");
+    W_printfRepl(".te\n");
     /* JMP 13-07-96 */
 }
 /*
@@ -302,12 +299,12 @@ static void E_print_eqres(int obs)
     int     i;
 
     W_print_tit(2);
-    E_printf("Results by equation\n");
+    W_printf("Results by equation\n");
     for(i = 0 ; i < E_NEQ ; i++) {
         W_print_tit(3);
-        E_printf("Equation : %s\n", E_ENDOS[i]);
+        W_printf("Equation : %s\n", E_ENDOS[i]);
         W_print_par(3);
-        E_printf("%s\n", E_LECS[i]);
+        W_printf("%s\n", E_LECS[i]);
         E_print_eqres_1(i);
         if(obs) E_print_eqres_2(i);
         /*        E_print_eqres_3(i); */
@@ -433,14 +430,14 @@ int E_graph(char** titles, SAMPLE* smpl, MAT* mlhs, MAT* mrhs, int view, int res
 int E_print_results(int corr, int corru, int obs, int grobs, int grres) 
 {
     W_print_tit(1);
-    E_printf("Estimation\n");
+    W_printf("Estimation\n");
 
     E_print_eqs();
     E_print_parms();
     E_print_instrs();
 
     if(E_CONV == 0) {
-        E_printf(".par1 parb\nTHE PROCESS DOES NOT CONVERGE\n");
+        W_printf(".par1 parb\nTHE PROCESS DOES NOT CONVERGE\n");
         return(0);
     }
 

--- a/api/iode.h
+++ b/api/iode.h
@@ -45,9 +45,6 @@
 #define MAXFLOAT  FLT_MAX
 #define MINFLOAT  FLT_MIN
 #endif
- 
-
-//#include "o_objs.h" // JMP 8/12/2011
 
 /******************************* DEFINES **********************************/
 // ALD 23/11/2023
@@ -126,9 +123,9 @@
 #define KNB(kdb)     ((kdb)->k_nb)
 #define KOBJS(kdb)   ((kdb)->k_objs)
 
-#define KONAME(kdb, pos)    ((kdb)->k_objs[pos].o_name)                 // name of the object
-#define KSOVAL(kdb, pos)    ((kdb)->k_objs[pos].o_val)                  // position of the object in the memory
-#define KGOVAL(kdb, pos)    (SW_getptr((kdb)->k_objs[pos].o_val))       // pointer to the object (as a char*)
+#define KONAME(kdb, pos)    ((kdb)->k_objs[pos].o_name)
+#define KSOVAL(kdb, pos)    ((kdb)->k_objs[pos].o_val)
+#define KGOVAL(kdb, pos)    (SW_getptr((kdb)->k_objs[pos].o_val))
 
 
 #define K_NBR_OBJ   7
@@ -807,37 +804,38 @@ typedef char    ONAME[K_MAX_NAME + 1];
 typedef long    OSIZE;   /* JMP 23-05-00 */
 
 typedef struct  _kobj_ {
-    SWHDL       o_val;          // "position" in the memory -> to be passed to SW_getptr()
-    ONAME       o_name;         // name of the object
+    SWHDL       o_val;      /* SWHDL=long */ /* IODE64K */
+    ONAME       o_name;
     char        o_pad[3];
 } KOBJ;
 
 typedef struct _kdb_ {
-    KOBJ        *k_objs;                // map <position in the memory, object name>
-	long        k_nb;                   // number of objects in the database
-    short       k_type;                 // type of the object: K_CMT, K_EQS, ..., K_VAR
-    short       k_mode;                 // case of the object name: K_UPPER, K_LOWER or K_ASIS 
-    char        k_arch[LMAGIC];         // ???
-    char        k_magic[LMAGIC];        // ???
-    OFNAME       k_oname;               // ??? (compat size but not used)
-    char        k_desc[K_MAX_DESC];     // ???
-    char        k_data[K_MAX_DESC];     // Sample if Variables database
-    char        k_compressed;           // ???
-    char        k_reserved[59];         // not used (NOTE: decreased by 4 bytes in version 6.44 for k_nameptr)
-    char        *k_nameptr;             // filepath to the database file
+    KOBJ        *k_objs;
+	long        k_nb;
+    short       k_type;
+    short       k_mode;
+    char        k_arch[LMAGIC];
+    char        k_magic[LMAGIC];
+    //OFNAME       k_name; // 6.44
+    OFNAME       k_oname;  // 6.44 (compat size but not used)
+    char        k_desc[K_MAX_DESC];
+    char        k_data[K_MAX_DESC];     /* Client Data */
+    char        k_compressed;           /* IODE64K */
+    char        k_reserved[59];         /* 6.44 : decreased by 4 bytes for k_nameptr */
+    char        *k_nameptr;             /* 6.44 */ // Alignment on 4 bytes, not 8 => pb in Google tests (not /Zp1)
 } KDB;
 
 typedef struct _period {
-    long    p_y;        // year
-    long    p_s;        // position in the year (according to the periodicity)
-    char    p_p;        // periodicity (Y S Q M W D)
+    long    p_y; /* PERIOD LONG */
+    long    p_s; /* PERIOD LONG */
+    char    p_p;
     char    p_pad[3];
 } PERIOD;
 
 typedef struct _sample {
-    PERIOD  s_p1;       // starting period
-    PERIOD  s_p2;       // ending period
-    short   s_nb;       // number of periods in the sample
+    PERIOD  s_p1,
+	    s_p2;
+    short   s_nb;
     char    s_pad[2];
 } SAMPLE;
 
@@ -887,6 +885,11 @@ typedef struct _idt_ {
 #define EQS_NBTESTS     20
 
 // EQ = Equation (struct continaing a LEC equation, its compled form (CLEC), the estimation parameter and tests...)
+//
+// WARNING about the method property. 
+// Before using it, check that the method property value is in the appropriate range: in the very first versions of iode,
+// the allowed values for method were 'l', 'z', instead of 0, 1...
+
 typedef struct _eq_ {
     char    *lec;       // LEC form of the equation (LHS := RHS)
     CLEC    *clec;      // Compiled equation for the simulation

--- a/api/iodeapi.h
+++ b/api/iodeapi.h
@@ -59,6 +59,8 @@ extern double *IodeGetVector(char *name, int *lg);
 extern int IodeCalcSamplePosition(char *str_la_from, char* str_la_to, int *la_pos, int *ws_pos, int *la_lg);
 extern int IodeSetVector(char *la_name, double *la_values, int la_pos, int ws_pos, int la_lg);
 
+extern int IodeExecuteIdts(char *smpl, char *idt_list, char *var_files, char *scl_files, int trace);
+
 extern int IodeEstimate(char* veqs, char* afrom, char* ato);
 
 extern int IodeModelSimulate(char *per_from, char *per_to, char *eqs_list, char *endo_exo_list, double eps, double relax, int maxit, int init_values, int sort_algo, int nb_passes, int debug, double newton_eps, int newton_maxit, int newton_debug);
@@ -70,7 +72,9 @@ extern int IodeModelSimulateSCC(char *per_from, char *per_to,
                          double newton_eps, int newton_maxit, int newton_debug);
 extern double IodeModelSimNorm(char* period);
 extern int IodeModelSimNIter(char* period);
-extern int IodeModelSimCpu(char* period);                         
+extern int IodeModelSimCpu(char* period);     
+extern int IodeModelCpuSort();
+extern int IodeModelCpuSCC();
                          
 extern int IodeExecArgs(char *filename, char **args);
 extern int IodeExec(char *filename);
@@ -90,6 +94,10 @@ extern double *IodeChartData(int hdl, int i);
 extern void kmsg_null(const char* msg);
 extern void IodeSuppressMsgs();
 extern void IodeResetMsgs();
+
+void IodeAddErrorMsg(char* msg);
+void IodeDisplayErrorMsgs();
+void IodeClearErrorMsgs();
 
 extern int IodeSetNbDec(int nbdec);
 extern int IodeGetNbDec();

--- a/api/iodebase.h
+++ b/api/iodebase.h
@@ -807,6 +807,7 @@ extern void B_IodeMsgPath();
 extern void B_seterror(char *,...);
 extern void B_seterrn(int , ...);
 
+extern void B_add_error(char* msg);
 extern char* B_get_last_error(void);
 extern void B_display_last_error(void);
 extern void B_print_last_error(void);

--- a/api/objs/k_pack.c
+++ b/api/objs/k_pack.c
@@ -125,7 +125,7 @@ static void K_tcell64_32(TCELL* tc64, TCELL32* tc32)
 {
     int pos_tc_type;
 
-    // Copy de tl_type � la fin
+    // Binary copy from tl_type to the end of the struct
     pos_tc_type = K_pos_struct(tc32, &tc32->tc_type);
     memcpy((char*)&tc32->tc_type, (char*)&tc64->tc_type, sizeof(TCELL32) - pos_tc_type);
     if(tc64->tc_val)
@@ -148,7 +148,7 @@ static void K_tline64_32(TLINE* tl64, TLINE32* tl32)
 {
     int pos_tl_type;
 
-    // Copy de tl_type � la fin
+    // Binary copy from tl_type to the end of the struct
     pos_tl_type = K_pos_struct(tl32, &tl32->tl_type);
     memcpy((char*)&tl32->tl_type, (char*)&tl64->tl_type, sizeof(TLINE32) - pos_tl_type);
 }
@@ -171,7 +171,7 @@ static void K_tbl64_32(TBL* tbl64, TBL32* tbl32)
     pos_t_div = K_pos_struct(tbl32, &tbl32->t_div);
     memcpy((char*)tbl32, (char*)tbl64, pos_t_div);
 
-    // Copy de t_zmin � la fin
+    // Binary copy from t_zmin to the end of the struct
     pos_t_zmin = K_pos_struct(tbl32, &tbl32->t_zmin);
     memcpy((char*)&tbl32->t_zmin, (char*)&tbl64->t_zmin, sizeof(TBL32) - pos_t_zmin);
 
@@ -293,7 +293,7 @@ static int K_tpack64(char **pack, char *a1)
             case KT_CELL:
                 /* [TLINE32 * NC] */
                 cell = (TCELL*)tbl->t_line[i].tl_val;
-                for(j = 0; j < T_NC(tbl); j++)
+                for(j = 0; j < T_NC(tbl); j++) 
                     K_tcell64_32(cell + j, cell32 + j);
                 *pack = P_add(*pack, (char*)cell32, sizeof(TCELL32) * (int)T_NC(tbl));
 
@@ -628,8 +628,7 @@ static void K_tcell32_64(TCELL32* tc32, TCELL* tc64)
 {
     int pos_tc_type;
 
-    // Copy de tl_type � la fin
-
+    // Binary copy from tc_type to the end of the struct
     pos_tc_type = K_pos_struct(tc32, &tc32->tc_type);
     memcpy((char*)&tc64->tc_type, (char*)&tc32->tc_type, sizeof(TCELL32) - pos_tc_type);
     if(tc32->tc_val) tc64->tc_val = (char*)1;
@@ -649,8 +648,7 @@ static void K_tline32_64(TLINE32* tl32, TLINE* tl64)
 {
     int pos_tl_type;
 
-    // Copy de tl_type � la fin
-
+    // Binary copy from tl_type to the end of the struct
     pos_tl_type = K_pos_struct(tl32, &tl32->tl_type);
     memcpy((char*)&tl64->tl_type, (char*)&tl32->tl_type, sizeof(TLINE32) - pos_tl_type);
 }
@@ -673,7 +671,7 @@ static void K_tbl32_64(TBL32* tbl32, TBL* tbl64)
     pos_t_div = K_pos_struct(tbl32, &tbl32->t_div);
     memcpy((char*)tbl64, (char*)tbl32, pos_t_div);
 
-    // Copy de t_zmin � la fin
+    // Binary copy from t_zmin to the end of the struct
     pos_t_zmin = K_pos_struct(tbl32, &tbl32->t_zmin);
     memcpy((char*)&tbl64->t_zmin, (char*)&tbl32->t_zmin, sizeof(TBL32) - pos_t_zmin);
 
@@ -712,12 +710,11 @@ static TBL* K_tunpack64(char *pack)
     for(j = 0, p = 2; j < T_NC(tbl); j++) {
         K_tcell32_64(cell32 + j, cell + j);
         if(cell32[j].tc_val != 0) {
-            K_tcell32_64(cell32 + j, cell + j);
             cell[j].tc_val = P_alloc_get_ptr(pack, p);
             p++;
         }
     }
-
+    
     /* lines */
     /* alloc must be a multiple of KT_CHUNCK */
     T_L(tbl) = (TLINE*)SW_nalloc(sizeof(TLINE) * ((int)T_NL(tbl) / KT_CHUNCK + 1) * KT_CHUNCK);

--- a/api/objs/k_wsvar.c
+++ b/api/objs/k_wsvar.c
@@ -28,10 +28,10 @@
 /**
  * Changes the SAMPLE of a KDB of variables. Truncates the vars and/or add NaN values to fill the variables on the new sample.
  * 
- * @param [in, out] kdb     KDB*        pointer to a KDB of variables
- * @param [in]      nsmpl   SAMPLE*     new sample 
- * @return                  int         -1 if the kdb's sample and nsmpl don't overlap
- *                                      0 otherwise
+ * @param [in, out] kdb     KDB*            pointer to a KDB of variables
+ * @param [in]      nsmpl   SAMPLE* | NULL  new sample or NULL. If NULL or empty, no changes are made to the current WS
+ * @return                  int             -1 if the kdb's sample and nsmpl don't overlap or the resulting set is empty
+ *                                          0 otherwise
  */
  
 int KV_sample(KDB *kdb, SAMPLE *nsmpl)
@@ -40,7 +40,10 @@ int KV_sample(KDB *kdb, SAMPLE *nsmpl)
     char    *ptr;
     SAMPLE  *ksmpl, smpl;
 
+    if(nsmpl == NULL || nsmpl->s_nb == 0) return(0);
+    
     ksmpl = (SAMPLE *) KDATA(kdb);
+
     if(ksmpl->s_nb != 0) {
         if(PER_common_smpl(ksmpl, nsmpl, &smpl) < 0) return(-1);
         if(smpl.s_nb > 0) {

--- a/api/report/commands/b_data.c
+++ b/api/report/commands/b_data.c
@@ -587,7 +587,7 @@ int B_DataUpdate(char* arg, int type)
 char** B_DataSearchParms(char* name, int word, int ecase, int names, int forms, int texts, int type)
 {
     int     rc = 0;
-    char    **args = NULL, **lst, buf[81];
+    char    **args = NULL, buf[81];
     char    **K_grep();
     KDB     *kdb = K_WS[type];
 
@@ -627,7 +627,7 @@ char** B_DataSearchParms(char* name, int word, int ecase, int names, int forms, 
 int B_DataSearch(char* arg, int type)
 {
     int     rc = 0, word, ecase, names, forms, texts;
-    char    **args = NULL, **lst, buf[81];
+    char    **args = NULL, **lst;
     char    **K_grep();
     KDB     *kdb = K_WS[type];
 
@@ -708,7 +708,11 @@ int B_DataEditCnf(char* arg)
  */
 static int my_strcmp(const void *pa, const void *pb)
 {
-    char    **a = pa, **b = pb;                 // TODO: warning 'initializing': different 'const' qualifiers
+    const char    **a, **b;      // TODO: warning 'initializing': different 'const' qualifiers
+    
+    a = (const char**) pa;
+    b = (const char**) pb;      
+
     return(strcmp(*a, *b));
     
     //const char    *a = pa, *b = pb; // JMP 1/10/2021 TODO: Check this => Does NOT work ???

--- a/api/report/commands/b_htol.c
+++ b/api/report/commands/b_htol.c
@@ -169,7 +169,7 @@ done:
 // !!! NOT TESTED !!!
 KDB* B_htol_kdb(int method, KDB* kdb_from)
 {
-    int         lg, nb, rc = 0, i, j, f, t, shift, skip;
+    int         nb, rc = 0, i, j, f, t, shift, skip;
     IODE_REAL   *t_vec = NULL, *f_vec = NULL;
     KDB         *kdb_to = NULL;
     SAMPLE      *t_smpl = NULL;

--- a/api/utils/per.c
+++ b/api/utils/per.c
@@ -97,20 +97,26 @@ int PER_nb(int ch)
  *  
  *  @param [in] p1 PERIOD * First period
  *  @param [in] p2 PERIOD * Second period
- *  @return        int      Number of periods bw p1 and p2 or -1 on error
+ *  @return        int      Number of periods bw p1 and p2. -1 if periodicities are different or illegal.
  *  
  *  @details On error, call B_seterrn(85) and returns -1.
  */
 int PER_diff_per(PERIOD *p1, PERIOD *p2)
 {
     int     nb;
+    int     period_pos;
 
     if(p1->p_p != p2->p_p) {
         //B_seterrn(85);
         B_seterror("Different periodicities");
         return(-1);
     }
-    nb = L_PERIOD_NB[L_pos(L_PERIOD_CH, p1->p_p)];
+    period_pos = L_pos(L_PERIOD_CH, p1->p_p);
+    if(period_pos < 0) {
+        B_seterror("Illegal periodicity");
+        return(-1);
+    }
+    nb = L_PERIOD_NB[period_pos];
     nb = nb * (p1->p_y - p2->p_y) + p1->p_s - p2->p_s;
 
     return(nb);
@@ -124,15 +130,26 @@ int PER_diff_per(PERIOD *p1, PERIOD *p2)
  *  
  *  @param [in] period  PERIOD* First period
  *  @param [in] shift   in      number of sub-periods to add to period
- *  @return             PERIOD* Pointer to a static PERIOD struct.
+ *  @return             PERIOD* Pointer to a static PERIOD struct or NULL if period is illegal
  *  
  */
 PERIOD  *PER_addper(PERIOD *period, int shift)
 {
     int     nb_per = L_PERIOD_NB[L_pos(L_PERIOD_CH, period->p_p)],
-            shiftper, backw;
+            shiftper, 
+            backw, 
+            period_pos;
     static  PERIOD  per;
 
+    period_pos = L_pos(L_PERIOD_CH, period->p_p);
+    if(period_pos < 0) {
+        B_seterror("Illegal periodicity");
+        return(NULL);
+    }
+
+        
+    nb_per = L_PERIOD_NB[period_pos];
+    
     memcpy(&per, period, sizeof(PERIOD));
     if(shift >= 0) {
         per.p_y += (per.p_s + shift - 1) / nb_per;

--- a/scr4/s_probas.h
+++ b/scr4/s_probas.h
@@ -615,6 +615,9 @@ extern int PG_fld_free(PAGE *pg);
 /* s_wuser.c */
 extern int WscrDOSUserInit(int argc,char *argv[]);
 
+/* s_wgetms.c */
+extern long WscrGetMS(); 
+
 /* s_cmtscr.c */
 extern int PG_display_scr(PAGE *pg);
 

--- a/tests/data/fun2.ae
+++ b/tests/data/fun2.ae
@@ -2,7 +2,6 @@ ACAF {
 	"(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+
 acaf4*(TIME=1995)"
 	LSQ
-	BLOCK "ACAF"
 	SAMPLE 1980Y1 1996Y1
 	DATE 19980612
 	STDEV 0.0042699003
@@ -17,84 +16,53 @@ acaf4*(TIME=1995)"
 }
 ACAG {
 	"ACAG := ACAG[-1]+r VBBP[-1]+(0.006*VBBP[-1]*(TIME=2001)-0.008*(TIME=2008))"
-	LSQ
-	BLOCK "ACAG"
-	COMMENT " "
 }
 AOUC {
 	"AOUC:=((WCRH/QL)/(WCRH/QL)[1990Y1])*(VAFF/(VM+VAFF))[-1]+PM*(VM/(VAFF+VM))[-1]"
-	LSQ
-	BLOCK "AOUC"
 }
 BENEF {
 	"d BENEF :=d(VBNP-(IT+ITCEE)+SUB-DPUU-(WCF+SSFFIC+WDOM+WBG+
 YN)-(GOSH-DPUH+IDH)-DTF-RIDGG+YIDG)"
-	LSQ
-	BLOCK "BENEF"
-	COMMENT " "
 }
 BQY {
 	"BQY:=(YK+YN)/PBBP"
-		BLOCK "BQY"
 }
 BRUGP {
 	"BRUGP := 0"
-	LSQ
-	BLOCK "WLCP;BRUGP"
-	COMMENT " "
 }
 BVY {
 	"BVY:=YN+YK"
-		BLOCK "BVY"
 }
 CGU {
 	"CGU:=WBG+DPUG+QOUG"
-	LSQ
-	BLOCK "CGU"
-	COMMENT " "
 }
 COEFON {
 	"COEFON :=(ITON/(VBBP_P-VAG-VAH))[1990Y1]"
-	LSQ
-	BLOCK "COEFON"
-	COMMENT " "
 }
 COTRES {
 	"r COTRES :=r VBBP[-1]"
-	LSQ
-	BLOCK "COTRES"
-	COMMENT " "
 }
 DEBT {
 	"d DEBT := OCP-FLG"
-	LSQ
-	BLOCK "DEBT"
-	COMMENT " "
 }
 DPU {
 	"DPU:=DPUF+DPUG+DPUH"
-		BLOCK "DPU"
 }
 DPUF {
 	"r (DPUF/PIF):=r (VKFF*KNFF[-1])"
-	LSQ
-	BLOCK "DPUF"
 }
 DPUG {
 	"r DPUG:=r VBBP[-1]"
 	LSQ
-	BLOCK "DPUG"
 	SAMPLE 1963Y1 1988Y1
+	DATE 0
 }
 DPUGO {
 	"DPUGO:=DPUG/PDPUG"
-	LSQ
-	BLOCK "DPUGO"
 }
 DPUH {
 	"dln (DPUH/DPUHO):=dpuh_1+dpuh_2*dln(IHU/PI5)+dln PC"
 	LSQ
-	BLOCK "DPUH"
 	SAMPLE 1972Y1 1996Y1
 	DATE 19980612
 	STDEV 0.037785605
@@ -109,114 +77,72 @@ DPUH {
 }
 DPUU {
 	"r DPUU := r DPU"
-	LSQ
-	BLOCK "DPUU"
-	COMMENT " "
 }
 DTF {
 	"ln (DTF-(DTFX*40.34)-100*(TIME>1998)):=dtf0+(dtf1*ln GOSF)+dtf2*ln(GOSF/VAF_)"
 	LSQ
-	BLOCK "DTF"
 	SAMPLE 1971Y1 1996Y1
+	DATE 0
 }
 DTH {
 	"dln (DTH/(NATY-UY)):= 1.4 * dln(((WBU_+YN+GOSH_)-(SSF+SSH))/(PC*(NATY-UY)))+
 dln PC+((DTHX*40.34)/DTH[-1]) -(20/DTH[-1])*(TIME=2001)
 -(30/DTH[-1])*(TIME=2005)-(30/DTH[-1])*(TIME=2006)"
 	LSQ
-	BLOCK "DTH"
 	SAMPLE 1971Y1 1994Y1
+	DATE 0
 }
 DTH1 {
 	"DTH1:=DTH1C"
-	LSQ
-	BLOCK "DTH1"
 }
 DTH1C {
 	"DTH1C:= PMINTP+0.37*PMDVD"
-	LSQ
-	BLOCK "DTH1C"
 }
 EX {
 	"grt EX := XEX"
-	LSQ
-	BLOCK "EX"
-	COMMENT " "
 }
 EXC {
 	"EXC := EXCC+ITEP"
-	LSQ
-	BLOCK "EXC"
-	COMMENT " "
 }
 EXCC {
 	"EXCC := (EXCCR/(1+EXCCR))*QC"
-	LSQ
-	BLOCK "EXCC"
-	COMMENT " "
 }
 FLF {
 	"FLF:=SF+ACAF-IFU"
-		BLOCK "FLF"
 }
 FLG {
 	"FLG:=SG+ACAG-IUG"
-	LSQ
-	BLOCK "FLG"
 }
 FLGR {
 	"FLGR :=FLG/VBBP"
-	LSQ
-	BLOCK "FLGR"
-	COMMENT " "
 }
 GAP {
 	"GAP := 100*((QBBP_P/QBBPPOT_)-1)"
-	LSQ
-	BLOCK "GAP"
-	COMMENT " "
 }
 GOSF {
 	"d GOSF:= d(VAF-(WCF+WDOM+SSFFIC))"
-	LSQ
-	BLOCK "GOSF"
 }
 GOSG {
 	"r GOSG := r VBBP[-1]"
-	LSQ
-	BLOCK "GOSG"
-	COMMENT " "
 }
 GOSH {
 	"r GOSH:= r VBBP"
-	LSQ
-	BLOCK "GOSH"
 }
 GOSH_ {
 	"r GOSH_ :=r VBBP[-1]"
-	LSQ
-	BLOCK "GOSH_"
-	COMMENT " "
 }
 IDF {
 	"IDF:=IDH-IDG-YK"
-		BLOCK "IDF"
 }
 IDG {
 	"IDG := YIDG- RIDG"
-	LSQ
-	BLOCK "IDG"
-	COMMENT " "
 }
 IDH {
 	"d IDH:=RLBE*(SH-VI5)/100"
-	LSQ
-	BLOCK "IDH"
 }
 IFU {
 	"IFU:=VIF+VS"
 	GLS
-	BLOCK "IFU"
 	SAMPLE 1971Y1 1996Y1
 	DATE 19980612
 	STDEV 0.11678226
@@ -231,167 +157,89 @@ IFU {
 }
 IHU {
 	"r IHU := r(VI+VS-(IFU+IUG))"
-	LSQ
-	BLOCK "IHU"
 }
 IT {
 	"IT := ITF+ITM+ITT-ITCEE"
-	LSQ
-	BLOCK "IT"
-	COMMENT " "
 }
 ITCEE {
 	"ITCEE:=TVACEE+ITCEEM"
-	LSQ
-	BLOCK "ITCEE"
 }
 ITCR {
 	"ITCR := VATPC-SUBR+EXCCR+ITCRX+ITDR"
-	LSQ
-	BLOCK "ITCR"
-	COMMENT " "
 }
 ITD {
 	"ITD := (ITDR/(1+ITDR))*(VC+QOUG+VIF+IUG+VI5+VS)"
-	LSQ
-	BLOCK "ITD"
-	COMMENT " "
 }
 ITEP {
 	"ITEP := (ITEPR/(1+ITEPR))*QAFF"
-	LSQ
-	BLOCK "ITEP"
-	COMMENT " "
 }
 ITF {
 	"ITF := ITFC+ITFGO+ITFGI+ITF5"
-	LSQ
-	BLOCK "ITF"
-	COMMENT " "
 }
 ITF5 {
 	"ITF5 := (ITF5R/(1+ITF5R))*VI5"
-	LSQ
-	BLOCK "ITF5"
-	COMMENT " "
 }
 ITFC {
 	"ITFC := (VATPC/(1+VATPC))*VC"
-	LSQ
-	BLOCK "ITFC"
-	COMMENT " "
 }
 ITFGI {
 	"ITFGI := (ITFIGR/(1+ITFIGR))*IUG"
-	LSQ
-	BLOCK "ITFGI"
-	COMMENT " "
 }
 ITFGO {
 	"ITFGO := (ITFGR/(1+ITFGR))*QOUG"
-	LSQ
-	BLOCK "ITFGO"
-	COMMENT " "
 }
 ITFQ {
 	"r ITFQ:=r QBBP[-1]"
-	LSQ
-	BLOCK "ITFQ"
 }
 ITGR {
 	"ITGR := ITFGR+ITDR"
-	LSQ
-	BLOCK "ITGR"
-	COMMENT " "
 }
 ITI5R {
 	"ITI5R := ITF5R+ITDR"
-	LSQ
-	BLOCK "ITI5R"
-	COMMENT " "
 }
 ITIFR {
 	"ITIFR :=ITDR"
-	LSQ
-	BLOCK "ITIFR"
-	COMMENT " "
 }
 ITIGR {
 	"ITIGR := ITFIGR+ITDR"
-	LSQ
-	BLOCK "ITIGR"
-	COMMENT " "
 }
 ITM {
 	"ITM := (ITMR/(1+ITMR)) * VM"
-	LSQ
-	BLOCK "ITM"
-	COMMENT " "
 }
 ITMQ {
 	"ITMQ:=(ITMQR/(ITMQR+1))*QM"
-	LSQ
-	BLOCK "ITMQ"
 }
 ITMQR {
 	"d ITMQR :=0"
-	LSQ
-	BLOCK "ITMQR"
-	COMMENT " "
 }
 ITNQ {
 	"ITNQ :=ITFQ+ITMQ+ITONQ"
-	LSQ
-	BLOCK "ITNQ"
-	COMMENT " "
 }
 ITON {
 	"ITON :=IT+ITCEE-(ITF+ITM)-SUB"
-	LSQ
-	BLOCK "ITON"
-	COMMENT " "
 }
 ITONQ {
 	"ITONQ :=COEFON*(QBBP_P-QAG-QAH)"
-	LSQ
-	BLOCK "ITONQ"
-	COMMENT " "
 }
 ITPL {
 	"r ITPL :=r VBBP[-1]"
-	LSQ
-	BLOCK "ITPL"
-	COMMENT " "
 }
 ITPR {
 	"r ITPR:=r VBBP[-1]"
-	LSQ
-	BLOCK "ITPR"
 }
 ITPS {
 	"r ITPS :=r VBBP[-1]"
-	LSQ
-	BLOCK "ITPS"
-	COMMENT " "
 }
 ITT {
 	"ITT := EXC+ITPL+ITD+ITPR+ITPS"
-	LSQ
-	BLOCK "ITT"
-	COMMENT " "
 }
 IUG {
 	"IUG := IUGR*VBBP"
-	LSQ
-	BLOCK "IUG"
-	COMMENT " "
 }
 KL {
 	"dln KL :=kl10+kl11*(kl14*mavg(5,ln(PIF/WCRH))-ln KL)[-1]
 +kl12*d(5,ln WCRH)+kl13*d(5,ln (PIF*(RLBER+VKF)))"
 	LSQ
-	BLOCK "KL"
-	COMMENT " "
 	SAMPLE 1974Y1 1996Y1
 	DATE 19980612
 	STDEV 0.016967019
@@ -408,20 +256,14 @@ KLFHP {
 	"ln (KLFHP/KLFHPO) := ln (KLFHP/KLFHPO)[-1]+k0+k1*(ln (KLFHP/KLFHPO)-ln PKF+ln WCRH)[-1]
 +k2*d(-ln PKF+ln WCRH)"
 	LSQ
-	BLOCK "KLFHP"
-	COMMENT " "
 	SAMPLE 1973Y1 1998Y1
+	DATE 0
 }
 KN5 {
 	"KN5:=(1-VK5)*KN5[-1]+QI5"
-	LSQ
-	BLOCK "KN5"
 }
 KNF {
 	"grt KNF:=grt KNFF"
-	LSQ
-	BLOCK "KNF"
-	COMMENT " "
 }
 KNFF {
 	"dln KNFF := knff0+knff1*ln(QAFF_/(Q_F+Q_I))[-1]+
@@ -429,8 +271,6 @@ knf2*ln mavg(3,(VAFF_-WCF_-WIND_-DTF)/(PIF*KNFF[-1]*
 (RLBER+VKFF+knf3)))+KNFFO
 +knff3*mavg(4,dln QAFF_)"
 	LSQ
-	BLOCK "KNFF"
-	COMMENT " "
 	SAMPLE 1972Y1 1996Y1
 	DATE 20000125
 	STDEV 0.012966477
@@ -445,39 +285,21 @@ knf2*ln mavg(3,(VAFF_-WCF_-WIND_-DTF)/(PIF*KNFF[-1]*
 }
 KNFFY {
 	"KNFFY := (KNFF+KNFF[-1])/2"
-	LSQ
-	BLOCK "KNFFY"
-	COMMENT " "
 }
 KNFY {
 	"KNFY := (KNF[-1]+KNF)/2"
-	LSQ
-	BLOCK "KNFY"
-	COMMENT " "
 }
 KNI {
 	"KNI := KNFF-KNF"
-	LSQ
-	BLOCK "KNI"
-	COMMENT " "
 }
 KNIY {
 	"KNIY := (KNI+KNI[-1])/2"
-	LSQ
-	BLOCK "KNIY"
-	COMMENT " "
 }
 NATY {
 	"grt NATY := XNATY"
-	LSQ
-	BLOCK "NATY"
-	COMMENT " "
 }
 NFY {
 	"NFY := NFYH/(.001*HF*(1-(1-PROF)*.01*PRDAL))"
-	LSQ
-	BLOCK "NFY"
-	COMMENT " "
 }
 NFYH {
 	"dln(NFYH/NFYHO) := nfyh3*dln QAF_+ nfyh1*dln(TFPFHP_)
@@ -485,8 +307,6 @@ NFYH {
 +nfyh5*dln(PKF/WCRH)
 +nfyh6*ln (QAF_/Q_F)[-1]"
 	LSQ
-	BLOCK "NFYH"
-	COMMENT " "
 	SAMPLE 1971Y1 1996Y1
 	DATE 20011226
 	STDEV 0.019502673
@@ -501,46 +321,27 @@ NFYH {
 }
 OCUF {
 	"r OCUF := r VBBP[-1]"
-	LSQ
-	BLOCK "OCUF"
-	COMMENT " "
 }
 OCUG {
 	"r OCUG := r VBBP[-1]"
-	LSQ
-	BLOCK "OCUG"
-	COMMENT " "
 }
 OCUH {
 	"r OCUH := r VBBP[-1]"
-	LSQ
-	BLOCK "OCUH"
-	COMMENT " "
 }
 PAF_ {
 	"PAF_ := VAF_/QAF_"
-	LSQ
-	BLOCK "PAF_"
-	COMMENT " "
 }
 PAG {
 	"PAG := VAG/QAG"
-		BLOCK "PAG"
-	COMMENT " "
 }
 PAH {
 	"PAH := VAH/QAH"
-	LSQ
-	BLOCK "PAH"
-	COMMENT " "
 }
 PBBP {
 	"PBBP:=VBBP/QBBP"
-		BLOCK "PBBP"
 }
 PBNP {
 	"PBNP:=VBNP/QBNP"
-		BLOCK "PBNP"
 }
 PC {
 	"dln(PC/((1+ITCR)*PCO)):=pc1*dln AOUC
@@ -548,8 +349,6 @@ PC {
 +(1-pc1)*dln(PC/(1+ITCR))[-1]
 +pc0+pc4*dln(QAF_/Q_F)[-1]"
 	LSQ
-	BLOCK "PC"
-	COMMENT " "
 	SAMPLE 1973Y1 1996Y1
 	DATE 20000130
 	STDEV 0.030821944
@@ -565,45 +364,29 @@ PC {
 PC_ {
 	"r(PC_) := r(PC)"
 	GLS
-	BLOCK "PC_"
-	COMMENT " "
 	SAMPLE 1972Y1 1993Y1
+	DATE 0
 }
 PDPUG {
 	"r PDPUG :=r  PC"
-	LSQ
-	BLOCK "PDPUG"
-	COMMENT " "
 }
 PFI {
 	"PFI:=((PC*(1-ITCR)*QC)+(PQOG*(1-ITGR)*QGO)+(PIF*(1-ITIFR)*
 QIF)+(PIG*(1-ITIGR)*QIG)+(PI5*(1-ITI5R)*QI5)+VS)/(QC+QGO+QI+
 QS)"
-	LSQ
-	BLOCK "PFI"
 }
 PFI_ {
 	"PFI_ :=((PC_*(1-ITCR)*QC_)+(PQOG*(1-ITGR)*QGO)+(PIF*(1-ITIFR)*QIF)+
 (PIG*(1-ITIGR)*QIG)+(PI5*(1-ITI5R)*QI5)+VS_)/(QC_+QGO+QI+QS_)"
-	LSQ
-	BLOCK "PFI_"
-	COMMENT " "
 }
 PFND {
 	"r PFND := r((VC+CGU+VI+VS)/(QC+QG+QI+QS))"
-	LSQ
-	BLOCK "PFND"
-	COMMENT " "
 }
 PG {
 	"PG :=CGU/QG"
-	LSQ
-	BLOCK "PG"
-	COMMENT " "
 }
 PI5 {
 	"r ((PI5/PI5O)*(1-ITI5R)):=r (PC*(1-ITCR))"
-		BLOCK "PI5"
 }
 PIF {
 	"dln((PIF/PIFO)*(1-ITIFR)):=(pif_1*d(.8*dln AOUC+.2*dln PMAB)
@@ -611,30 +394,23 @@ PIF {
 +dln ((PIF/PIFO)*(1-ITIFR))[-1])*0
 +dln PC/(1+ITCR)"
 	LSQ
-	BLOCK "PIF"
 	SAMPLE 1975Y1 1996Y1
+	DATE 0
 }
 PIG {
 	"r ((PIG/PIGO)*(1-ITIGR)):=r (PC*(1-ITCR))"
-		BLOCK "PIG"
 }
 PKF {
 	"PKF := PIF*(RLBER+VKFF+0.1)"
-	LSQ
-	BLOCK "PKF"
-	COMMENT " "
 }
 PM {
 	"PM:=VM/QM"
-		BLOCK "PM"
 }
 PMAB {
 	"dln (PMAB/PMABO) :=pmab0*(pmab1*ln(PWMAB*EX)
 -ln(PMAB/PMABO))[-1]+pmab4
 +pmab6*dln (PWMAB*EX)"
 	LSQ
-	BLOCK "PMAB"
-	COMMENT " "
 	SAMPLE 1971Y1 1996Y1
 	DATE 19980620
 	STDEV 0.053380836
@@ -649,87 +425,55 @@ PMAB {
 }
 PME {
 	"r PME:=r (PW3*EX)"
-	LSQ
-	BLOCK "QME;PME"
 }
 PMS {
 	"dln (PMS):=
 dln(PWMS)+dln(EX)"
 	LSQ
-	BLOCK "PMS"
-	COMMENT " "
 	SAMPLE 1971Y1 1996Y1
+	DATE 0
 }
 PMT {
 	"dln(PMT/PMTO):=dln (PWMAB*EX)"
 	LSQ
-	BLOCK "PMT"
 	SAMPLE 1975Y1 1993Y1
+	DATE 0
 }
 POIL {
 	"grt POIL := XPOIL"
-	LSQ
-	BLOCK "POIL"
-	COMMENT " "
 }
 PQOG {
 	"r PQOG := r PC"
-	LSQ
-	BLOCK "PQOG"
-	COMMENT " "
 }
 PROD {
 	"PROD := QAF/NFYH"
-	LSQ
-	BLOCK "PROD"
 }
 PW3 {
 	"r PW3 := r POIL"
-	LSQ
-	BLOCK "PW3"
-	COMMENT " "
 }
 PWBG {
 	"grt PWBG :=.5*((grt TWG)*(WBGP/WBG)[-1]+
 (grt TWGP)*(YSFIC/WBG)[-1])+grt ZJ"
-	LSQ
-	BLOCK "PWBG"
-	COMMENT " "
 }
 PWMAB {
 	"dln PWMAB := XPWMAB/100-dln EX"
-	LSQ
-	BLOCK "PWMAB"
-	COMMENT " "
 }
 PWMS {
 	"dln PWMS := XPWMS/100-dln EX"
-	LSQ
-	BLOCK "PWMS"
-	COMMENT " "
 }
 PWXAB {
 	"dln PWXAB := XPWXAB/100-dln EX"
-	LSQ
-	BLOCK "PWXAB"
-	COMMENT " "
 }
 PWXS {
 	"dln PWXS := XPWXS/100-dln EX"
-	LSQ
-	BLOCK "PWXS"
-	COMMENT " "
 }
 PX {
 	"PX:=VX/QX"
-		BLOCK "PX"
 }
 PXAB {
 	"dln (PXAB/PXABO) :=pxab1*dln(PWXAB*EX)+
 +(1-pxab1)*dln(PXAB)[-1]"
 	LSQ
-	BLOCK "PXAB"
-	COMMENT " "
 	SAMPLE 1972Y1 1996Y1
 	DATE 19980620
 	STDEV 0.058685016
@@ -743,21 +487,15 @@ PXAB {
 }
 PXB {
 	"PXB := VXB/QXB"
-	LSQ
-	BLOCK "PXB"
-	COMMENT " "
 }
 PXE {
 	"r PXE:=r (PW3*EX)"
-		BLOCK "PXE"
 }
 PXS {
 	"dln (PXS/PXSO) := pxs1 * dln(AOUC) +
  pxs2 * (ln(PC) -ln (PXS/PXSO))[-1]
  +pxs3*dln(QAF_/Q_F)[-1]+pxs4"
 	LSQ
-	BLOCK "PXS"
-	COMMENT " "
 	SAMPLE 1972Y1 1996Y1
 	DATE 20000130
 	STDEV 0.039930049
@@ -773,109 +511,66 @@ PXS {
 PXT {
 	"dln (PXT/PXTO):=dln PC"
 	LSQ
-	BLOCK "PXT"
 	SAMPLE 1961Y1 1993Y1
+	DATE 0
 }
 QAF {
 	"r QAF := r(QAFF-QAI)"
-	LSQ
-	BLOCK "QAF"
-	COMMENT " "
 }
 QAFF {
 	"r QAFF := r(QAT-(QAG+QAH))"
-	LSQ
-	BLOCK "QAFF"
 }
 QAFF_ {
 	"r QAFF_ :=r (QAT_-(QAG+QAH))"
-	LSQ
-	BLOCK "QAFF_"
-	COMMENT " "
 }
 QAF_ {
 	"r QAF_ := r(QAFF_-QAI_)"
-	LSQ
-	BLOCK "QAF_"
-	COMMENT " "
 }
 QAG {
 	"r QAG := r (QG-QGO)"
-		BLOCK "QAG"
-	COMMENT " "
 }
 QAH {
 	"r QAH := r QAH[-1]"
-	LSQ
-	BLOCK "QAH"
-	COMMENT " "
 }
 QAI {
 	"QAI := VAI/PAF_"
-	LSQ
-	BLOCK "QAI"
-	COMMENT " "
 }
 QAI_ {
 	"QAI_ :=VAI_/PAF_"
-	LSQ
-	BLOCK "QAI_"
-	COMMENT " "
 }
 QAT {
 	"r QAT := r(QBBP-ITNQ)"
-	LSQ
-	BLOCK "QAT"
-	COMMENT " "
 }
 QAT_ {
 	"r QAT_ := r(QBBP_P-ITNQ)"
-	LSQ
-	BLOCK "QAT_"
-	COMMENT " "
 }
 QBBP {
 	"r QBBP:= r(QC+QG+QI+QS+(QX-QM))"
-	LSQ
-	BLOCK "QBBP"
 }
 QBBPPOT_ {
 	"r QBBPPOT_ := r(Q_F+Q_I+QAGHP+QAHHP+ITNQHP)*(TIME<1999)
        +   r(Q_F+Q_I+QAG+QAH+ITNQ)*(TIME>1998)"
-	LSQ
-	BLOCK "QBBPPOT_"
-	COMMENT " "
 }
 QBBP_B {
 	"r QBBP_B:= r(QC+QG+QI+QS+(QX-QM))"
-	LSQ
-	BLOCK "QBBP_B"
-	COMMENT " "
 }
 QBBP_P {
 	"QBBP_P := (2*QBBP)-QBBP_B"
-	LSQ
-	BLOCK "QBBP_P"
-	COMMENT " "
 }
 QBNP {
 	"r QBNP := r(QBBP+BQY)"
-	LSQ
-	BLOCK "QBNP"
 }
 QC {
 	"r QC:=r QC_"
 	GLS
-	BLOCK "QC"
 	SAMPLE 1964Y1 1991Y1
+	DATE 0
 }
 QC_ {
 	"ln(QC_/QCO):=qc1_+qc2_*ln(YDH_/PC_)+qc0*ln(YDH_/PC_)[-1]
 +qc3*d(UY/NATY)[-1]+qc4*(0.01*RSBE-dln PC_)[-1]
 +qc6*(t=1993Y1)"
 	LSQ
-	BLOCK "QC_"
-	COMMENT " "
 	SAMPLE 1967Y1 1996Y1
 	DATE 20041031
 	STDEV 0.22061615
@@ -890,32 +585,21 @@ QC_ {
 }
 QFND {
 	"r QFND := r(QC+QG+QI+QS)"
-	LSQ
-	BLOCK "QFND"
-	COMMENT " "
 }
 QG {
 	"r QG:= r(WBGO+QGO+DPUGO)"
-	LSQ
-	BLOCK "QG"
 }
 QGO {
 	"QGO :=QOUG/PQOG"
-	LSQ
-	BLOCK "QGO"
-	COMMENT " "
 }
 QI {
 	"r QI:=r (QIF+QIG+QI5)"
-	LSQ
-	BLOCK "QI"
 }
 QI5 {
 	"QI5/QI5O:=(1-qi5_4)*(QI5/QI5O)[-1]-qi5_4*(1-VK5)*KN5[-1]+qi5_4*
 (qi5_5*(qi5_1+qi5_2*(YDH_/PC)+qi5_3*((PI5/PC)*(.01*RLBE-
 (d (5,ln PC/5)))))+(1-qi5_5)*KN5[-1])"
 	LSQ
-	BLOCK "QI5"
 	SAMPLE 1965Y1 1996Y1
 	DATE 19980620
 	STDEV 67.852379
@@ -930,32 +614,21 @@ QI5 {
 }
 QIF {
 	"QIF:= KNF-(1-VKF)*KNF[-1]"
-	LSQ
-	BLOCK "QIF"
 }
 QIG {
 	"QIG:=IUG/PIG"
-	LSQ
-	BLOCK "QIG"
 }
 QL {
 	"QL :=KLFHP**(ZZF_-1)*TFPFHP_"
-	LSQ
-	BLOCK "QL"
-	COMMENT " "
 }
 QM {
 	"r QM:= r (QMAB+QME+QMS+QMT)"
-	LSQ
-	BLOCK "QM"
 }
 QMAB {
 	"dln(QMAB/QMABO):=qmab_10+qmab_5*dln (PFI_/PMAB)+
 1*dln QQMAB_+qmab_4*(qmab_1+qmab_2*ln(PFI_/PMAB)
 +1*ln QQMAB_+qmab_10*t-ln(QMAB/QMABO))[-1]"
 	LSQ
-	BLOCK "QMAB"
-	COMMENT " "
 	SAMPLE 1972Y1 1996Y1
 	DATE 19980620
 	STDEV 0.062368844
@@ -973,16 +646,12 @@ QME {
 0.019*QIF+0.0247976*QIG+0.02907*QI5+.11881*QS_+
 .76698*QXE+.02969*QXAB +0.056*(QXS+QXT))+
 qme_2*dln (PME/PFI)"
-	LSQ
-	BLOCK "QME;PME"
 }
 QMS {
 	"dln (QMS/QMSO) :=qms1*dln (0.019*QC_+.016*QG+0.023*QIF+0.027*QIG+0.028*QI5 +
 .006*QS_+ .002*QXE+.021*QXAB +.037*(QXS+QXT))[-1]+qms2
 +qms3*dln (PMS/PFI)+qms4*(TIME=1989)+qms5*(TIME=1995)"
 	LSQ
-	BLOCK "QMS"
-	COMMENT " "
 	SAMPLE 1976Y1 1996Y1
 	DATE 19980620
 	STDEV 0.084672637
@@ -999,7 +668,6 @@ QMT {
 	"ln(QMT/QMTO):=qmt_1*ln (YDH_/PC)+
 qmt_2*ln (YDH_/PC)[-1]+qmt_3*ln ((PWXAB*EX)/PC)"
 	LSQ
-	BLOCK "QMT"
 	SAMPLE 1974Y1 1996Y1
 	DATE 19980620
 	STDEV 0.21539952
@@ -1014,72 +682,45 @@ qmt_2*ln (YDH_/PC)[-1]+qmt_3*ln ((PWXAB*EX)/PC)"
 }
 QOUG {
 	"r QOUG := r VBBP[-1]"
-	LSQ
-	BLOCK "QOUG"
-	COMMENT " "
 }
 QQMAB_ {
 	"QQMAB_ :=.25131*QC_+.06459*QG+.46412*QIF+.31415*QIG+.20257*QI5+
 .55279*QS_+.55453*QXAB+.0092*QXE +.046* QXS"
-	LSQ
-	BLOCK "QQMAB_"
-	COMMENT " "
 }
 QS {
 	"d (QS/QSO) := d  QS_"
-	LSQ
-	BLOCK "QS"
-	COMMENT " "
 }
 QS_ {
 	"(d QS_)/QBBP[-1] := -0.011*(TIME=1999)+0.004*(TIME=2000)"
-	LSQ
-	BLOCK "QS_"
-	COMMENT " "
 }
 QWXAB {
 	"grt QWXAB := XQWXAB"
-	LSQ
-	BLOCK "QWXAB"
-	COMMENT " "
 }
 QWXS {
 	"grt QWXS := XQWXS"
-	LSQ
-	BLOCK "QWXS"
-	COMMENT " "
 }
 QWXSS {
 	"grt QWXSS := XQWXSS"
-	LSQ
-	BLOCK "QWXSS"
-	COMMENT " "
 }
 QX {
 	"r QX := r(QXAB+QXE+QXS+QXT)"
 	LSQ
-	BLOCK "QX"
-	COMMENT " "
 	SAMPLE 1971Y1 1995Y1
+	DATE 0
 }
 QXAB {
 	"ln(QXAB/QXABO):=qxab1*mavg(2,ln(PWXAB*EX/AOUC))+qxab0
 +qxab2*ln QWXSS+qxab3*t+qxab4*(TIME>1994)"
 	LSQ
-	BLOCK "QXAB"
-	COMMENT " "
 	SAMPLE 1974Y1 1996Y1
+	DATE 0
 }
 QXB {
 	"r QXB := r(QXAB+QXE)"
-	LSQ
-	BLOCK "QXB"
-	COMMENT " "
 }
 QXE {
 	"dln (QXE/QXEO):=dln QME"
 	LSQ
-	BLOCK "QXE"
 	SAMPLE 1962Y1 1992Y1
 	DATE 19940520
 	STDEV 0.38079327
@@ -1097,7 +738,6 @@ QXS {
 (WCF_/QAF_))+qxs1*ln QWXS-ln (QXS/QXSO))[-1]+
 qxs4*dln QWXSS+qxs5*(TIME=1977)+qx6*(TIME=1995)"
 	LSQ
-	BLOCK "QXS"
 	SAMPLE 1973Y1 1996Y1
 	DATE 19980620
 	STDEV 0.08203423
@@ -1114,7 +754,6 @@ QXT {
 	"dln (QXT/QXTO):=qxt3*(qxt0+qxt1*ln((PWXAB*EX)/PC)-
 ln(QXT/QXTO))[-1]+qxt2*dln ((PWXAB*EX)/PC)"
 	LSQ
-	BLOCK "QXT"
 	SAMPLE 1973Y1 1996Y1
 	DATE 19980620
 	STDEV 0.085953832
@@ -1129,68 +768,38 @@ ln(QXT/QXTO))[-1]+qxt2*dln ((PWXAB*EX)/PC)"
 }
 Q_F {
 	"Q_F := KNFY*KLFHP**ZZF_*TFPFHP_"
-	LSQ
-	BLOCK "Q_F"
-	COMMENT " "
 }
 Q_I {
 	"Q_I := PROIHP_*mean(t-0,t+0,KNIY)"
-	LSQ
-	BLOCK "Q_I"
-	COMMENT " "
 }
 RDEBT {
 	"d RDEBT := 0.2*d (0.01*RSBE)+0.8*d(0.1*(0.01*RLBE)+0.9*(RDEBT
 -0.2*(0.01*RSBE)))[-1]"
-	LSQ
-	BLOCK "RDEBT"
-	COMMENT " "
 }
 RENT {
 	"RENT :=(VAF_-WCF_-DTF)/(PIF*KNF[-1]*(RLBER+VKFF+knf3))"
-	LSQ
-	BLOCK "RENT"
-	COMMENT " "
 }
 RIDG {
 	"r RIDG:=r VBBP[-1]"
-	LSQ
-	BLOCK "RIDG"
 }
 RIDGG {
 	"r RIDGG := r RIDG"
-	LSQ
-	BLOCK "RIDGG"
-	COMMENT " "
 }
 RIPBE {
 	"RIPBE/RIPBEO := .9*RSBE+.1*RLBE"
-	LSQ
-	BLOCK "RIPBE"
-	COMMENT " "
 }
 RLBE {
 	"RLBE :=XRLBER+100*dln PC"
-	LSQ
-	BLOCK "RLBE"
-	COMMENT " "
 }
 RSBE {
 	"RSBE :=XRSBER+100*dln PC"
-	LSQ
-	BLOCK "RSBE"
-	COMMENT " "
 }
 SBF {
 	"SBF:= SSFFIC+SBF3L"
-	LSQ
-	BLOCK "SBF"
 }
 SBF3L {
 	"SBF3L := sbf3l_0+sbf3l_1*SSF3L"
 	LSQ
-	BLOCK "SBF3L"
-	COMMENT " "
 	SAMPLE 1980Y1 1996Y1
 	DATE 19980620
 	STDEV 17.720501
@@ -1205,209 +814,122 @@ SBF3L {
 }
 SBG {
 	"SBG :=SBGX*ZJ+WLCP"
-	LSQ
-	BLOCK "SBG"
-	COMMENT " "
 }
 SBGX {
 	"grt SBGX := SBGXR"
-	LSQ
-	BLOCK "SBGX"
 }
 SBH {
 	"SBH:=SBG+SBF"
-	LSQ
-	BLOCK "SBH"
 }
 SF {
 	"SF:=GOSF+YSSF+OCUF-(DTF+SBF+IDF+VAMARE)"
-		BLOCK "SF"
 }
 SG {
 	"SG:=GOSG+IT+YDTG+YSSG+COTRES+OCUG-CGU-IDG-SUB+SUBCEE-SBG"
-	LSQ
-	BLOCK "SG"
 }
 SH {
 	"SH := YDH+VAMARE-VC"
-	LSQ
-	BLOCK "SH"
 }
 SSF {
 	"SSF:=SSF3+YSFIC+YSSF+COTRES"
-	LSQ
-	BLOCK "SSF"
 }
 SSF3 {
 	"SSF3:=SSF3P+YSEFP"
-	LSQ
-	BLOCK "SSF3"
 }
 SSF3L {
 	"SSF3L/WBF_ := (SSF3L/WBF_)[-1]"
-	LSQ
-	BLOCK "SSF3L"
-	COMMENT " "
 }
 SSF3P {
 	"SSF3P:=SSF3PR*WBF_+SSFDOM"
-	LSQ
-	BLOCK "SSF3P"
 }
 SSFDOM {
 	"SSFDOM:=SSRDOM*WDOM"
-		BLOCK "SSFDOM"
 }
 SSFF {
 	"SSFF:=SSF3P+SSF3L-SSFDOM+SSFFX"
-	LSQ
-	BLOCK "SSFF"
 }
 SSFFIC {
 	"SSFFIC/WBF_ := (SSFFIC/WBF_)[-1]"
-	LSQ
-	BLOCK "SSFFIC"
-	COMMENT " "
 }
 SSFFX {
 	"SSFFX/WBF := (SSFFX/WBF)[-1]"
-	LSQ
-	BLOCK "SSFFX"
-	COMMENT " "
 }
 SSFG {
 	"SSFG:=YSEFP+YSFIC+COTRES"
-	LSQ
-	BLOCK "SSFG"
 }
 SSH {
 	"SSH:=YSEFT1+YSEFT2+SSH3WW+SSH3WA+SSH3ZA+SSH3ZW"
-	LSQ
-	BLOCK "SSH"
 }
 SSH3GP {
 	"r SSH3GP :=r PC"
-	LSQ
-	BLOCK "SSH3GP"
-	COMMENT " "
 }
 SSH3O {
 	"SSH3O:=SSH3RO*WG"
-		BLOCK "SSH3O"
 }
 SSH3P {
 	"r SSH3P:= r YSFIC"
-	LSQ
-	BLOCK "SSH3P"
 }
 SSH3W {
 	"SSH3W:=SSH3RW*(WBF_+WDOM-SSFDOM)"
-	LSQ
-	BLOCK "SSH3W"
 }
 SSH3WA {
 	"r SSH3WA:=r YSSF"
-	LSQ
-	BLOCK "SSH3WA"
 }
 SSH3WW {
 	"SSH3WW:=SSH3P+SSH3O+SSH3W+SSH3GP"
-	LSQ
-	BLOCK "SSH3WW"
 	COMMENT "WERKNEMERSBIJDRAGEN IN HET VERPLICHTE STELSEL:ESER"
 }
 SSH3ZA {
 	"r SSH3ZA:=r YSSF"
-		BLOCK "SSH3ZA"
 }
 SSH3ZW {
 	"grt SSH3ZW:=grt SSHRZW+grt ((VAI_[-3])*
 (PC/PC[-3]))"
-	LSQ
-	BLOCK "SSH3ZW"
 }
 SSHFF {
 	"SSHFF := SSH3WA+SSH3W"
-	LSQ
-	BLOCK "SSHFF"
-	COMMENT " "
 }
 SUB {
 	"r SUB := r (SUBR*VBBP)"
-	LSQ
-	BLOCK "SUB"
-	COMMENT " "
 }
 SUBCEE {
 	"r SUBCEE :=r VBBP[-1]"
-	LSQ
-	BLOCK "SUBCEE"
-	COMMENT " "
 }
 TFPFHP_ {
 	"grt TFPFHP_ := XTFP"
-	LSQ
-	BLOCK "TFPFHP_"
-	COMMENT " "
 }
 TWG {
 	"grt TWG := TWGR"
-	LSQ
-	BLOCK "TWG"
-	COMMENT " "
 }
 TWGP {
 	"grt TWGP :=TWGR"
-	LSQ
-	BLOCK "TWGP"
-	COMMENT " "
 }
 ULCP {
 	"(ULCP/ULCPO) := (UY-ULAG)-ULIL-ULIO"
-	LSQ
-	BLOCK "ULCP"
 	COMMENT "CHOMEURS COMPLETS INDEMNISES,MOYENNE ANNUELLE"
 }
 UY {
 	"UY := NATY-NDOMY-NIY-NGY-(EFXY-EFMY)-NFY"
-	LSQ
-	BLOCK "UY"
-	COMMENT " "
 }
 VAF {
 	"VAF :=VAFF-VAI"
-	LSQ
-	BLOCK "VAF"
-	COMMENT " "
 }
 VAFF {
 	"VAFF:=VAT-(VAG+VAH)"
-	LSQ
-	BLOCK "VAFF"
 }
 VAFF_ {
 	"VAFF_ :=VAT_-(VAG+VAH)"
-	LSQ
-	BLOCK "VAFF_"
-	COMMENT " "
 }
 VAF_ {
 	"VAF_ := VAFF_-VAI_"
-	LSQ
-	BLOCK "VAF_"
-	COMMENT " "
 }
 VAG {
 	"r VAG := r (WBG+DPUG)"
-		BLOCK "VAG"
-	COMMENT " "
 }
 VAH {
 	"VAH :=vah_1+vah_2*(.5*(VK5*KN5[-1]*PI5)+
 .5*(VK5*KN5[-1]*PI5)[-1])+vah_3*VAH[-1]"
 	LSQ
-	BLOCK "VAH"
-	COMMENT " "
 	SAMPLE 1965Y1 1996Y1
 	DATE 19980612
 	STDEV 200.707
@@ -1423,8 +945,6 @@ VAH {
 VAI {
 	"r VAI:= r VAI_"
 	LSQ
-	BLOCK "VAI"
-	COMMENT " "
 	SAMPLE 1961Y1 1993Y1
 	DATE 19950105
 	STDEV 0.046656549
@@ -1442,8 +962,6 @@ VAI_ {
 vai3_*dln QAFF_+vai4_*(vai1_+ln(WBF_/NFY)+
 vai2_*ln PM-ln(((VAI_/VAIO))/NIY))[-1]"
 	LSQ
-	BLOCK "VAI_"
-	COMMENT " "
 	SAMPLE 1961Y1 1996Y1
 	DATE 19980612
 	STDEV 0.036393154
@@ -1458,110 +976,64 @@ vai2_*ln PM-ln(((VAI_/VAIO))/NIY))[-1]"
 }
 VAMARE {
 	"r VAMARE := r WBF_"
-	LSQ
-	BLOCK "VAMARE"
-	COMMENT " "
 }
 VAT {
 	"VAT :=VBBP-(IT+ITCEE)+SUB"
-	LSQ
-	BLOCK "VAT"
-	COMMENT " "
 }
 VAT_ {
 	"VAT_ :=VBBP_P-(IT+ITCEE)+SUB"
-	LSQ
-	BLOCK "VAT_"
-	COMMENT " "
 }
 VBBP {
 	"VBBP:= VC+CGU+VI+VS+(VX-VM)"
-	LSQ
-	BLOCK "VBBP"
 }
 VBBP_B {
 	"VBBP_B:=VC_+CGU+VI+VS_+(VX-VM)"
-	LSQ
-	BLOCK "VBBP_B"
-	COMMENT " "
 }
 VBBP_P {
 	"VBBP_P := VBNP_P-BVY"
-	LSQ
-	BLOCK "VBBP_P"
-	COMMENT " "
 }
 VBNP {
 	"VBNP:= VBBP+BVY"
-	LSQ
-	BLOCK "VBNP"
 }
 VBNP_B {
 	"VBNP_B :=VBBP_B+BVY"
-	LSQ
-	BLOCK "VBNP_B"
-	COMMENT " "
 }
 VBNP_I {
 	"r VBNP_I :=r VBNP_B"
-	LSQ
-	BLOCK "VBNP_I"
-	COMMENT " "
 }
 VBNP_P {
 	"VBNP_P := (3*VBNP)-(VBNP_B+VBNP_I)"
-	LSQ
-	BLOCK "VBNP_P"
-	COMMENT " "
 }
 VC {
 	"VC:=QC*PC"
-	LSQ
-	BLOCK "VC"
 }
 VC_ {
 	"VC_ :=QC_*PC_"
-	GLS
-	BLOCK "VC_"
-	COMMENT " "
 }
 VI {
 	"VI:=VIF+IUG+VI5"
-	LSQ
-	BLOCK "VI"
 }
 VI5 {
 	"VI5:=QI5*PI5"
-		BLOCK "VI5"
 }
 VIF {
 	"VIF:=QIF*PIF"
-		BLOCK "VIF"
 }
 VM {
 	"VM:=VMAB+VME+VMS+VMT"
-	LSQ
-	BLOCK "VM"
 }
 VMAB {
 	"VMAB :=QMAB*PMAB"
-	LSQ
-	BLOCK "VMAB"
-	COMMENT " "
 }
 VME {
 	"VME:=PME*QME"
-		BLOCK "VME"
 }
 VMK {
 	"VMK/PC:=(VMK/PC)[-1]"
-	LSQ
-	BLOCK "VMK"
 }
 VMN {
 	"ln VMN:=vmn_1+vmn_2*ln (EFMY*(WCF/NFY))+vmn_3*ln VMN[-1]"
 	LSQ
-	BLOCK "VMN"
 	SAMPLE 1971Y1 1996Y1
 	DATE 19980620
 	STDEV 0.81608188
@@ -1576,26 +1048,17 @@ VMN {
 }
 VMS {
 	"VMS :=QMS*PMS"
-	LSQ
-	BLOCK "VMS"
-	COMMENT " "
 }
 VMT {
 	"VMT:=QMT*PMT"
-		BLOCK "VMT"
 }
 VS {
 	"d (VS-VSO) := d VS_"
-	LSQ
-	BLOCK "VS"
-	COMMENT " "
 }
 VS_ {
 	"VS_-VS_O :=vs0_+vs1_*grt(VAF_)+vs2_*grt PAF_+
 vs3_*grt(PW3*EX)"
 	LSQ
-	BLOCK "VS_"
-	COMMENT " "
 	SAMPLE 1961Y1 1996Y1
 	DATE 19980620
 	STDEV 15.835134
@@ -1610,35 +1073,23 @@ vs3_*grt(PW3*EX)"
 }
 VX {
 	"VX:=VXAB+VXE+VXS+VXT"
-	LSQ
-	BLOCK "VX"
 }
 VXAB {
 	"VXAB :=QXAB*PXAB"
-	LSQ
-	BLOCK "VXAB"
-	COMMENT " "
 }
 VXB {
 	"VXB := VXAB+VXE"
-	LSQ
-	BLOCK "VXB"
-	COMMENT " "
 }
 VXE {
 	"VXE:=QXE*PXE"
-		BLOCK "VXE"
 }
 VXK {
 	"(VXK/VXKO):=PC*((VXK/VXKO)/PC)[-1]"
-	LSQ
-	BLOCK "VXK"
 }
 VXN {
 	"ln (VXN/VXNO):=vxn_1+vxn_2*ln (EFXY*(WCF/NFY))+vxn_3
 *ln (VXN/VXNO)[-1]"
 	LSQ
-	BLOCK "VXN"
 	SAMPLE 1971Y1 1996Y1
 	DATE 19980620
 	STDEV 0.59703708
@@ -1653,209 +1104,120 @@ VXN {
 }
 VXS {
 	"VXS :=QXS*PXS"
-	LSQ
-	BLOCK "VXS"
-	COMMENT " "
 }
 VXT {
 	"VXT:=QXT*PXT"
-		BLOCK "VXT"
 }
 W {
 	"dln (W/WO) := dln ZJ +gamma1*dln PROD + gamma *ln ((NATY-UY)/NATY)[-1]+gamma2
 +gamma3*(- ln(WCF/(PAF_*WO))[-1]+gamma4*ln (WMIN/ZJ)
 +gamma5*ln PROD[-1])+(XW)+XWC"
 	LSQ
-	BLOCK "W"
-	COMMENT " "
 	SAMPLE 1975Y1 1997Y1
+	DATE 0
 }
 WBF {
 	"grt WBF:=grt WBF_"
-	LSQ
-	BLOCK "WBF"
-	COMMENT " "
 }
 WBF_ {
 	"grt WBF_:=(grt NFYH) +
 
 grt W"
-	LSQ
-	BLOCK "WBF_"
-	COMMENT " "
 }
 WBG {
 	"WBG:=WBGP+YSFIC"
-	LSQ
-	BLOCK "WBG"
 }
 WBGO {
 	"WBGO :=WBG/PWBG"
-	LSQ
-	BLOCK "WBGO"
-	COMMENT " "
 }
 WBGP {
 	"WBGP :=WBGR*TWG*NGY*ZJ"
-	LSQ
-	BLOCK "WBGP"
-	COMMENT " "
 }
 WBU {
 	"WBU :=WCF+SSFFIC+WBG+WDOM"
-	LSQ
-	BLOCK "WBU"
 }
 WBU_ {
 	"WBU_ :=WCF_+SSFFIC+WBG+WDOM"
-	LSQ
-	BLOCK "WBU_"
-	COMMENT " "
 }
 WCF {
 	"WCF := WBF+SSFF-SSFFIC"
-	LSQ
-	BLOCK "WCF"
-	COMMENT " "
 }
 WCF_ {
 	"WCF_ :=WBF_+SSFF"
-	LSQ
-	BLOCK "WCF_"
-	COMMENT " "
 }
 WCRH {
 	"WCRH := WCF/NFYH"
-	LSQ
-	BLOCK "WCRH"
-	COMMENT " "
 }
 WDOM {
 	"r WDOM:=r (PC*NDOMY)"
 	LSQ
-	BLOCK "WDOM"
 	SAMPLE 1954Y1 1993Y1
+	DATE 0
 }
 WG {
 	"WG:=WBG-SSFG"
-		BLOCK "WG"
 }
 WIND {
 	"r WIND:=r ((WBF/NFY)*NIY)"
-	LSQ
-	BLOCK "WIND"
 }
 WIND_ {
 	"r WIND_ :=r WIND"
-	LSQ
-	BLOCK "WIND_"
-	COMMENT " "
 }
 WLCP {
 	"r WLCP:=r ZJ * r ULCP"
-	LSQ
-	BLOCK "WLCP;BRUGP"
 	COMMENT "WERKLOOSHEIDSUITKERINGEN U.V.W.,ESER DEFINITIE"
 }
 WMIN {
 	"grt WMIN := grt ZJ+1"
-	LSQ
-	BLOCK "WMIN"
-	COMMENT " "
 }
 WNF {
 	"WNF :=WBF-SSHFF"
-	LSQ
-	BLOCK "WNF"
-	COMMENT " "
 }
 WNF_ {
 	"WNF_ :=WBF_-SSHFF"
-	LSQ
-	BLOCK "WNF_"
-	COMMENT " "
 }
 YDH {
 	"r YDH := r YDH_"
-	LSQ
-	BLOCK "YDH"
-	COMMENT " "
 }
 YDH_ {
 	"grt YDH_ :=grt((WBU_+YN+GOSH_+IDH)-(SSF+SSH+DTH)+(SBH+OCUH))"
-	LSQ
-	BLOCK "YDH_"
-	COMMENT " "
 }
 YDTG {
 	"YDTG:=DTF+DTH"
-	LSQ
-	BLOCK "YDTG"
 }
 YIDG {
 	"YIDG :=RDEBT*DEBT[-1]"
-	LSQ
-	BLOCK "YIDG"
-	COMMENT " "
 }
 YK {
 	"YK:=VXK-VMK"
-		BLOCK "YK"
 }
 YN {
 	"YN:=VXN-VMN"
-		BLOCK "YN"
 }
 YSEFP {
 	"YSEFP := YSEFPR*WBGP"
-	LSQ
-	BLOCK "YSEFP"
-	COMMENT " "
 }
 YSEFT1 {
 	"r YSEFT1 :=r WBGP"
-	LSQ
-	BLOCK "YSEFT1"
-	COMMENT " "
 }
 YSEFT2 {
 	"r YSEFT2 := r WBGP"
-	LSQ
-	BLOCK "YSEFT2"
-	COMMENT " "
 }
 YSFIC {
 	"YSFIC :=YSFICR*TWGP*ZJ"
-	LSQ
-	BLOCK "YSFIC"
-	COMMENT " "
 }
 YSSF {
 	"dln YSSF:=dln WBF_"
-	LSQ
-	BLOCK "YSSF"
 }
 YSSG {
 	"YSSG := SSF+SSH-(YSSF+COTRES)"
-	LSQ
-	BLOCK "YSSG"
-	COMMENT " "
 }
 ZF {
 	"grt ZF :=grt PC+ZX-0.05*grt PME"
-	LSQ
-	BLOCK "ZF"
-	COMMENT " "
 }
 ZJ {
 	"grt ZJ :=grt PC +ZX-0.05*grt PME"
-	LSQ
-	BLOCK "ZJ"
-	COMMENT " "
 }
 ZZF_ {
 	"ZZF_ := ZZF_[-1]"
-	LSQ
-	BLOCK "ZZF_"
-	COMMENT " "
 }

--- a/tests/data/rep_fns.ref.a2m
+++ b/tests/data/rep_fns.ref.a2m
@@ -389,7 +389,7 @@ acaf4*(TIME=1995)"
 
 @ChronoGet()   
 ------------
-        @chronoget()              =>  "0"
+        @chronoget()              =>  "...variable..."
 
 
 

--- a/tests/data/rep_fns.rep
+++ b/tests/data/rep_fns.rep
@@ -421,7 +421,7 @@ $ModelSimulate 2000Y1 2001Y1
 
 `@ChronoGet()   `
 `------------`
-        `@chronoget()`              =>  "@chronoget()"
+        `@chronoget()`              =>  "...variable..."
 
 
 

--- a/tests/test_c_api/test1.c
+++ b/tests/test_c_api/test1.c
@@ -675,6 +675,7 @@ void Tests_OBJECTS()
     KV_sample(KV_WS, NULL);
     PER_smpltoa(KSMPL(KV_WS), asmpl2);
     S4ASSERT(U_cmp_strs(asmpl1, asmpl2), "KV_sample(kdb, NULL) does not modify the current sample");
+    
 }    
 
 
@@ -770,7 +771,7 @@ void Tests_TBL_ADD_GET()
           case KT_TITLE:
             cell_cont_0 = (char*) SCR_stracpy((unsigned char*)T_cell_cont(cells_0, 0));
             cell_cont_1 = (char*) SCR_stracpy((unsigned char*)T_cell_cont(cells_1, 0));
-            S4ASSERT(U_cmp_strs(cell_cont_0, cell_cont_1), "line %d, KT_TITLE: cell contents == '%s'", i, cell_cont_1);
+            S4ASSERT(U_cmp_strs(cell_cont_0, cell_cont_1) == 1, "line %d, KT_TITLE: cell contents == '%s'", i, cell_cont_1);
             SCR_free(cell_cont_0);
             SCR_free(cell_cont_1);
             break;
@@ -781,7 +782,7 @@ void Tests_TBL_ADD_GET()
                 S4ASSERT(cells_0[j].tc_attr == cells_1[j].tc_attr, "line %d, col %d: tc_attr == %d", i, j, cells_1[j].tc_attr);
                 cell_cont_0 = (char*)SCR_stracpy((unsigned char*)T_cell_cont(cells_0, j));
                 cell_cont_1 = (char*)SCR_stracpy((unsigned char*)T_cell_cont(cells_1, j));
-                S4ASSERT(U_cmp_strs(cell_cont_0, cell_cont_1), "line %d, col %d: cell contents == '%s'", i, j, cell_cont_1);
+                S4ASSERT(U_cmp_strs(cell_cont_0, cell_cont_1) == 1, "line %d, col %d: cell contents == '%s'", i, j, cell_cont_1);
                 SCR_free(cell_cont_0);
                 SCR_free(cell_cont_1);
             }


### PR DESCRIPTION
Identities
----------
- generated trace file improved to indicate the source files for each variable and scalar needed to compute identities.
- when the execution sample is empty, the current WS sample is used (if defined)

Python module
-------------
New functions for the iode.pyd module:
- Simulation: `IodeModelCpuSort()` and `IodeModelCpuSCC()`: new fonctions to report the CPU needed to decompose and reorder a model
- Error Messages: `IodeAddErrorMsg()`, `IodeDisplayErrorMsgs()`, `IodeClearErrorMsgs()`: new fonctions to add, display and reset error messages created by the fns `B_seterrn()` and `B_seterror()`
- Identities: `IodeExecuteIdts()` for the implementation `idt_execute()`

Ascii conversion
----------------
In equation ascii format, when the SAMPLE is empty, no informations about the estimation is dumped.
(no estimation date, no block, no instruments, no estimation method, no statistical results)
        
Estimation
-----------        
Bug fixed when the table cell separator defined in iode.ini was not `&` (some output were empty).

Tests
-----
- New tests for identity execution
- New tests for `KV_sample()`
- Some corrections to allow translation to google tests. 
