### PR TITLE
Import iode-python module from IODE-DOS  6.71

### DIFF
--- a/pyiode/iode_python.pxd
+++ b/pyiode/iode_python.pxd
@@ -27,25 +27,6 @@ cdef extern from "iode.h":
     cdef int    SCR_free(void *ptr)
     cdef int    SCR_free_tbl(char **tbl)
 
-    # MODEL functions
-    cdef int    IodeModelSimulate(char *per_from, char *per_to, char *eqs_list, char *endo_exo_list, double eps, double relax, int maxit, int init_values, int sort_algo, int nb_passes, int debug, double newton_eps, int newton_maxit, int newton_debug)
-    cdef int    IodeModelCalcSCC(int nbtris, char* pre_listname, char* inter_listname, char* post_listname, char *eqs_list)
-    cdef int    IodeModelSimulateSCC(char *per_from, char *per_to, 
-                                     char *pre_eqlist, char *inter_eqlist, char* post_eqlist,
-                                     double eps, double relax, int maxit, 
-                                     int init_values, int debug, 
-                                     double newton_eps, int newton_maxit, int newton_debug)
-    
-    cdef float  IodeModelSimNorm(char* period)
-    cdef int    IodeModelSimNIter(char* period)
-    cdef int    IodeModelSimCpu(char* period)
-    cdef int    IodeModelCpuSort()
-    cdef int    IodeModelCpuSCC()
-
-    # IDENTITY functions
-    cdef int    IodeExecuteIdts(char *smpl, char *idt_list, char *var_files, char *scl_files, int trace)
- 
-
     # TO Check
     cdef int    PyIodePrint(char*name, void* values, int lg)
     cdef int    ODE_assign_super_PYIODE()

--- a/pyiode/iode_python.pxd
+++ b/pyiode/iode_python.pxd
@@ -25,7 +25,7 @@ cdef extern from "iode.h":
 
     # SCR4 functions
     cdef int    SCR_free(void *ptr)
-    cdef int    SCR_free_tbl(char **tbl)
+    cdef int    SCR_free_tbl(unsigned char **tbl)
 
     # TO Check
     cdef int    PyIodePrint(char*name, void* values, int lg)

--- a/pyiode/iode_python.pxd
+++ b/pyiode/iode_python.pxd
@@ -25,6 +25,26 @@ cdef extern from "iode.h":
 
     # SCR4 functions
     cdef int    SCR_free(void *ptr)
+    cdef int    SCR_free_tbl(char **tbl)
+
+    # MODEL functions
+    cdef int    IodeModelSimulate(char *per_from, char *per_to, char *eqs_list, char *endo_exo_list, double eps, double relax, int maxit, int init_values, int sort_algo, int nb_passes, int debug, double newton_eps, int newton_maxit, int newton_debug)
+    cdef int    IodeModelCalcSCC(int nbtris, char* pre_listname, char* inter_listname, char* post_listname, char *eqs_list)
+    cdef int    IodeModelSimulateSCC(char *per_from, char *per_to, 
+                                     char *pre_eqlist, char *inter_eqlist, char* post_eqlist,
+                                     double eps, double relax, int maxit, 
+                                     int init_values, int debug, 
+                                     double newton_eps, int newton_maxit, int newton_debug)
+    
+    cdef float  IodeModelSimNorm(char* period)
+    cdef int    IodeModelSimNIter(char* period)
+    cdef int    IodeModelSimCpu(char* period)
+    cdef int    IodeModelCpuSort()
+    cdef int    IodeModelCpuSCC()
+
+    # IDENTITY functions
+    cdef int    IodeExecuteIdts(char *smpl, char *idt_list, char *var_files, char *scl_files, int trace)
+ 
 
     # TO Check
     cdef int    PyIodePrint(char*name, void* values, int lg)

--- a/pyiode/pyiode_cdef.pyx
+++ b/pyiode/pyiode_cdef.pyx
@@ -64,7 +64,7 @@ cdef pyfloats(double *cvar, int lg):
     return res    
 
 
-cdef iodevar_to_ndarray(char * name, int copy = True):
+cdef iodevar_to_ndarray(char * name, int copy = 1):
     '''
     Create an numpy array from the content of an IODE variable (KV_WS[name]). 
     The ndarray data may be either a newly allocated vector, or may point to the IODE memory.

--- a/pyiode/pyiode_cdef.pyx
+++ b/pyiode/pyiode_cdef.pyx
@@ -64,7 +64,7 @@ cdef pyfloats(double *cvar, int lg):
     return res    
 
 
-cdef iodevar_to_ndarray(char * name, int copy = 1):
+cdef iodevar_to_ndarray(char * name, bint copy = True):
     '''
     Create an numpy array from the content of an IODE variable (KV_WS[name]). 
     The ndarray data may be either a newly allocated vector, or may point to the IODE memory.

--- a/pyiode/pyiode_data.pyx
+++ b/pyiode/pyiode_data.pyx
@@ -129,7 +129,7 @@ def data_update_var(varname: str, values, operation: str = "L", per_from: str = 
     >>> iode.data_update_var("ACAF", [1, 2, 3.1], "L", "1962Y1")
     >>> ACAF = iode.get_var("ACAF")
     >>> ACAF[:7]
-    [nan, nan, nan, 2.0, 3.1000000000000001, nan, nan]
+    [nan, nan, 1.0, 2.0, 3.1000000000000001, nan, nan]
     ''' 
     cmd = varname + " " + operation
     

--- a/pyiode/pyiode_data.pyx
+++ b/pyiode/pyiode_data.pyx
@@ -138,9 +138,7 @@ def data_update_var(varname: str, values, operation: str = "L", per_from: str = 
         per_from = smpl[0]
         
     cmd = cmd + " " + per_from
-    cmd = cmd + " " + repr(values)
-    #for x in values:
-    #    cmd += f" {x}"
+    cmd = cmd + " " + repr(values)[1:-1]
  
     #print(f"Command:{cmd}")
     if B_DataUpdate(cstr(cmd), K_VAR) != 0:

--- a/pyiode/pyiode_estim.pyx
+++ b/pyiode/pyiode_estim.pyx
@@ -16,9 +16,8 @@ def eqs_estimate(eq_list: Union[str, List[str]], afrom: str, ato: str):
     Estimate an equation or a block of equations on the given sample.
     The estimation method and the instruments must be specified in the equation before the estimation.
     '''
-    if isinstance(eq_list, list):
-        eq_list = ','.join(eq_list)
-
+    eq_list = arg_to_str(eq_list, sep = ',')
+    
     if IodeEstimate(cstr(eq_list), cstr(afrom), cstr(ato)):
         raise RuntimeError(f"Estimation of {eq_list} failed")
 

--- a/pyiode/pyiode_estim.pyx
+++ b/pyiode/pyiode_estim.pyx
@@ -16,7 +16,7 @@ def eqs_estimate(eq_list: Union[str, List[str]], afrom: str, ato: str):
     Estimate an equation or a block of equations on the given sample.
     The estimation method and the instruments must be specified in the equation before the estimation.
     '''
-    if type(eq_list) == list:
+    if isinstance(eq_list, list):
         eq_list = ','.join(eq_list)
 
     if IodeEstimate(cstr(eq_list), cstr(afrom), cstr(ato)):

--- a/pyiode/pyiode_exec.pyx
+++ b/pyiode/pyiode_exec.pyx
@@ -6,18 +6,106 @@
 #  IODE identity execution
 #  -----------------------
 # 
-#  TODO
-#  ---- 
-#   idt_execute(idt_list: Union(str, List[str]), sample: Union(str, List[str]), var_files: Union(str, List[str]), scl_files: Union(str, List[str])) | Execute a list of identities on a given sample
+#   idt_execute(sample: Optional[Union[str, List[str]]] = None, idt_list: Optional[Union[str, List[str]]] = None, var_files: Optional[Union[str, List[str]]] = None, scl_files: Optional[Union[str, List[str]]] = None,trace: int = 0) | Execute a list of identities on a given sample
 
-
-def idt_execute(idt_list: Union[str, List[str]], 
-                sample: Union[str, List[str]], 
-                var_files: Union[str, List[str]], 
-                scl_files: Union[str, List[str]]):
-    '''
-    Estimate a (block of) equations
-     
-    '''
-    pass
+def idt_execute(sample: Optional[Union[str, List[str]]] = None, 
+                idt_list: Optional[Union[str, List[str]]] = None, 
+                var_files: Optional[Union[str, List[str]]] = None, 
+                scl_files: Optional[Union[str, List[str]]] = None,
+                trace: bool = False):
+    r'''
+    Execute a list of identities
     
+    Parameters
+    ----------
+    sample: Optional[Union[str, List[str]]] = None
+            range of period on which the identities must be calculated
+            if sample is None or empty, the WS sample is used 
+            
+    idt_list: Optional[Union[str, List[str]]] = None
+            list of identities to execute
+            if empty, all identities are executed
+            
+    var_files: Optional[Union[str, List[str]]] = None
+            list of files the needed variables must be read from. "WS" means current current Variable WS.
+            if empty, only the current KV_WS is used
+            
+    scl_files: Optional[Union[str, List[str]]] = None
+            list of files the needed scalars must be read from. "WS" means current current WS.
+            if empty, only the current workspace is used
+                        
+    trace: int = 0
+            optional trace indicating the source of the variables and scalars. For example:
+            
+            Execution of identities
+            
+            Parameters
+                Execution sample : 1960Y1:2015Y1
+            
+                Variables loaded
+                    From WS : AOUC AOUC_ COTRES DEBT DTF DTH EFMY EFXY EX FLG FLGR GAP2 GAP_ GOSF HF  
+                    
+                Scalars loaded
+                    From ../data/fun : gamma gamma2 gamma3 gamma4 knf3
+            
+    Examples
+    --------
+        # define the "trace" file
+        iode.w_dest("test_iode.htm", iode.W_HTML)
+    
+        # Simple case: no vars in WS, sample given
+        iode.ws_clear_var()
+        iode.ws_sample_set("1960Y1", "2015Y1")
+        iode.ws_load_idt(f"{IODE_DATA_DIR}fun")
+        iode.idt_execute("1961Y1:2000Y1", "AOUC", f"{IODE_DATA_DIR}fun", trace = 1)
+        AOUC = iode.get_var("AOUC")
+        test_eq('iode.idt_execute("1961Y1:2000Y1", "AOUC", f"{IODE_DATA_DIR}fun, trace = 1") -> AOUC[1961Y1]', 0.24783192, AOUC[1])
+    
+        # Load WS + change value before execution to check the result
+        iode.ws_load_var(f"{IODE_DATA_DIR}fun")
+        AOUC = iode.get_var("AOUC")
+        AOUC[1] = 0.1 
+        iode.set_var("AOUC", AOUC) # var changed in IODE WS
+        iode.idt_execute("1961Y1:2015Y1", "AOUC")
+        AOUC = iode.get_var("AOUC")
+        test_eq('2. iode.idt_execute("1961Y1:2015Y1", "AOUC") -> AOUC[1961Y1]', 0.24783192, AOUC[1])
+    
+        # Shortest way using get_var_as_ndarray(..., False) => no iode.set_var() needed
+        iode.ws_load_var(f"{IODE_DATA_DIR}fun")
+        AOUC = iode.get_var_as_ndarray("AOUC", False)
+        AOUC[1] = 0.1
+        iode.idt_execute("1961Y1:2015Y1", "AOUC")
+        test_eq('3. iode.idt_execute("1961Y1:2015Y1", "AOUC") -> AOUC[1961Y1]', 0.24783192, AOUC[1])
+    
+        # Alternative ways to call idt_execute
+        AOUC = iode.get_var_as_ndarray("AOUC", False)
+        AOUC[1] = 0.1
+        iode.idt_execute(["1961Y1", "2015Y1"], ["AOUC", "FLGR"])
+        test_eq('4. iode.idt_execute(["1961Y1", "2015Y1"], ["AOUC", "FLGR"]) -> AOUC[1961Y1]', 0.24783192, AOUC[1])
+    
+        # Call with empty parameters 
+        iode.ws_load_scl(f"{IODE_DATA_DIR}fun")
+        iode.delete_idt("SSFFX") # SSFFX contains non existent variables
+        AOUC = iode.get_var_as_ndarray("AOUC", False)
+        print(f"AOUC[1]={AOUC[1]}")
+        AOUC[1] = 0.1
+        iode.idt_execute() # all idts on full sample using current loaded WS
+        AOUC = iode.get_var_as_ndarray("AOUC", False)
+        test_eq(' 5. iode.idt_execute() -> AOUC[1961Y1]', 0.24677525, AOUC[1])
+    
+        iode.w_close()
+    
+    '''
+
+    
+    # Transforms Lists into strs
+    sample = arg_to_str(sample)
+    idt_list = arg_to_str(idt_list, ";")
+    var_files = arg_to_str(var_files, ";")
+    scl_files = arg_to_str(scl_files, ";")
+
+    clear_error_msgs() # clear messages before executing the function
+    rc = IodeExecuteIdts(cstr(sample), cstr(idt_list), cstr(var_files), cstr(scl_files), trace) 
+    if rc < 0:
+        display_error_msgs() 
+        raise RuntimeError(f"idt_execute() failed.")

--- a/pyiode/pyiode_exec.pyx
+++ b/pyiode/pyiode_exec.pyx
@@ -9,7 +9,7 @@
 #   idt_execute(sample: Optional[Union[str, List[str]]] = None, idt_list: Optional[Union[str, List[str]]] = None, var_files: Optional[Union[str, List[str]]] = None, scl_files: Optional[Union[str, List[str]]] = None,trace: int = 0) | Execute a list of identities on a given sample
 
 cdef extern from "iode.h": 
-    IodeExecuteIdts()
+    cdef int    IodeExecuteIdts(char *smpl, char *idt_list, char *var_files, char *scl_files, int trace)
 
 def idt_execute(sample: Optional[Union[str, List[str]]] = None, 
                 idt_list: Optional[Union[str, List[str]]] = None, 

--- a/pyiode/pyiode_exec.pyx
+++ b/pyiode/pyiode_exec.pyx
@@ -8,6 +8,9 @@
 # 
 #   idt_execute(sample: Optional[Union[str, List[str]]] = None, idt_list: Optional[Union[str, List[str]]] = None, var_files: Optional[Union[str, List[str]]] = None, scl_files: Optional[Union[str, List[str]]] = None,trace: int = 0) | Execute a list of identities on a given sample
 
+cdef extern from "iode.h": 
+    IodeExecuteIdts()
+
 def idt_execute(sample: Optional[Union[str, List[str]]] = None, 
                 idt_list: Optional[Union[str, List[str]]] = None, 
                 var_files: Optional[Union[str, List[str]]] = None, 

--- a/pyiode/pyiode_exec.pyx
+++ b/pyiode/pyiode_exec.pyx
@@ -11,6 +11,7 @@
 cdef extern from "iode.h": 
     cdef int    IodeExecuteIdts(char *smpl, char *idt_list, char *var_files, char *scl_files, int trace)
 
+# TODO: (ALD) rewrite Examples section below
 def idt_execute(sample: Optional[Union[str, List[str]]] = None, 
                 idt_list: Optional[Union[str, List[str]]] = None, 
                 var_files: Optional[Union[str, List[str]]] = None, 
@@ -50,8 +51,8 @@ def idt_execute(sample: Optional[Union[str, List[str]]] = None,
                     
                 Scalars loaded
                     From ../data/fun : gamma gamma2 gamma3 gamma4 knf3
-            
-    Examples
+    
+    Examples 
     --------
         IODE_DATA_DIR = "../data."
         

--- a/pyiode/pyiode_exec.pyx
+++ b/pyiode/pyiode_exec.pyx
@@ -6,7 +6,7 @@
 #  IODE identity execution
 #  -----------------------
 # 
-#   idt_execute(sample: Optional[Union[str, List[str]]] = None, idt_list: Optional[Union[str, List[str]]] = None, var_files: Optional[Union[str, List[str]]] = None, scl_files: Optional[Union[str, List[str]]] = None,trace: int = 0) | Execute a list of identities on a given sample
+#   idt_execute(sample: Optional[Union[str, List[str]]] = None, idt_list: Optional[Union[str, List[str]]] = None, var_files: Optional[Union[str, List[str]]] = None, scl_files: Optional[Union[str, List[str]]] = None, trace: bool = False) | Execute a list of identities on a given sample
 
 cdef extern from "iode.h": 
     cdef int    IodeExecuteIdts(char *smpl, char *idt_list, char *var_files, char *scl_files, int trace)
@@ -37,7 +37,7 @@ def idt_execute(sample: Optional[Union[str, List[str]]] = None,
             list of files the needed scalars must be read from. "WS" means current current WS.
             if empty, only the current workspace is used
                         
-    trace: int = 0
+    trace: bool = False
             optional trace indicating the source of the variables and scalars. For example:
             
             Execution of identities
@@ -53,6 +53,8 @@ def idt_execute(sample: Optional[Union[str, List[str]]] = None,
             
     Examples
     --------
+        IODE_DATA_DIR = "../data."
+        
         # define the "trace" file
         iode.w_dest("test_iode.htm", iode.W_HTML)
     
@@ -60,7 +62,7 @@ def idt_execute(sample: Optional[Union[str, List[str]]] = None,
         iode.ws_clear_var()
         iode.ws_sample_set("1960Y1", "2015Y1")
         iode.ws_load_idt(f"{IODE_DATA_DIR}fun")
-        iode.idt_execute("1961Y1:2000Y1", "AOUC", f"{IODE_DATA_DIR}fun", trace = 1)
+        iode.idt_execute("1961Y1:2000Y1", "AOUC", f"{IODE_DATA_DIR}fun", trace = True)
         AOUC = iode.get_var("AOUC")
         test_eq('iode.idt_execute("1961Y1:2000Y1", "AOUC", f"{IODE_DATA_DIR}fun, trace = 1") -> AOUC[1961Y1]', 0.24783192, AOUC[1])
     
@@ -90,7 +92,7 @@ def idt_execute(sample: Optional[Union[str, List[str]]] = None,
         iode.ws_load_scl(f"{IODE_DATA_DIR}fun")
         iode.delete_idt("SSFFX") # SSFFX contains non existent variables
         AOUC = iode.get_var_as_ndarray("AOUC", False)
-        print(f"AOUC[1]={AOUC[1]}")
+        # AOUC[1] = 0.24783192
         AOUC[1] = 0.1
         iode.idt_execute() # all idts on full sample using current loaded WS
         AOUC = iode.get_var_as_ndarray("AOUC", False)

--- a/pyiode/pyiode_larray.pyx
+++ b/pyiode/pyiode_larray.pyx
@@ -8,9 +8,11 @@
 #   __la_to_ws_pos(la_input, int* la_pos, int* ws_pos, int* la_lg, time_axis_name = 'time')
 #  
 #   larray_to_ws(la_input: Array, time_axis_name: str = 'time', sep: str = "_")   | Copies LArray la_input into IODE KV_WS.    
-#   ws_to_larray(vars_pattern: str = '*', vars_axis_name: str = 'vars', time_axis_name: str = 'time', split_axis_names = '', regex = None, split_sep = None, time_as_floats: bool = False) -> Array | Creates an LArray from the current KV_WS content
-#   ws_load_var_to_larray(filename: str, vars_pattern = '*', vars_axis_name = 'vars', time_axis_name = 'time', split_axis_names = None, regex = None, split_sep = None) -> Array | Load an IODE var file into an Larray object with 2 axes (vars and time)  
+#   ws_to_larray(vars_pattern: str = '*', vars_axis_name: str = 'vars', time_axis_name: str = 'time', split_axis_names = '', regex = None, split_sep = '', time_as_floats: bool = False) -> Array | Creates an LArray from the current KV_WS content
+#   ws_load_var_to_larray(filename: str, vars_pattern = '*', vars_axis_name = 'vars', time_axis_name = 'time', split_axis_names = None, regex = None, split_sep = '') -> Array | Load an IODE var file into an Larray object with 2 axes (vars and time)  
 #   larray_get_sample(la_input, time_axis_name = 'time') -> List[Union[str,float]]             | Return the first and last time axis labels as a list of 2 strings
+
+from typing import Any
 
 try:
     import larray as la
@@ -22,7 +24,6 @@ except ImportError:
     Axis = Any
 
 import numpy as np
-
 
 # private function -> must be imported by the end user
 cdef __la_to_ws_pos(la_input, int* la_pos, int* ws_pos, int* la_lg, time_axis_name = 'time'):
@@ -106,7 +107,7 @@ def ws_to_larray(vars_pattern: str = '*',
                  time_axis_name: str = 'time', 
                  split_axis_names = '', 
                  regex = None, 
-                 split_sep = None, 
+                 split_sep = '', 
                  time_as_floats: bool = False) -> Array:
     '''
     Creates an LArray from the current KV_WS content with time axis labels in the IODE syntax ['2000Q2',...].
@@ -160,9 +161,9 @@ def ws_load_var_to_larray(filename: str,
                             vars_pattern = '*', 
                             vars_axis_name = 'vars', 
                             time_axis_name = 'time', 
-                            split_axis_names = None, 
+                            split_axis_names = '', 
                             regex = None, 
-                            split_sep = None) -> Array:
+                            split_sep = '') -> Array:
     
     '''Load an IODE .var file into an Larray object with 2 axes (vars and time) 
     '''

--- a/pyiode/pyiode_model.pxd
+++ b/pyiode/pyiode_model.pxd
@@ -12,3 +12,11 @@ cdef extern from "iode.h":
     cdef int    IodeModelSimCpu(char* period)
     cdef int    IodeModelCpuSort()
     cdef int    IodeModelCpuSCC()
+    cdef int    KSIM_MAXIT 
+    cdef float  KSIM_EPS   
+    cdef float  KSIM_RELAX 
+    cdef int    KSIM_PASSES
+    cdef int    KSIM_SORT
+    cdef int    KSIM_START 
+    cdef int    KSIM_CPU_SCC
+    cdef int    KSIM_CPU_SORT

--- a/pyiode/pyiode_model.pxd
+++ b/pyiode/pyiode_model.pxd
@@ -1,10 +1,14 @@
 
 cdef extern from "iode.h":
-    cdef int    IodeModelSimulate()
-    cdef int    IodeModelCalcSCC()
-    cdef int    IodeModelSimulateSCC()
-    cdef float  IodeModelSimNorm()
-    cdef int    IodeModelSimNIter()
-    cdef int    IodeModelSimCpu()
+    cdef int    IodeModelSimulate(char *per_from, char *per_to, char *eqs_list, char *endo_exo_list, double eps, double relax, int maxit, int init_values, int sort_algo, int nb_passes, int debug, double newton_eps, int newton_maxit, int newton_debug)
+    cdef int    IodeModelCalcSCC(int nbtris, char* pre_listname, char* inter_listname, char* post_listname, char *eqs_list)
+    cdef int    IodeModelSimulateSCC(char *per_from, char *per_to, 
+                                     char *pre_eqlist, char *inter_eqlist, char* post_eqlist,
+                                     double eps, double relax, int maxit, 
+                                     int init_values, int debug, 
+                                     double newton_eps, int newton_maxit, int newton_debug)
+    cdef float  IodeModelSimNorm(char* period)
+    cdef int    IodeModelSimNIter(char* period)
+    cdef int    IodeModelSimCpu(char* period)
     cdef int    IodeModelCpuSort()
     cdef int    IodeModelCpuSCC()

--- a/pyiode/pyiode_model.pxd
+++ b/pyiode/pyiode_model.pxd
@@ -1,3 +1,10 @@
 
 cdef extern from "iode.h":
-    cdef int    IodeModelSimulate(char *per_from, char *per_to, char *eqs_list, char *endo_exo_list, double eps, double relax, int maxit, int init_values, int sort_algo, int nb_passes, int debug, double newton_eps, int newton_maxit, int newton_debug)
+    cdef int    IodeModelSimulate()
+    cdef int    IodeModelCalcSCC()
+    cdef int    IodeModelSimulateSCC()
+    cdef float  IodeModelSimNorm()
+    cdef int    IodeModelSimNIter()
+    cdef int    IodeModelSimCpu()
+    cdef int    IodeModelCpuSort()
+    cdef int    IodeModelCpuSCC()

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -59,6 +59,7 @@ from pyiode_model cimport (IodeModelSimulate, IodeModelCalcSCC, IodeModelSimulat
                            IodeModelCpuSort, IodeModelCpuSCC, KSIM_MAXIT, KSIM_EPS, KSIM_RELAX, KSIM_PASSES, KSIM_SORT, KSIM_START, 
                            KSIM_CPU_SCC, KSIM_CPU_SORT)
 
+# TODO: (ald) add Parameters, Returns and Examples section
 def model_simulate(sample_from: str, sample_to: str, 
                     eqs_list=None, 
                     endo_exo_list=None,
@@ -134,6 +135,7 @@ def model_calc_scc(nb_passes: int = 1,
         raise RuntimeError(f"Cannot create the model Connex Components")
     
 
+# TODO: (ald) add Parameters, Returns and Examples section
 def model_simulate_scc( sample_from: str, sample_to: str, 
                         pre_listname: str = "_PRE", 
                         inter_listname: str = "_INTER", 
@@ -157,6 +159,7 @@ def model_simulate_scc( sample_from: str, sample_to: str,
         raise RuntimeError(f"model_simulate_scc() failed")
         
 
+# TODO: (ald) add Parameters, Returns and Examples section
 def model_simulate_save_parms(
                     eps: float = 0.0001, 
                     relax: float = 1.0, 
@@ -165,7 +168,7 @@ def model_simulate_save_parms(
                     sort_algo: int = SORT_BOTH, 
                     nb_passes: int = 1):
     ''' 
-        Save in the global variabels KSIM_* the simulation parameters used during the last 
+        Save in the global variables KSIM_* the simulation parameters used during the last 
         call to model_simulate() and model_simulate_scc(). 
         The purpose of this function is to enable later reporting
         via the functions model_simulate_maxit(), model_simulate_eps()...
@@ -178,24 +181,29 @@ def model_simulate_save_parms(
 
     if nb_passes >= 0: KSIM_PASSES = nb_passes  # not used by model_simulate_scc()
     if sort_algo >= 0: KSIM_SORT = sort_algo    # id.
+
     
-   
+# TODO: (ald) add Parameters, Returns and Examples section
 def model_simulate_maxit() -> int:
     ''' Returns the maxit parameter of the last simulation '''
     return KSIM_MAXIT
 
+# TODO: (ald) add Parameters, Returns and Examples section
 def model_simulate_eps() -> float:
     ''' Returns the eps parameter of the last simulation '''
     return KSIM_EPS
 
+# TODO: (ald) add Parameters, Returns and Examples section  
 def model_simulate_relax() -> float:
     ''' Returns the relax parameter of the last simulation '''
     return KSIM_RELAX
 
+# TODO: (ald) add Parameters, Returns and Examples section 
 def model_simulate_nb_passes() -> int:
     ''' Returns the nb_passes parameter of the last simulation '''
     return KSIM_PASSES
 
+# TODO: (ald) add Parameters, Returns and Examples section  
 def model_simulate_sort_algo() -> int:
     ''' 
     Returns the sort_algo parameter of the last simulation: 
@@ -206,7 +214,8 @@ def model_simulate_sort_algo() -> int:
     
     return KSIM_SORT
 
-        
+
+# TODO: (ald) add Parameters, Returns and Examples section       
 def model_simulate_init_values() -> int:
     ''' 
     Returns the init_values parameter of the last simulation:
@@ -220,23 +229,32 @@ def model_simulate_init_values() -> int:
     '''
     return KSIM_START
 
+
+# TODO: (ald) add Parameters, Returns and Examples section 
 def model_simulate_cpu_scc() -> int:
     ''' Returns the elapsed time in ms during the last SCC decomposition '''
     return IodeModelCpuSCC()
 
+
+# TODO: (ald) add Parameters, Returns and Examples section 
 def model_simulate_cpu_sort() -> int:
     ''' Returns the elapsed time in ms during the last sort algorithm '''
     return IodeModelCpuSort()
 
 
+# TODO: (ald) add Parameters, Returns and Examples section  
 def model_simulate_cpu(period: str) -> int:
     ''' Returns the elapsed time in ms during the last simulation of the given period'''
     return IodeModelSimCpu(cstr(period))
 
+
+# TODO: (ald) add Parameters, Returns and Examples section  
 def model_simulate_niter(period: str) -> int:
     ''' Returns the number of iterations needed to reach a solution during the last simulation of the given period'''
     return IodeModelSimNIter(cstr(period))
+    
 
+# TODO: (ald) add Parameters, Returns and Examples section
 def model_simulate_norm(period: str) -> float:
     ''' Returns the convergence threshold reached during the last simulation of the given period'''
     return IodeModelSimNorm(cstr(period))

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -48,7 +48,7 @@
 # model_simulate_niter(period: str) -> int      | Returns the number of iterations needed to reach a solution during the last simulation of the given period
 # model_simulate_norm(period: str) -> float     | Returns the convergence threshold reached during the last simulation of the given period
 
-from pyiode_model cimport IodeModelSimulate, IodeModelCalcSCC(), IodeModelSimulateSCC, IodeModelSimNorm, IodeModelSimNIter, IodeModelSimCpu, IodeModelCpuSort, IodeModelCpuSCC
+from pyiode_model cimport IodeModelSimulate, IodeModelCalcSCC, IodeModelSimulateSCC, IodeModelSimNorm, IodeModelSimNIter, IodeModelSimCpu, IodeModelCpuSort, IodeModelCpuSCC
 
 def model_simulate(sample_from: str, sample_to: str, 
                     eqs_list=None, 

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -122,8 +122,10 @@ def model_calc_scc(nb_passes: int = 1,
     
     Examples
     --------
-    >>> iode.model_calc_scc(nb_passes=1)
-    
+    >>> from iode import model_calc_scc, ws_load_eqs
+    >>> ws_load_eqs("../data/fun.eqs")
+    274
+    >>> model_calc_scc(nb_passes=1)
     '''
     eqs_list = arg_to_str(eqs_list, sep = ',')
     if IodeModelCalcSCC(nb_passes, 

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -55,7 +55,9 @@
 # model_simulate_niter(period: str) -> int      | Returns the number of iterations needed to reach a solution during the last simulation of the given period
 # model_simulate_norm(period: str) -> float     | Returns the convergence threshold reached during the last simulation of the given period
 
-from pyiode_model cimport IodeModelSimulate, IodeModelCalcSCC, IodeModelSimulateSCC, IodeModelSimNorm, IodeModelSimNIter, IodeModelSimCpu, IodeModelCpuSort, IodeModelCpuSCC
+from pyiode_model cimport (IodeModelSimulate, IodeModelCalcSCC, IodeModelSimulateSCC, IodeModelSimNorm, IodeModelSimNIter, IodeModelSimCpu, 
+                           IodeModelCpuSort, IodeModelCpuSCC, KSIM_MAXIT, KSIM_EPS, KSIM_RELAX, KSIM_PASSES, KSIM_SORT, KSIM_START, 
+                           KSIM_CPU_SCC, KSIM_CPU_SORT)
 
 def model_simulate(sample_from: str, sample_to: str, 
                     eqs_list=None, 

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -6,45 +6,246 @@
 # IODE Model functions
 # --------------------
 # 
-#   model_simulate(sample_from: str, sample_to: str, eqs_list=None, endo_exo_list=None,
-#                    eps: float = 0.0001, relax: float = 1.0, maxit: int = 100, 
-#                    init_values: int = KV_INIT_TM1, sort_algo: int = SORT_BOTH, nb_passes: int = 5, 
-#                    debug: int = 0, newton_eps: float = 1e-6, newton_maxit: int = 50, newton_debug: int = 0
-#                  )    |   Simulate a model
-#   model_calc_scc 
-#   model_simulateparms 
-#   model_simulate_scc 
-#   model_exchange 
-#   model_compile 
-#   model_simulate_save_niters 
-#   model_simulate_save_norms
+#   model_simulate(sample_from: str, sample_to: str, 
+#                   eqs_list=None, endo_exo_list=None,
+#                   eps: float = 0.0001, 
+#                   relax: float = 1.0, 
+#                   maxit: int = 100, 
+#                   init_values: int = KV_INIT_TM1, 
+#                   sort_algo: int = SORT_BOTH, 
+#                   nb_passes: int = 5, 
+#                   debug: int = 0, 
+#                   newton_eps: float = 1e-6, 
+#                   newton_maxit: int = 50, 
+#                   newton_debug: int = 0)          
+#  
+#   model_calc_scc(nb_passes: int = 5, 
+#                   pre_listname: str, 
+#                   inter_listname: str, 
+#                   post_listname: str, 
+#                   eqs_list = None)
+#  
+#   model_simulateparms => included int the parameters of model_simulate(), model_simulate_scc() and model_calc_scc()
+#  
+#   model_simulate_scc( sample_from: str, sample_to: str, 
+#                       pre_listname: str = "_PRE", 
+#                       inter_listname: str = "_INTER", 
+#                       post_listname: str = "_POST")
+                   
+#   model_exchange => included in the parameters of model_simulate()
+#   model_compile  => not yet implemented
+#  
+#  
+# model_simulate_maxit() -> int                 | Returns the maxit parameter of the last simulation   
+# model_simulate_eps() -> float                 | Returns the eps parameter of the last simulation
+# model_simulate_relax() -> float               | Returns the relax parameter of the last simulation
+# model_simulate_nb_passes() -> int             | Returns the nb_passes parameter of the last simulation
+# model_simulate_sort_algo() -> int             | Returns the sort_algo parameter of the last simulation
+# model_simulate_init_values() -> int           | Returns the init_values parameter of the last simulation 
+# model_simulate_cpu_scc() -> int               | Returns the elapsed time during the last SCC decomposition 
+# model_simulate_cpu_sort() -> int              | Returns the elapsed time during the last sort algorithm
+# model_simulate_cpu(period: str) -> int        | Returns the elapsed time during the last simulation of the given period
+# model_simulate_niter(period: str) -> int      | Returns the number of iterations needed to reach a solution during the last simulation of the given period
+# model_simulate_norm(period: str) -> float     | Returns the convergence threshold reached during the last simulation of the given period
 
-from pyiode_model cimport IodeModelSimulate
 
 
-def model_simulate(sample_from: str, sample_to: str, eqs_list=None, endo_exo_list=None,
-                    eps: float = 0.0001, relax: float = 1.0, maxit: int = 100, 
-                    init_values: int = KV_INIT_TM1, sort_algo: int = SORT_BOTH, nb_passes: int = 5, 
-                    debug: int = 0, newton_eps: float = 1e-6, newton_maxit: int = 50, newton_debug: int = 0
-                   ):
+def model_simulate(sample_from: str, sample_to: str, 
+                    eqs_list=None, 
+                    endo_exo_list=None,
+                    eps: float = 0.0001, 
+                    relax: float = 1.0, 
+                    maxit: int = 100, 
+                    init_values: int = KV_INIT_TM1, 
+                    sort_algo: int = SORT_BOTH, 
+                    nb_passes: int = 5, 
+                    debug: int = 0, 
+                    newton_eps: float = 1e-6, 
+                    newton_maxit: int = 50, 
+                    newton_debug: int = 0):
     '''
     Simulate the model defined by eqs_list on the period [sample_from, sample_to].     
     '''
-    if type(eqs_list) == list:
+    if isinstance(eqs_list, list):
         eqs_list = ','.join(eqs_list)
     elif eqs_list is None:
         eqs_list = ""
 
-    if type(endo_exo_list) == list:
+    if isinstance(endo_exo_list, list):
         endo_exo_list = ','.join(endo_exo_list)
     elif endo_exo_list is None:
         endo_exo_list = ""
         
+    model_simulate_save_parms(eps, relax, maxit, init_values, sort_algo, nb_passes)
+    
     if IodeModelSimulate(cstr(sample_from), cstr(sample_to), 
                          cstr(eqs_list), cstr(endo_exo_list),
                          eps, relax, maxit, init_values, sort_algo, nb_passes, debug, 
                          newton_eps, newton_maxit, newton_debug):
         raise RuntimeError(f"Simulation failed")
+        
+    
+  
+def model_calc_scc(nb_passes: int = 1, 
+                   pre_listname: str = "_PRE", 
+                   inter_listname: str = "_INTER", 
+                   post_listname: str = "_POST", 
+                   eqs_list = None):
+    '''
+    Decompose a model into its Strong Connex Components: pre-recursive, interdependent
+    and post-recursive list of equations.
+    
+    These 3 components are saved in 3 lists whose names are given as parameters pre_listnames,
+    inter_listname and post_listname. 
+    
+    Optionally, the interdependent list of equations may be reordered by applying an heuristic
+    algorithm which tries to improve the position of the equations in the interdep list
+    to accelerate the Gauss-Seidel algorithm.
+    
+    Parameters
+    ----------
+    nb_passes: int
+        number of iterations of the reordering algo (aka triangulation)
+    pre_listname: str
+        name of the iode list where the prolog block of equations must be stored
+    inter_listname: str 
+        name of the iode list where the interdependent block of equations must be stored
+    post_listname: str 
+        name of the iode list where the epilog block of equations must be stored
+    eqs_list
+        list of equations defining the model or None for all equations in the current WS of equations
+        
+    Returns
+    -------    
+    No return value.  On error, raises an exception .
+    
+    Examples
+    --------
+    >>> iode.model_calc_scc(nb_passes=1)        # doctest: +SKIP
+    
+    '''
+    if isinstance(eqs_list, list):
+        eqs_list = ','.join(eqs_list)
+    elif eqs_list is None:
+        eqs_list = ""
+    
+    if IodeModelCalcSCC(nb_passes, 
+                         cstr(pre_listname), cstr(inter_listname), cstr(post_listname),
+                         cstr(eqs_list)):
+        raise RuntimeError(f"Cannot create the model Connex Components")
+    
+
+def model_simulate_scc( sample_from: str, sample_to: str, 
+                        pre_listname: str = "_PRE", 
+                        inter_listname: str = "_INTER", 
+                        post_listname: str = "_POST",
+                        eps: float = 0.0001, 
+                        relax: float = 1.0, 
+                        maxit: int = 100, 
+                        init_values: int = KV_INIT_TM1, 
+                        debug: int = 0, 
+                        newton_eps: float = 1e-6, 
+                        newton_maxit: int = 50, 
+                        newton_debug: int = 0):
+    '''
+    Simulate a model defined by the 3 Connex Components (stored in 3 lists).
+    '''
+
+    model_simulate_save_parms(eps, relax, maxit, init_values, -1, -1)
+    
+    if IodeModelSimulateSCC(cstr(sample_from), cstr(sample_to), 
+                         cstr(pre_listname), cstr(inter_listname), cstr(post_listname),
+                         eps, relax, maxit, init_values, debug, 
+                         newton_eps, newton_maxit, newton_debug):
+        raise RuntimeError(f"model_simulate_scc() failed")
+        
+
+def model_simulate_save_parms(
+                    eps: float = 0.0001, 
+                    relax: float = 1.0, 
+                    maxit: int = 100, 
+                    init_values: int = KV_INIT_TM1, 
+                    sort_algo: int = SORT_BOTH, 
+                    nb_passes: int = 1):
+    ''' 
+        Save in the global variabels KSIM_* the simulation parameters used during the last 
+        call to model_simulate() and model_simulate_scc(). 
+        The purpose of this function is to enable later reporting
+        via the functions model_simulate_maxit(), model_simulate_eps()...
+    '''
+    global KSIM_MAXIT
+    global KSIM_EPS
+    global KSIM_RELAX
+    global KSIM_PASSES
+    global KSIM_SORT
+    global KSIM_START
+
+    KSIM_MAXIT = maxit
+    KSIM_EPS = eps
+    KSIM_RELAX = relax
+    KSIM_START = init_values
+
+    if nb_passes >= 0: KSIM_PASSES = nb_passes  # not used by model_simulate_scc()
+    if sort_algo >= 0: KSIM_SORT = sort_algo    # id.
+    
    
+def model_simulate_maxit() -> int:
+    ''' Returns the maxit parameter of the last simulation '''
+    return KSIM_MAXIT
+
+def model_simulate_eps() -> float:
+    ''' Returns the eps parameter of the last simulation '''
+    return KSIM_EPS
+
+def model_simulate_relax() -> float:
+    ''' Returns the relax parameter of the last simulation '''
+    return KSIM_RELAX
+
+def model_simulate_nb_passes() -> int:
+    ''' Returns the nb_passes parameter of the last simulation '''
+    return KSIM_PASSES
+
+def model_simulate_sort_algo() -> int:
+    ''' 
+    Returns the sort_algo parameter of the last simulation: 
+        - iode.SORT_CONNEX (0) for SCC decomposition only
+        - iode.SORT_BOTH (1)   for SCC decomposition and triangulation
+        - iode.SORT_NONE (2)   for no reordering nor SCC decomposition
+    '''
     
-    
+    return KSIM_SORT
+
+        
+def model_simulate_init_values() -> int:
+    ''' 
+    Returns the init_values parameter of the last simulation:
+        - iode.KV_INIT_TM1      (0): Y := Y[-1], if Y null or NA 
+        - iode.KV_INIT_TM1_A    (1): Y := Y[-1], always 
+        - iode.KV_INIT_EXTRA    (2): Y := extrapolation, if Y null or NA 
+        - iode.KV_INIT_EXTRA_A  (3): Y := extrapolation, always 
+        - iode.KV_INIT_ASIS     (4): Y unchanged 
+        - iode.KV_INIT_TM1_NA   (5): Y := Y[-1], if Y is NA 
+        - iode.KV_INIT_EXTRA_NA (6): Y := extrapolation, if Y is NA 
+    '''
+    return KSIM_START
+
+def model_simulate_cpu_scc() -> int:
+    ''' Returns the elapsed time in ms during the last SCC decomposition '''
+    return IodeModelCpuSCC()
+
+def model_simulate_cpu_sort() -> int:
+    ''' Returns the elapsed time in ms during the last sort algorithm '''
+    return IodeModelCpuSort()
+
+
+def model_simulate_cpu(period: str) -> int:
+    ''' Returns the elapsed time in ms during the last simulation of the given period'''
+    return IodeModelSimCpu(cstr(period))
+
+def model_simulate_niter(period: str) -> int:
+    ''' Returns the number of iterations needed to reach a solution during the last simulation of the given period'''
+    return IodeModelSimNIter(cstr(period))
+
+def model_simulate_norm(period: str) -> float:
+    ''' Returns the convergence threshold reached during the last simulation of the given period'''
+    return IodeModelSimNorm(cstr(period))

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -48,7 +48,7 @@
 # model_simulate_niter(period: str) -> int      | Returns the number of iterations needed to reach a solution during the last simulation of the given period
 # model_simulate_norm(period: str) -> float     | Returns the convergence threshold reached during the last simulation of the given period
 
-
+from pyiode_model cimport IodeModelSimulate, IodeModelCalcSCC(), IodeModelSimulateSCC, IodeModelSimNorm, IodeModelSimNIter, IodeModelSimCpu, IodeModelCpuSort, IodeModelCpuSCC
 
 def model_simulate(sample_from: str, sample_to: str, 
                     eqs_list=None, 

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -14,24 +14,31 @@
 #                   init_values: int = KV_INIT_TM1, 
 #                   sort_algo: int = SORT_BOTH, 
 #                   nb_passes: int = 5, 
-#                   debug: int = 0, 
+#                   debug: bool = False, 
 #                   newton_eps: float = 1e-6, 
 #                   newton_maxit: int = 50, 
-#                   newton_debug: int = 0)          
+#                   newton_debug: bool = False)
 #  
 #   model_calc_scc(nb_passes: int = 5, 
-#                   pre_listname: str, 
-#                   inter_listname: str, 
-#                   post_listname: str, 
-#                   eqs_list = None)
-#  
-#   model_simulateparms => included int the parameters of model_simulate(), model_simulate_scc() and model_calc_scc()
-#  
+#                   pre_listname: str = "_PRE", 
+#                   inter_listname: str = "_INTER", 
+#                   post_listname: str = "_POST", 
+#                   eqs_list = None):
+#
 #   model_simulate_scc( sample_from: str, sample_to: str, 
-#                       pre_listname: str = "_PRE", 
-#                       inter_listname: str = "_INTER", 
-#                       post_listname: str = "_POST")
-                   
+#                           pre_listname: str = "_PRE", 
+#                           inter_listname: str = "_INTER", 
+#                           post_listname: str = "_POST",
+#                           eps: float = 0.0001, 
+#                           relax: float = 1.0, 
+#                           maxit: int = 100, 
+#                           init_values: int = KV_INIT_TM1, 
+#                           debug: bool = False, 
+#                           newton_eps: float = 1e-6, 
+#                           newton_maxit: int = 50, 
+#                           newton_debug: bool = False)
+#
+#  
 #   model_exchange => included in the parameters of model_simulate()
 #   model_compile  => not yet implemented
 #  
@@ -59,23 +66,15 @@ def model_simulate(sample_from: str, sample_to: str,
                     init_values: int = KV_INIT_TM1, 
                     sort_algo: int = SORT_BOTH, 
                     nb_passes: int = 5, 
-                    debug: int = 0, 
+                    debug: bool = False, 
                     newton_eps: float = 1e-6, 
                     newton_maxit: int = 50, 
-                    newton_debug: int = 0):
+                    newton_debug: bool = False):
     '''
     Simulate the model defined by eqs_list on the period [sample_from, sample_to].     
     '''
-    if isinstance(eqs_list, list):
-        eqs_list = ','.join(eqs_list)
-    elif eqs_list is None:
-        eqs_list = ""
-
-    if isinstance(endo_exo_list, list):
-        endo_exo_list = ','.join(endo_exo_list)
-    elif endo_exo_list is None:
-        endo_exo_list = ""
-        
+    eqs_list = arg_to_str(eqs_list, sep = ',')
+    endo_exo_list = arg_to_str(endo_exo_list, sep = ',')
     model_simulate_save_parms(eps, relax, maxit, init_values, sort_algo, nb_passes)
     
     if IodeModelSimulate(cstr(sample_from), cstr(sample_to), 
@@ -121,14 +120,10 @@ def model_calc_scc(nb_passes: int = 1,
     
     Examples
     --------
-    >>> iode.model_calc_scc(nb_passes=1)        # doctest: +SKIP
+    >>> iode.model_calc_scc(nb_passes=1)
     
     '''
-    if isinstance(eqs_list, list):
-        eqs_list = ','.join(eqs_list)
-    elif eqs_list is None:
-        eqs_list = ""
-    
+    eqs_list = arg_to_str(eqs_list, sep = ',')
     if IodeModelCalcSCC(nb_passes, 
                          cstr(pre_listname), cstr(inter_listname), cstr(post_listname),
                          cstr(eqs_list)):
@@ -143,16 +138,14 @@ def model_simulate_scc( sample_from: str, sample_to: str,
                         relax: float = 1.0, 
                         maxit: int = 100, 
                         init_values: int = KV_INIT_TM1, 
-                        debug: int = 0, 
+                        debug: bool = False, 
                         newton_eps: float = 1e-6, 
                         newton_maxit: int = 50, 
-                        newton_debug: int = 0):
+                        newton_debug: bool = False):
     '''
     Simulate a model defined by the 3 Connex Components (stored in 3 lists).
     '''
-
     model_simulate_save_parms(eps, relax, maxit, init_values, -1, -1)
-    
     if IodeModelSimulateSCC(cstr(sample_from), cstr(sample_to), 
                          cstr(pre_listname), cstr(inter_listname), cstr(post_listname),
                          eps, relax, maxit, init_values, debug, 
@@ -173,12 +166,6 @@ def model_simulate_save_parms(
         The purpose of this function is to enable later reporting
         via the functions model_simulate_maxit(), model_simulate_eps()...
     '''
-    global KSIM_MAXIT
-    global KSIM_EPS
-    global KSIM_RELAX
-    global KSIM_PASSES
-    global KSIM_SORT
-    global KSIM_START
 
     KSIM_MAXIT = maxit
     KSIM_EPS = eps

--- a/pyiode/pyiode_reports.pyx
+++ b/pyiode/pyiode_reports.pyx
@@ -5,11 +5,10 @@
 # 
 #  IODE report functions
 #  ---------------------
-#   report_exec(filename_parms: str)     | Execute a report
-#   reportline_exec(repline: str)        | Execute a report line
+#   report_exec(filename_parms: str)                | Execute a report with optional arguments
+#   reportline_exec(repline: Union[str, List[str]]) | Execute report line(s)
 
 from pyiode_reports cimport B_ReportExec, B_ReportLine
-
 
 # $ExecReport filename_parms
 # TODO: add parameters
@@ -28,4 +27,3 @@ def reportline_exec(repline: Union[str, List[str]]):
     rc = B_ReportLine(cstr(repline))
     if rc != 0:
         raise  RuntimeError(f"Execution of report line '{repline}' has failed. rc = {rc}")
-

--- a/pyiode/pyiode_reports.pyx
+++ b/pyiode/pyiode_reports.pyx
@@ -21,10 +21,11 @@ def report_exec(filename_parms: str):
 
 
 # $ExecReportLine repline
-def reportline_exec(repline: str):
-    '''Execute a report line'''
+def reportline_exec(repline: Union[str, List[str]]):
+    '''Execute report line(s)'''
+    
+    repline = arg_to_str(repline, sep = '\n')
     rc = B_ReportLine(cstr(repline))
     if rc != 0:
         raise  RuntimeError(f"Execution of report line '{repline}' has failed. rc = {rc}")
-
 

--- a/pyiode/pyiode_reports.pyx
+++ b/pyiode/pyiode_reports.pyx
@@ -11,7 +11,7 @@
 from pyiode_reports cimport B_ReportExec, B_ReportLine
 
 # $ExecReport filename_parms
-# TODO: add parameters
+# TODO: (ald) add Parameters, Returns and Examples section 
 def report_exec(filename_parms: str):
     '''Execute a report'''
     rc = B_ReportExec(cstr(filename_parms))
@@ -19,6 +19,7 @@ def report_exec(filename_parms: str):
         raise  RuntimeError(f"Execution of report {'filename_parms'} has failed. rc = {rc}")
 
 
+# TODO: (ald) add Parameters, Returns and Examples section 
 # $ExecReportLine repline
 def reportline_exec(repline: Union[str, List[str]]):
     '''Execute report line(s)'''

--- a/pyiode/pyiode_util.pxd
+++ b/pyiode/pyiode_util.pxd
@@ -3,3 +3,6 @@ cdef extern from "iode.h":
     cdef char   *IodeVersion()
     cdef void   IodeSuppressMsgs()
     cdef void   IodeResetMsgs()
+    cdef void   IodeAddErrorMsg(char* msg)
+    cdef void   IodeDisplayErrorMsgs()
+    cdef void   IodeClearErrorMsgs()

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -18,7 +18,7 @@
 # ------------------------------------------------------------------------------------------------------------------
 
 from collections.abc import Iterable
-#from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs,  IodeAddErrorMsg, IodeDisplayErrorMsgs, IodeClearErrorMsgs
+from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs,  IodeAddErrorMsg, IodeDisplayErrorMsgs, IodeClearErrorMsgs
 
 # Miscellaneous functions
 # -----------------------

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -84,7 +84,7 @@ def add_error_msg(msg: str = ''):
     --------
     >>> from iode import add_error_msg, display_error_msgs
     >>> add_error_msg("Missing variables: QIG, PIG")
-    >>> display_error_msgs()
+    >>> display_error_msgs() # doctest: +SKIP
     '''
 
     IodeAddErrorMsg(cstr(msg))
@@ -100,7 +100,8 @@ def display_error_msgs():
     --------
     >>> from iode import add_error_msg, display_error_msgs
     >>> add_error_msg("Missing variables: QIG, PIG")
-    >>> display_error_msgs()   '''
+    >>> display_error_msgs()     # doctest: +SKIP
+    '''
 
     IodeDisplayErrorMsgs()
  
@@ -116,6 +117,7 @@ def clear_error_msgs():
     >>> # reset the stack of messages
     >>> clear_error_msgs() 
     >>> add_error_msg("Missing variables: QIG, PIG")
-    >>> display_error_msgs()    '''
+    >>> display_error_msgs()    # doctest: +SKIP
+    '''
 
     IodeClearErrorMsgs()

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -5,16 +5,19 @@
 # 
 #  Utilities
 #  =========
-#       version() -> str      | Return the Iode version.    
-#       cstr(pystr) -> bytes  | Convert a python string (UTF8) to a C null terminated string (ANSI cp850).
-#       pystr(cstr) -> str    | Convert a C null terminated string (ANSI cp850) into a python string (UTF8).
-#  
-#       suppress_msgs()       | Suppress the output during an IODE session.'''
-#       reset_msgs()          | Reset the normal output mechanism during an IODE session.'''
+#       version() -> str                        | Return the Iode version.    
+#       cstr(pystr) -> bytes                    | Convert a python string (UTF8) to a C null terminated string (ANSI cp850).
+#       pystr(cstr) -> str                      | Convert a C null terminated string (ANSI cp850) into a python string (UTF8).
+#       arg_to_str(arg, sep: str = ' ') -> str  | Convert None, a list of str or an str to a str
+#       suppress_msgs()                         | Suppress the output during an IODE session.'''
+#       reset_msgs()                            | Reset the normal output mechanism during an IODE session.'''
+#       
+#       add_error_msg(msg: str = '')            | Add an error message to the stack of error messages.
+#       display_error_msgs()                    | Display all messages accumulated on to the stack of error messages.
+#       clear_error_msgs()                      | Empty the stack of error messages
 # ------------------------------------------------------------------------------------------------------------------
 
 from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs
-
 
 # Miscellaneous functions
 # -----------------------
@@ -34,6 +37,24 @@ def pystr(cstr) -> str:
     if cstr is None: return None
     return cstr.decode("cp850")
 
+# Convert None, a list or str or an str to a str
+def arg_to_str(arg, sep: str = ' ') -> str:
+    '''Convert a string, a list of strings or None to a string.'''
+    if isinstance(arg, list):
+        return sep.join(arg)
+    elif isinstance(arg, str):
+        return arg
+#    elif callable(arg):
+#        res = arg()
+#        if callable(res): 
+#            raise RuntimeError(f"arg_to_str(): Bad argument type: {type(arg)}")
+#        else:
+#            return arg_to_str(res, sep)
+    elif arg is None:
+        return ""
+    else:
+        raise RuntimeError(f"arg_to_str(): Bad argument type: {type(arg)}")
+    
 
 
 # Messages
@@ -46,6 +67,52 @@ def suppress_msgs():
 def reset_msgs():
     '''Reset the normal output mechanism during an IODE session.'''
     IodeResetMsgs()
-    
+
+
+def add_error_msg(msg: str = ''):
+
+    r'''
+    Add an error message to the stack of error messages.
+   
+    Parameters
+    ----------
+    msg: str
+        string containing the text of the error
+        
+    Examples
+    --------
+    >>> iode.add_error_msg("Missing variables: QIG, PIG")
+    >>> iode.display_error_msgs()
+    '''
+
+    IodeAddErrorMsg(cstr(msg))
  
  
+def display_error_msgs():
+
+    r'''
+    Display all messages accumulated on to the stack of error messages.
+    Calls clear_error_msgs().
+        
+    Examples
+    --------
+    >>> iode.add_error_msg("Missing variables: QIG, PIG")
+    >>> iode.display_error_msgs()
+    '''
+
+    IodeDisplayErrorMsgs()
+ 
+def clear_error_msgs():
+
+    r'''
+    Empty the stack of error messages.
+    clear_error_msgs() is called by display_error_msgs()
+   
+    Examples
+    --------
+    >>> iode.clear_error_msgs() # reset the stack of messages
+    >>> iode.add_error_msg("Missing variables: QIG, PIG")
+    >>> iode.display_error_msgs()
+    '''
+
+    IodeClearErrorMsgs()

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -17,7 +17,8 @@
 #       clear_error_msgs()                      | Empty the stack of error messages
 # ------------------------------------------------------------------------------------------------------------------
 
-from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs
+from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs,  IodeAddErrorMsg, IodeDisplayErrorMsgs, IodeClearErrorMsgs
+
 
 # Miscellaneous functions
 # -----------------------

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -17,8 +17,8 @@
 #       clear_error_msgs()                      | Empty the stack of error messages
 # ------------------------------------------------------------------------------------------------------------------
 
+from collections.abc import Iterable
 from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs,  IodeAddErrorMsg, IodeDisplayErrorMsgs, IodeClearErrorMsgs
-
 
 # Miscellaneous functions
 # -----------------------
@@ -38,13 +38,13 @@ def pystr(cstr) -> str:
     if cstr is None: return None
     return cstr.decode("cp850")
 
-# Convert None, a list or str or an str to a str
+# Convert None, a string or an Iterable to a string
 def arg_to_str(arg, sep: str = ' ') -> str:
     '''Convert a string, a list of strings or None to a string.'''
-    if isinstance(arg, list):
-        return sep.join(arg)
-    elif isinstance(arg, str):
+    if isinstance(arg, str):
         return arg
+    if isinstance(arg, Iterable):
+        return sep.join(arg)
 #    elif callable(arg):
 #        res = arg()
 #        if callable(res): 
@@ -54,7 +54,7 @@ def arg_to_str(arg, sep: str = ' ') -> str:
     elif arg is None:
         return ""
     else:
-        raise RuntimeError(f"arg_to_str(): Bad argument type: {type(arg)}")
+        raise RuntimeError(f"arg_to_str(): Bad argument type: {type(arg).__name__}")
     
 
 

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -18,7 +18,7 @@
 # ------------------------------------------------------------------------------------------------------------------
 
 from collections.abc import Iterable
-from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs,  IodeAddErrorMsg, IodeDisplayErrorMsgs, IodeClearErrorMsgs
+#from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs,  IodeAddErrorMsg, IodeDisplayErrorMsgs, IodeClearErrorMsgs
 
 # Miscellaneous functions
 # -----------------------
@@ -82,8 +82,9 @@ def add_error_msg(msg: str = ''):
         
     Examples
     --------
-    >>> iode.add_error_msg("Missing variables: QIG, PIG")
-    >>> iode.display_error_msgs()
+    >>> from iode import add_error_msg, display_error_msgs
+    >>> add_error_msg("Missing variables: QIG, PIG")
+    >>> display_error_msgs()
     '''
 
     IodeAddErrorMsg(cstr(msg))
@@ -97,9 +98,9 @@ def display_error_msgs():
         
     Examples
     --------
-    >>> iode.add_error_msg("Missing variables: QIG, PIG")
-    >>> iode.display_error_msgs()
-    '''
+    >>> from iode import add_error_msg, display_error_msgs
+    >>> add_error_msg("Missing variables: QIG, PIG")
+    >>> display_error_msgs()   '''
 
     IodeDisplayErrorMsgs()
  
@@ -111,9 +112,10 @@ def clear_error_msgs():
    
     Examples
     --------
-    >>> iode.clear_error_msgs() # reset the stack of messages
-    >>> iode.add_error_msg("Missing variables: QIG, PIG")
-    >>> iode.display_error_msgs()
-    '''
+    >>> from iode import clear_error_msgs, add_error_msg, display_error_msgs
+    >>> # reset the stack of messages
+    >>> clear_error_msgs() 
+    >>> add_error_msg("Missing variables: QIG, PIG")
+    >>> display_error_msgs()    '''
 
     IodeClearErrorMsgs()

--- a/pyiode/pyiode_ws.pyx
+++ b/pyiode/pyiode_ws.pyx
@@ -86,7 +86,7 @@ import warnings
 
 from pyiode_ws cimport (IodeLoad, IodeSave, IodeClearWs, IodeClearAll, IodeContents, 
                         B_WsHtoLLast, B_WsHtoLMean, B_WsHtoLSum, B_WsLtoHStock, B_WsLtoHFlow)
-from iode_python cimport free_tbl
+from iode_python cimport free_tbl, SCR_free_tbl
 
 
 def __ws_content_from_str(pattern: str = '*', objtype: int = 6) -> List[str]:

--- a/pyiode/pyiode_ws.pyx
+++ b/pyiode/pyiode_ws.pyx
@@ -87,10 +87,10 @@ import warnings
 
 from pyiode_ws cimport (IodeLoad, IodeSave, IodeClearWs, IodeClearAll, IodeContents, 
                         B_WsHtoLLast, B_WsHtoLMean, B_WsHtoLSum, B_WsLtoHStock, B_WsLtoHFlow)
-from iode_python cimport free_tbl, SCR_free_tbl
+from iode_python cimport free_tbl
 
 
-def __ws_content_from_str(pattern: str = '*', objtype: int = 6) -> List[str]:
+def _ws_content_from_str(pattern: str = '*', objtype: int = 6) -> List[str]:
     r"""Return the names of objects of a given type, satisfying a pattern specification.
 
     Parameters
@@ -135,7 +135,7 @@ def __ws_content_from_str(pattern: str = '*', objtype: int = 6) -> List[str]:
             res[nb] = pystr(s)
             nb = nb + 1
 
-    SCR_free_tbl(<unsigned char **>cnt)
+    free_tbl(cnt)
 
     return res
 
@@ -174,12 +174,12 @@ def ws_content(pattern: Union[str, List[str]] = '*', objtype: int = K_VAR) -> Li
     """
 
     if isinstance(pattern, str):
-        return(__ws_content_from_str(pattern, objtype))
+        return(_ws_content_from_str(pattern, objtype))
 
     elif isinstance(pattern, Iterable):
         res = set()
         for pattern1 in pattern:
-            res = res| set(__ws_content_from_str(pattern1, objtype))
+            res = res| set(_ws_content_from_str(pattern1, objtype))
         res = list(res)
         res.sort()
         return res

--- a/pyiode/pyiode_ws.pyx
+++ b/pyiode/pyiode_ws.pyx
@@ -161,8 +161,7 @@ def ws_content(pattern: Union[str, List[str]] = '*', objtype: int = K_VAR) -> Li
     Examples
     -------
     >>> import iode
-    >>> iode.ws_load_cmt("../fun.cmt")               
-    317
+    >>> iode.Comments.load("../data/fun.cmt")
     >>> result = iode.ws_content("ACA*", 0)          
     >>> print(result)                                
     ['ACAF', 'ACAG']


### PR DESCRIPTION
IODE python module
==================

Identities
----------- 
New function `idt_execute()` to execute a list of identities: 
```
idt_execute(sample: Optional[Union[str, List[str]]] = None, 
                idt_list: Optional[Union[str, List[str]]] = None, 
                var_files: Optional[Union[str, List[str]]] = None, 
                scl_files: Optional[Union[str, List[str]]] = None,
                trace: bool = False):
```

Model simulation
----------------
New functions: 

|Syntax|Description|
|:---|:---|
| `model_calc_scc()` | decompose a model into lists of Strong Connex Components and reorder the interdependent block list
| `model_simulate_scc()`| simulate a model defined by its SCC
| `model_simulate_maxit() -> int             ` | Returns the maxit parameter of the last simulation   
| `model_simulate_eps() -> float             ` | Returns the eps parameter of the last simulation
| `model_simulate_relax() -> float           ` | Returns the relax parameter of the last simulation
| `model_simulate_nb_passes() -> int         ` | Returns the nb_passes parameter of the last simulation
| `model_simulate_sort_algo() -> int         ` | Returns the sort_algo parameter of the last simulation
| `model_simulate_init_values() -> int       ` | Returns the init_values parameter of the last simulation 
| `model_simulate_cpu_scc() -> int           ` | Returns the elapsed time during the last SCC decomposition 
| `model_simulate_cpu_sort() -> int          ` | Returns the elapsed time during the last sort algorithm
| `model_simulate_cpu(period: str) -> int    ` | Returns the elapsed time during the last simulation of the given period
| `model_simulate_niter(period: str) -> int  ` | Returns the number of iterations needed to reach a solution during the last simulation of the given period
| `model_simulate_norm(period: str) -> float ` | Returns the convergence threshold reached during the last simulation of the given period

Utils
-----
New functions:

|Syntax|Description|
|:---|:---|
| `arg_to_str()`        | convert `None`, a `list` of `str` or a `str` to a `str`
| `add_error_msg()`     | mimic `B_seterror()`
| `display_error_msgs()`| mimic `B_display_last_error()`
| `clear_error_msgs()`  | mimic `B_clear_last_error()`

Workspace functions
-------------------
- `ws_content()` and `ws_content_*()`: the `pattern` argument may now be a string or a list of strings
- `ws_ltoh()`, `ws_ltoh_flow()` and `ws_ltoh_stock()`: parameter `method` extended to `Union[int, str]`

Reports
-------
- `reportline_exec()`: the parameter `repline` may be a single string or a list of strings, each containing a report line.

Bugs fixed
----------
- `data_update_var()`: bug fixed (some data was lost or replaced by NaN).