### PR TITLE
PYIODE: hide utility functions to users

### DIFF
--- a/pyiode/iode_python.pyx
+++ b/pyiode/iode_python.pyx
@@ -55,9 +55,9 @@
 #      If needed, use the python utility functions:
 #          - cstr() to translate python strings (utf8) to C char* (ansi code cp850)
 #          - pystr() to do the reverse
-#          - pylist(char** c_list) to convert C char** to python lists 
+#          - _pylist(char** c_list) to convert C char** to python lists 
 #               (don't forget to free c_list afterwards, e.g. by a call to SCR_free_tbl(c_list))
-#          - pyfloats(double *cvar, int lg) to convert a vector of doubles of length lg 
+#          - _pyfloats(double *cvar, int lg) to convert a vector of doubles of length lg 
 #               into a python list of doubles
 #  
 #  3. In a Developer Command Prompt:

--- a/pyiode/iode_python.pyx
+++ b/pyiode/iode_python.pyx
@@ -50,11 +50,11 @@
 #      
 #      Create the Python equivalent to IodeMyFn() in the appropriate module pyiode_*.pyx.
 #          def myfn(arg):
-#              return IodeMyFn(cstr(arg))
+#              return IodeMyFn(_cstr(arg))
 #  
 #      If needed, use the python utility functions:
-#          - cstr() to translate python strings (utf8) to C char* (ansi code cp850)
-#          - pystr() to do the reverse
+#          - _cstr() to translate python strings (utf8) to C char* (ansi code cp850)
+#          - _pystr() to do the reverse
 #          - _pylist(char** c_list) to convert C char** to python lists 
 #               (don't forget to free c_list afterwards, e.g. by a call to SCR_free_tbl(c_list))
 #          - _pyfloats(double *cvar, int lg) to convert a vector of doubles of length lg 

--- a/pyiode/pyiode_cdef.pyx
+++ b/pyiode/pyiode_cdef.pyx
@@ -5,17 +5,17 @@
 #  
 #  Utilities using explicit C data types in arguments 
 #  --------------------------------------------------
-#   pylist(char** c_list)                           Convert a C vector of char* to a python list of python str
-#   pyfloats(double *cvar, int lg)                  Convert a C vector of lg doubles into a list of python floats 
-#   iodevar_to_ndarray(char *name, int copy = True) Create an numpy array from the content of an IODE variable
-#   iodesample_to_ndarray()                         Convert the current WS sample into a numpy 1D array of doubles
+#   _pylist(char** c_list)                           Convert a C vector of char* to a python list of python str
+#   _pyfloats(double *cvar, int lg)                  Convert a C vector of lg doubles into a list of python floats 
+#   _iodevar_to_ndarray(char *name, int copy = True) Create an numpy array from the content of an IODE variable
+#   _iodesample_to_ndarray()                         Convert the current WS sample into a numpy 1D array of doubles
 
 cimport numpy as np
 from pyiode_cdef cimport IodeGetVector
 from pyiode_sample cimport IodeGetSampleAsDoubles
 
 
-cdef pylist(char** c_list):
+cdef _pylist(char** c_list):
     '''
     Convert a C vector of char* to a python list of strings
     
@@ -51,7 +51,7 @@ cdef pylist(char** c_list):
 
 
 
-cdef pyfloats(double *cvar, int lg):
+cdef _pyfloats(double *cvar, int lg):
     '''Convert a C vector of lg doubles into a list of python floats'''
     if cvar == NULL:
         return []
@@ -64,7 +64,7 @@ cdef pyfloats(double *cvar, int lg):
     return res    
 
 
-cdef iodevar_to_ndarray(char * name, int copy = True):
+cdef _iodevar_to_ndarray(char * name, int copy = True):
     '''
     Create an numpy array from the content of an IODE variable (KV_WS[name]). 
     The ndarray data may be either a newly allocated vector, or may point to the IODE memory.
@@ -107,7 +107,7 @@ cdef iodevar_to_ndarray(char * name, int copy = True):
  
 # Obsolete ? 
 # ----------
-cdef iodesample_to_ndarray():
+cdef _iodesample_to_ndarray():
     '''Convert the current WS sample into a numpy 1D array of doubles'''
     
     cdef np.npy_intp shape[1]

--- a/pyiode/pyiode_cdef.pyx
+++ b/pyiode/pyiode_cdef.pyx
@@ -44,7 +44,7 @@ cdef _pylist(char** c_list):
     nb = 0
     while c_list[nb] != NULL:
         s = bytes(c_list[nb])      
-        res[nb] = pystr(s)
+        res[nb] = _pystr(s)
         nb = nb + 1
         
     return res

--- a/pyiode/pyiode_data.pyx
+++ b/pyiode/pyiode_data.pyx
@@ -65,7 +65,7 @@ def data_update(obj_name: str, obj_value: str, obj_type: int):
     '''
      
     cmd = obj_name + " " + obj_value
-    if B_DataUpdate(cstr(cmd), obj_type):
+    if B_DataUpdate(_cstr(cmd), obj_type):
         raise RuntimeError(f"{obj_name} update failed")
 
 def data_update_cmt(obj_name: str, obj_value: str):
@@ -93,7 +93,7 @@ def data_update_scl(obj_name: str, value: float = None, relax: float = None, std
     if stderr is None: cmd += " -- "
     else:              cmd += " " + repr(stderr)
 
-    if B_DataUpdate(cstr(cmd), K_SCL):
+    if B_DataUpdate(_cstr(cmd), K_SCL):
         raise RuntimeError(f"Scalar {obj_name} update failed")
 
 def data_update_var(varname: str, values, operation: str = "L", per_from: str = None):
@@ -143,6 +143,6 @@ def data_update_var(varname: str, values, operation: str = "L", per_from: str = 
     #    cmd += f" {x}"
  
     #print(f"Command:{cmd}")
-    if B_DataUpdate(cstr(cmd), K_VAR) != 0:
+    if B_DataUpdate(_cstr(cmd), K_VAR) != 0:
         raise RuntimeError(f"Variable {varname} update failed")
 

--- a/pyiode/pyiode_estim.pyx
+++ b/pyiode/pyiode_estim.pyx
@@ -19,7 +19,7 @@ def eqs_estimate(eq_list: Union[str, List[str]], afrom: str, ato: str):
     if type(eq_list) == list:
         eq_list = ','.join(eq_list)
 
-    if IodeEstimate(cstr(eq_list), cstr(afrom), cstr(ato)):
+    if IodeEstimate(_cstr(eq_list), _cstr(afrom), _cstr(ato)):
         raise RuntimeError(f"Estimation of {eq_list} failed")
 
 

--- a/pyiode/pyiode_larray.pyx
+++ b/pyiode/pyiode_larray.pyx
@@ -34,7 +34,7 @@ cdef __la_to_ws_pos(la_input, int* la_pos, int* ws_pos, int* la_lg, time_axis_na
         raise RuntimeError(f"Passed Array object must contain an axis named {time_axis_name}.\nGot axes {repr(la_input.axes)}.")
 
     time = la_input.axes[time_axis_name]
-    IodeCalcSamplePosition(cstr(time.labels[0]), cstr(time.labels[-1]), la_pos, ws_pos, la_lg)
+    IodeCalcSamplePosition(_cstr(time.labels[0]), _cstr(time.labels[-1]), la_pos, ws_pos, la_lg)
     #print(f"la_pos: {la_pos} - ws_pos: {ws_pos} - la_lg: {la_lg} ")
 
 
@@ -61,7 +61,7 @@ def larray_to_ws(la_input: Array, time_axis_name: str = 'time', sep: str = "_"):
 
     # Define the KV_WS sample if not yet set
     if not IodeIsSampleSet():
-        IodeSetSampleStr(cstr(time.labels[0]), cstr(time.labels[-1]))
+        IodeSetSampleStr(_cstr(time.labels[0]), _cstr(time.labels[-1]))
     
     # Push the time axis as last axis and combine all other axes 
     la_input = la_input.transpose(..., time_axis_name)
@@ -84,20 +84,20 @@ def larray_to_ws(la_input: Array, time_axis_name: str = 'time', sep: str = "_"):
             for v, la_line_data in zip(vars.labels, la_input.data):
                 # Save the vector of doubles in KV_WS
                 values = < double * > np.PyArray_DATA(la_line_data)
-                IodeSetVector(cstr(v), values, la_pos, ws_pos, la_lg)
+                IodeSetVector(_cstr(v), values, la_pos, ws_pos, la_lg)
         else:
             for v, la_line_data in zip(vars.labels, la_input.data):
                 la_line_data = la_line_data.copy()  # copy if non contiguous
                 # Save the vector of doubles in KV_WS
                 values = < double * > np.PyArray_DATA(la_line_data)
-                IodeSetVector(cstr(v), values, la_pos, ws_pos, la_lg)
+                IodeSetVector(_cstr(v), values, la_pos, ws_pos, la_lg)
     else:
         for v, la_line_data in zip(vars.labels, la_input.data):
             la_line_data = la_line_data.astype("double") # astype creates a copy
 
             # Save the vector of doubles in KV_WS
             values = <double*>np.PyArray_DATA(la_line_data)
-            IodeSetVector(cstr(v), values, la_pos, ws_pos, la_lg)
+            IodeSetVector(_cstr(v), values, la_pos, ws_pos, la_lg)
 
  
 # TODO: review this function logic / parameters 

--- a/pyiode/pyiode_lec.pyx
+++ b/pyiode/pyiode_lec.pyx
@@ -40,6 +40,6 @@ def exec_lec(lec: str, t: int = -1) -> Union[float, List[float]]:
         return IodeExecLecT(cstr(lec), t)   # simple value
     else:
         cvar = IodeExecLec(cstr(lec))       # vector of calculated values    
-        res = pyfloats(cvar, IodeGetSampleLength())
+        res = _pyfloats(cvar, IodeGetSampleLength())
         SCR_free(cvar)
         return res

--- a/pyiode/pyiode_lec.pyx
+++ b/pyiode/pyiode_lec.pyx
@@ -37,9 +37,9 @@ def exec_lec(lec: str, t: int = -1) -> Union[float, List[float]]:
     cdef    double* cvar
     
     if t >= 0:
-        return IodeExecLecT(cstr(lec), t)   # simple value
+        return IodeExecLecT(_cstr(lec), t)   # simple value
     else:
-        cvar = IodeExecLec(cstr(lec))       # vector of calculated values    
+        cvar = IodeExecLec(_cstr(lec))       # vector of calculated values    
         res = _pyfloats(cvar, IodeGetSampleLength())
         SCR_free(cvar)
         return res

--- a/pyiode/pyiode_model.pyx
+++ b/pyiode/pyiode_model.pyx
@@ -40,8 +40,8 @@ def model_simulate(sample_from: str, sample_to: str, eqs_list=None, endo_exo_lis
     elif endo_exo_list is None:
         endo_exo_list = ""
         
-    if IodeModelSimulate(cstr(sample_from), cstr(sample_to), 
-                         cstr(eqs_list), cstr(endo_exo_list),
+    if IodeModelSimulate(_cstr(sample_from), _cstr(sample_to), 
+                         _cstr(eqs_list), _cstr(endo_exo_list),
                          eps, relax, maxit, init_values, sort_algo, nb_passes, debug, 
                          newton_eps, newton_maxit, newton_debug):
         raise RuntimeError(f"Simulation failed")

--- a/pyiode/pyiode_objs.pyx
+++ b/pyiode/pyiode_objs.pyx
@@ -86,13 +86,13 @@ def delete_objects(pattern: str = '*', obj_type: int = K_VAR):
     >>> nbobjs2
     0
     '''
-    if B_DataDelete(cstr(pattern), obj_type):
+    if B_DataDelete(_cstr(pattern), obj_type):
         raise RuntimeError(f"Delete '{pattern}' of type {obj_type} failed")
 
 # delete_<obj_type> functions
 # ---------------------------
 def delete_obj(obj_name: str, obj_type: int):
-    if IodeDeleteObj(cstr(obj_name), obj_type): 
+    if IodeDeleteObj(_cstr(obj_name), obj_type): 
         raise RuntimeError(f"Variable {obj_name} cannot be deleted")
 
 def delete_cmt(name: str):
@@ -142,8 +142,8 @@ def set_cmt(name: str, cmt: str):
 def get_eqs_lec(eq_name: str) -> str:
     '''Return an IODE equation LEC form as a string'''
     
-    lec850 = IodeGetEqsLec(cstr(eq_name))
-    return pystr(lec850)
+    lec850 = IodeGetEqsLec(_cstr(eq_name))
+    return _pystr(lec850)
 
 def get_eqs(eq_name: str) -> Equation:
     '''Return an IODE equation as an iode.Equation class instance'''
@@ -156,45 +156,45 @@ def get_eqs(eq_name: str) -> Equation:
     cdef char   *instr
     cdef float  tests[20]
     
-    rc = IodeGetEqs(cstr(eq_name), &lec, &method, sample_from, sample_to, &blk, &instr, tests)
+    rc = IodeGetEqs(_cstr(eq_name), &lec, &method, sample_from, sample_to, &blk, &instr, tests)
     if rc != 0:
         return None
     
     py_tests = [tests[i] for i in range(10)]
     comment = ""
-    eq_res = Equation(eq_name, pystr(lec), method, pystr(sample_from), pystr(sample_to),  
-                comment, pystr(instr), pystr(blk), py_tests)
+    eq_res = Equation(eq_name, _pystr(lec), method, _pystr(sample_from), _pystr(sample_to),  
+                comment, _pystr(instr), _pystr(blk), py_tests)
 
     return eq_res
 
 
 # TODO: save other (optional) equation properties like tests, sample, method
 def set_eqs(eq_name: str, lec: str):
-    if IodeSetEqs(cstr(eq_name), cstr(lec)):
+    if IodeSetEqs(_cstr(eq_name), _cstr(lec)):
         raise RuntimeError(f"Equation {eq_name} cannot be set")
 
 # Identities
 # ----------
 def get_idt(name: str) -> str:
     '''Return the LEC formula of an IODE identity '''
-    idt850 = IodeGetIdt(cstr(name))
-    return pystr(idt850)
+    idt850 = IodeGetIdt(_cstr(name))
+    return _pystr(idt850)
 
 def set_idt(name: str, idt: str):
     '''Update or create an identity'''
-    if IodeSetIdt(cstr(name), cstr(idt)):
+    if IodeSetIdt(_cstr(name), _cstr(idt)):
         raise RuntimeError(f"Identity {name} cannot be set")
     
 # Lists
 # -----
 def get_lst(name: str) -> str:
     '''Return a list as a string'''
-    lst850 = IodeGetLst(cstr(name))
-    return pystr(lst850)
+    lst850 = IodeGetLst(_cstr(name))
+    return _pystr(lst850)
 
 def set_lst(name: str, lst: str):
     '''Update or create a list fro a string'''
-    if IodeSetLst(cstr(name), cstr(lst)):
+    if IodeSetLst(_cstr(name), _cstr(lst)):
         raise RuntimeError(f"List {name} cannot be set")
 
 
@@ -206,7 +206,7 @@ def get_scl(name: str) -> Scalar:
     cdef    double crelax
     cdef    double cstd
     
-    cdef rc = IodeGetScl(cstr(name), &cval, &crelax, &cstd)
+    cdef rc = IodeGetScl(_cstr(name), &cval, &crelax, &cstd)
     if rc == 0:
         res = Scalar(cval, crelax, cstd)
         return res
@@ -216,7 +216,7 @@ def get_scl(name: str) -> Scalar:
 
 def set_scl(name: str, scalar: Scalar):
     '''Create or update an IODE scalar from an iode.Scalar class instance'''
-    if IodeSetScl(cstr(name), scalar.value, scalar.relax, scalar.std):
+    if IodeSetScl(_cstr(name), scalar.value, scalar.relax, scalar.std):
         raise RuntimeError(f"Scalar {name} cannot be set")
 
     
@@ -243,7 +243,7 @@ def get_var(varname: str) -> List[float]:
 # Copy (or refer to) an IODE var into a ndarray
 def get_var_as_ndarray(varname: str, copy: bool = True) -> np.ndarray:
     '''Get an IODE variable in a numpy ndarray'''
-    vararray = _iodevar_to_ndarray(cstr(varname), copy)
+    vararray = _iodevar_to_ndarray(_cstr(varname), copy)
     return vararray 
 
 # Copy a ndarray or a list into KV_WS
@@ -257,7 +257,6 @@ def set_var(varname: str, py_values):
     ndarray = np.array(py_values, dtype = np.double) 
     
     c_values = <double*>np.PyArray_DATA(ndarray)
-    pos =  IodeSetVector(cstr(varname), c_values, 0, 0, -1)
+    pos =  IodeSetVector(_cstr(varname), c_values, 0, 0, -1)
     if pos < 0:
         raise RuntimeError(f"Variable {varname} cannot be set")
-    

--- a/pyiode/pyiode_objs.pyx
+++ b/pyiode/pyiode_objs.pyx
@@ -243,7 +243,7 @@ def get_var(varname: str) -> List[float]:
 # Copy (or refer to) an IODE var into a ndarray
 def get_var_as_ndarray(varname: str, copy: bool = True) -> np.ndarray:
     '''Get an IODE variable in a numpy ndarray'''
-    vararray = iodevar_to_ndarray(cstr(varname), copy)
+    vararray = _iodevar_to_ndarray(cstr(varname), copy)
     return vararray 
 
 # Copy a ndarray or a list into KV_WS

--- a/pyiode/pyiode_reports.pyx
+++ b/pyiode/pyiode_reports.pyx
@@ -15,7 +15,7 @@ from pyiode_reports cimport B_ReportExec, B_ReportLine
 # TODO: add parameters
 def report_exec(filename_parms: str):
     '''Execute a report'''
-    rc = B_ReportExec(cstr(filename_parms))
+    rc = B_ReportExec(_cstr(filename_parms))
     if rc != 0:
         raise  RuntimeError(f"Execution of report {'filename_parms'} has failed. rc = {rc}")
 
@@ -23,7 +23,7 @@ def report_exec(filename_parms: str):
 # $ExecReportLine repline
 def reportline_exec(repline: str):
     '''Execute a report line'''
-    rc = B_ReportLine(cstr(repline))
+    rc = B_ReportLine(_cstr(repline))
     if rc != 0:
         raise  RuntimeError(f"Execution of report line '{repline}' has failed. rc = {rc}")
 

--- a/pyiode/pyiode_sample.pyx
+++ b/pyiode/pyiode_sample.pyx
@@ -247,11 +247,11 @@ def ws_sample_set(from_period: str, to_period: str) -> Optional[Tuple[str, str]]
         raise RuntimeError(f"ws_sample_set(): sample insufficiently undefined.") 
 
     if from_period == "":
-        rc = IodeSetSampleStr(cstr(cursample[0]), cstr(to_period))
+        rc = IodeSetSampleStr(_cstr(cursample[0]), _cstr(to_period))
     elif to_period == "":
-        rc = IodeSetSampleStr(cstr(from_period), cstr(cursample[1]))
+        rc = IodeSetSampleStr(_cstr(from_period), _cstr(cursample[1]))
     else: 
-        rc = IodeSetSampleStr(cstr(from_period), cstr(to_period))
+        rc = IodeSetSampleStr(_cstr(from_period), _cstr(to_period))
 
     if rc != 0:
         raise RuntimeError(f"ws_sample_set(): cannot set sample '{from_period}' '{to_period}'") 
@@ -281,7 +281,7 @@ def ws_sample_get() -> Optional[Tuple[str, str]]:
         return None
     else:
         c_str = IodeGetSampleAsString()
-        start, end = pystr(c_str).split(" ")
+        start, end = _pystr(c_str).split(" ")
         SCR_free(c_str)
         return start, end
 
@@ -388,7 +388,7 @@ def ws_sample_to_list(from_period: str = "", to_period: str = "", as_floats: boo
             from_period = start
         if not to_period:
             to_period = end
-        smpl = IodeCreateSampleAsPeriods(cstr(from_period), cstr(to_period))
+        smpl = IodeCreateSampleAsPeriods(_cstr(from_period), _cstr(to_period))
         lst = _pylist(smpl)
         free_tbl(smpl)
         return lst 

--- a/pyiode/pyiode_sample.pyx
+++ b/pyiode/pyiode_sample.pyx
@@ -380,7 +380,7 @@ def ws_sample_to_list(from_period: str = "", to_period: str = "", as_floats: boo
         return
 
     if as_floats: 
-        vararray = iodesample_to_ndarray()
+        vararray = _iodesample_to_ndarray()
         return vararray
     else:
         start, end = ws_sample_get()
@@ -389,7 +389,7 @@ def ws_sample_to_list(from_period: str = "", to_period: str = "", as_floats: boo
         if not to_period:
             to_period = end
         smpl = IodeCreateSampleAsPeriods(cstr(from_period), cstr(to_period))
-        lst = pylist(smpl)
+        lst = _pylist(smpl)
         free_tbl(smpl)
         return lst 
         

--- a/pyiode/pyiode_util.pyx
+++ b/pyiode/pyiode_util.pyx
@@ -6,8 +6,8 @@
 #  Utilities
 #  =========
 #       version() -> str      | Return the Iode version.    
-#       cstr(pystr) -> bytes  | Convert a python string (UTF8) to a C null terminated string (ANSI cp850).
-#       pystr(cstr) -> str    | Convert a C null terminated string (ANSI cp850) into a python string (UTF8).
+#       _cstr(pystr) -> bytes  | Convert a python string (UTF8) to a C null terminated string (ANSI cp850).
+#       _pystr(cstr) -> str    | Convert a C null terminated string (ANSI cp850) into a python string (UTF8).
 #  
 #       suppress_msgs()       | Suppress the output during an IODE session.'''
 #       reset_msgs()          | Reset the normal output mechanism during an IODE session.'''
@@ -20,20 +20,18 @@ from pyiode_util cimport IodeVersion, IodeSuppressMsgs, IodeResetMsgs
 # -----------------------
 def version() -> str:
     "Return the Iode version."
-    return pystr(IodeVersion())
+    return _pystr(IodeVersion())
+
 
 # Conversions python-C strings
 # ----------------------------
-def cstr(pystr) -> bytes:
+def _cstr(py_str) -> bytes:
     '''Convert a python string (UTF8) to a C null terminated string (ANSI cp850).'''
-    if pystr is None: return None
-    return pystr.encode("cp850")
+    return py_str.encode("cp850") if py_str is not None else None
 
-def pystr(cstr) -> str:
+def _pystr(c_str) -> str:
     '''Convert a C null terminated string (ANSI cp850) into a python string (UTF8).'''
-    if cstr is None: return None
-    return cstr.decode("cp850")
-
+    return c_str.decode("cp850") if c_str is not None else None
 
 
 # Messages

--- a/pyiode/pyiode_wrt.pyx
+++ b/pyiode/pyiode_wrt.pyx
@@ -24,7 +24,7 @@ from pyiode_wrt cimport (W_dest, W_close, W_flush, W_printf, W_print_enum, W_pri
 
 def w_dest(filename: str = "", dest: int = W_DUMMY):
     '''Initialise a new output session'''
-    W_dest(cstr(filename), dest)
+    W_dest(_cstr(filename), dest)
 
 def w_flush():
     '''Flush the output session buffer.'''
@@ -36,7 +36,7 @@ def w_close():
 
 def w_print(txt: str = ""):
     '''Send a string into the output session buffer.'''
-    return W_printf(cstr("%s"), cstr(txt))
+    return W_printf(_cstr("%s"), _cstr(txt))
     
 def w_print_enum(level: int = 1, text: str = ""):
     '''Print a bulleted paragraph of the given level''' 
@@ -64,11 +64,11 @@ def w_print_tit(level: int = 1, title: str = ""):
 
 def w_print_pg_header(arg: str = ""):
     '''Define the page header as from the current page''' 
-    W_print_pg_header(cstr(arg))
+    W_print_pg_header(_cstr(arg))
     
 def w_print_pg_footer(arg: str = ""):
     '''Define the page footer as from the current page''' 
-    W_print_pg_footer(cstr(arg))
+    W_print_pg_footer(_cstr(arg))
 
     
 

--- a/pyiode/pyiode_ws.pyx
+++ b/pyiode/pyiode_ws.pyx
@@ -115,7 +115,7 @@ def ws_content(pattern: str = '*', objtype: int = 6) -> List[str]:
     >>> names
     ['ACAF', 'ACAG']
     """
-    cdef char **cnt = IodeContents(cstr(pattern), objtype)
+    cdef char **cnt = IodeContents(_cstr(pattern), objtype)
     cdef int nb
 
     res = []
@@ -130,7 +130,7 @@ def ws_content(pattern: str = '*', objtype: int = 6) -> List[str]:
         nb = 0
         while cnt[nb] != NULL:
             s = bytes(cnt[nb])
-            res[nb] = pystr(s)
+            res[nb] = _pystr(s)
             nb = nb + 1
 
     free_tbl(cnt)
@@ -204,7 +204,7 @@ def ws_clear_var():
 def ws_load(filename: str, filetype: int) -> int:
     '''Load an IODE file and return the number of read objects'''
     
-    nb = IodeLoad(cstr(filename), filetype)
+    nb = IodeLoad(_cstr(filename), filetype)
     if nb < 0:
         raise RuntimeError(f"File {filename} of type {filetype} cannot be loaded")
     return nb    
@@ -237,7 +237,7 @@ def ws_load_var(filename: str) -> int:
 # -------
 def ws_save(filename: str, filetype: int):
     '''Save the current IODE workspace of a given type'''
-    if IodeSave(cstr(filename), filetype):
+    if IodeSave(_cstr(filename), filetype):
         raise RuntimeError(f"Workspace of type {filetype} cannot be saved in file {filename}.")
 
 def ws_save_cmt(filename: str):
@@ -279,13 +279,13 @@ def ws_htol(filename: str, varlist, series_type: int):
 
     arg = f"{filename} {varlist}"
     if series_type == HTOL_LAST:
-        if B_WsHtoLLast(cstr(arg)):
+        if B_WsHtoLLast(_cstr(arg)):
             raise RuntimeError(f"ws_htol_last() on file {filename} failed.")
     elif series_type == HTOL_MEAN:
-        if B_WsHtoLMean(cstr(arg)):
+        if B_WsHtoLMean(_cstr(arg)):
             raise RuntimeError(f"ws_htol_mean() on file {filename} failed.")
     else:
-        if B_WsHtoLSum(cstr(arg)):
+        if B_WsHtoLSum(_cstr(arg)):
             raise RuntimeError(f"ws_htol_sum() on file {filename} failed.")
 
 def ws_htol_last(filename: str, varlist):
@@ -307,10 +307,10 @@ def ws_ltoh(filename: str, varlist, series_type, method: Union[int, str]):
 
     arg = f"{method} {filename} {varlist}"
     if series_type == LTOH_FLOW:
-        if B_WsLtoHFlow(cstr(arg)):
+        if B_WsLtoHFlow(_cstr(arg)):
             raise RuntimeError(f"ws_ltoh_flow() on file {filename} failed.")
     else:
-        if B_WsLtoHStock(cstr(arg)):
+        if B_WsLtoHStock(_cstr(arg)):
             raise RuntimeError(f"ws_ltoh_stock() on file {filename} failed.")
 
 def ws_ltoh_flow(filename: str, varlist, method: Union[int, str] = LTOH_CS):


### PR DESCRIPTION
@jmpplan 
Basically I renamed the functions that are not supposed to be exposed to the final users by prepending their names by an underscore.

In Python, objects or functions or classes starting with an underscore are not imported when you do `from iode import *`

See [this link](https://stackoverflow.com/a/8689983)