### PR TITLE
PYIODE: strip newline from lec formatting and update pytests

### DIFF
--- a/pyiode/compute/estimation.pyx
+++ b/pyiode/compute/estimation.pyx
@@ -54,19 +54,19 @@ def dynamic_adjustment(method: Union[AdjustmentMethod, str], eqs: str, c1: str =
     >>> equations.load(f"{SAMPLE_DATA_DIR}/fun.eqs")
     >>> lec = equations["ACAF"].lec           # doctest: +NORMALIZE_WHITESPACE
     >>> lec
-    '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+    '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
     
     Partial Adjustment
 
     >>> partial_adjust_eq = dynamic_adjustment(AdjustmentMethod.PARTIAL, lec)
     >>> partial_adjust_eq
-    'd((ACAF/VAF[-1])) := c1 * (acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995) -((ACAF/VAF[-1]))[-1])'
+    'd((ACAF/VAF[-1])) := c1 * (acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995) -((ACAF/VAF[-1]))[-1])'
 
     Error Correction Model
 
     >>> error_corr_adjust_eq = dynamic_adjustment(AdjustmentMethod.ERROR_CORRECTION, lec)
     >>> error_corr_adjust_eq
-    'd((ACAF/VAF[-1])) := c1 * d(acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)) + c2 * (acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995) -(ACAF/VAF[-1]))[-1]'
+    'd((ACAF/VAF[-1])) := c1 * d(acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)) + c2 * (acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995) -(ACAF/VAF[-1]))[-1]'
     """
     if isinstance(method, str):
         method = method.upper()
@@ -405,7 +405,7 @@ cdef class EditAndEstimateEquations:
         >>> current_eq.endogenous
         'ACAF'
         >>> current_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'             
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'             
         >>> # ---- next equation ---- 
         >>> next_eq = estimation.next_equation
         >>> next_eq.endogenous
@@ -417,7 +417,7 @@ cdef class EditAndEstimateEquations:
         >>> next_eq.endogenous
         'ACAF'
         >>> next_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
 
         >>> # ====== add a non existing equation to the block ======
         >>> # set_block("new_block", "currently_displayed_equation")
@@ -453,7 +453,7 @@ cdef class EditAndEstimateEquations:
         >>> next_eq.endogenous
         'ACAF'
         >>> next_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
 
         >>> # ====== remove an equation from the block ======
         >>> # set_block("new_block", "currently_displayed_equation")
@@ -477,7 +477,7 @@ cdef class EditAndEstimateEquations:
         >>> current_eq.endogenous
         'ACAF'
         >>> current_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
         >>> # ---- next equation ----
         >>> next_eq = estimation.next_equation
         >>> next_eq.endogenous
@@ -772,7 +772,7 @@ cdef class EditAndEstimateEquations:
         >>> current_eq.endogenous
         'ACAF'
         >>> current_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)' 
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)' 
 
         >>> # ---- next equation ---- 
         >>> next_eq = estimation.next_equation
@@ -786,7 +786,7 @@ cdef class EditAndEstimateEquations:
         >>> next_eq.endogenous
         'ACAF'
         >>> next_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
         """
         cdef CEquation* c_current_eq = self.c_estimation_ptr.current_equation()
         eq = Equation._from_ptr(c_current_eq, <bint>True)
@@ -817,7 +817,7 @@ cdef class EditAndEstimateEquations:
         >>> current_eq.endogenous
         'ACAF'
         >>> current_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)' 
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)' 
 
         >>> # ---- next equation ---- 
         >>> next_eq = estimation.next_equation
@@ -831,7 +831,7 @@ cdef class EditAndEstimateEquations:
         >>> next_eq.endogenous
         'ACAF'
         >>> next_eq.lec           # doctest: +NORMALIZE_WHITESPACE
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
         """
         cdef CEquation* c_next_eq = self.c_estimation_ptr.next_equation()
         eq = Equation._from_ptr(c_next_eq, <bint>True)

--- a/pyiode/iode_database/abstract_database.pyx
+++ b/pyiode/iode_database/abstract_database.pyx
@@ -847,7 +847,7 @@ cdef class _AbstractDatabase:
         >>> # a) get one Equation
         >>> equations["ACAF"]                  # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                  method = 'LSQ',
                  from_period = '1980Y1',
                  to_period = '1996Y1',
@@ -1117,7 +1117,7 @@ cdef class _AbstractDatabase:
         >>> # b) update one equation        
         >>> equations["ACAF"]                  # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                  method = 'LSQ',
                  from_period = '1980Y1',
                  to_period = '1996Y1',

--- a/pyiode/iode_database/equations_database.pyx
+++ b/pyiode/iode_database/equations_database.pyx
@@ -49,10 +49,10 @@ cdef class Equations(_AbstractDatabase):
     filename: ...\tests\data\fun.eqs
     <BLANKLINE>
      name                                                    lec                                                method      sample      block    fstat      r2adj     dw     loglik    date
-    ACAF        (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+ acaf4*(TIME=1995)                                           LSQ  1980Y1:1996Y1    ACAF   32.2732     0.7963  2.3293  83.8075 12-06-1998
+    ACAF        (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)                                            LSQ  1980Y1:1996Y1    ACAF   32.2732     0.7963  2.3293  83.8075 12-06-1998
     ACAG        ACAG := ACAG[-1]+r VBBP[-1]+(0.006*VBBP[-1]*(TIME=2001)-0.008*(TIME=2008))                         LSQ              :    ACAG    0.0000     0.0000  0.0000   0.0000
     AOUC        AOUC:=((WCRH/QL)/(WCRH/QL)[1990Y1])*(VAFF/(VM+VAFF))[-1]+PM*(VM/(VAFF+VM))[-1]                     LSQ              :    AOUC    0.0000     0.0000  0.0000   0.0000
-    BENEF       d BENEF :=d(VBNP-(IT+ITCEE)+SUB-DPUU-(WCF+SSFFIC+WDOM+WBG+ YN)-(GOSH-DPUH+IDH)-DTF-RIDGG+YIDG)     LSQ              :   BENEF    0.0000     0.0000  0.0000   0.0000
+    BENEF       d BENEF :=d(VBNP-(IT+ITCEE)+SUB-DPUU-(WCF+SSFFIC+WDOM+WBG+YN)-(GOSH-DPUH+IDH)-DTF-RIDGG+YIDG)      LSQ              :   BENEF    0.0000     0.0000  0.0000   0.0000
     BQY         BQY:=(YK+YN)/PBBP                                                                                  LSQ              :     BQY    0.0000     0.0000  0.0000   0.0000
     ...         ...                                                                                                ...            ...     ...       ...        ...     ...      ...        ...
     YSSF        dln YSSF:=dln WBF_                                                                                 LSQ              :    YSSF    0.0000     0.0000  0.0000   0.0000
@@ -235,7 +235,7 @@ cdef class Equations(_AbstractDatabase):
         >>> variables.load(f"{SAMPLE_DATA_DIR}/fun.var")
 
         >>> equations["ACAF"].lec
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
         >>> equations["DPUH"].lec
         'dln (DPUH/DPUHO):=dpuh_1+dpuh_2*dln(IHU/PI5)+dln PC'
 
@@ -558,7 +558,7 @@ cdef class Equations(_AbstractDatabase):
         ['ACAF', 'ACAG', 'AOUC', ..., 'YSSG', 'ZF', 'ZJ', 'ZZF_']
         >>> equations["ACAF"]               # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                  method = 'LSQ',
                  from_period = '1980Y1',
                  to_period = '1996Y1',
@@ -576,7 +576,7 @@ cdef class Equations(_AbstractDatabase):
                           stdev = 0.0042699},
                  date = '12-06-1998')
         >>> df.loc["ACAF"]                  # doctest: +NORMALIZE_WHITESPACE
-        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*...
+        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(T...
         method                                                       LSQ
         sample                                             1980Y1:1996Y1
         comment
@@ -631,7 +631,7 @@ cdef class Equations(_AbstractDatabase):
         ['ACAF', 'ACAG', 'AOUC', ..., 'WNF_', 'YDH_', 'ZZF_']
         >>> equations["ACAF"]               # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                  method = 'LSQ',
                  from_period = '1980Y1',
                  to_period = '1996Y1',
@@ -649,7 +649,7 @@ cdef class Equations(_AbstractDatabase):
                           stdev = 0.0042699},
                  date = '12-06-1998')
         >>> df.loc["ACAF"]                  # doctest: +NORMALIZE_WHITESPACE
-        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*...
+        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(T...
         method                                                       LSQ
         sample                                             1980Y1:1996Y1
         comment
@@ -732,7 +732,7 @@ cdef class Equations(_AbstractDatabase):
         ['ACAF', 'ACAG', 'AOUC', ..., 'YSSG', 'ZF', 'ZJ', 'ZZF_']
         >>> equations["ACAF"]               # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                  method = 'LSQ',
                  from_period = '1980Y1',
                  to_period = '1996Y1',
@@ -750,7 +750,7 @@ cdef class Equations(_AbstractDatabase):
                           stdev = 0.0042699},
                  date = '12-06-1998')
         >>> df.loc["ACAF"]                  # doctest: +NORMALIZE_WHITESPACE
-        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*...
+        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(T...
         method                                                       LSQ
         sample                                             1980Y1:1996Y1
         comment
@@ -805,7 +805,7 @@ cdef class Equations(_AbstractDatabase):
         ['ACAF', 'ACAG', 'AOUC', ..., 'WNF_', 'YDH_', 'ZZF_']
         >>> equations["ACAF"]               # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                 lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                  method = 'LSQ',
                  from_period = '1980Y1',
                  to_period = '1996Y1',
@@ -823,7 +823,7 @@ cdef class Equations(_AbstractDatabase):
                           stdev = 0.0042699},
                  date = '12-06-1998')
         >>> df.loc["ACAF"]                  # doctest: +NORMALIZE_WHITESPACE
-        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*...
+        lec            (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(T...
         method                                                       LSQ
         sample                                             1980Y1:1996Y1
         comment

--- a/pyiode/lec.pyx
+++ b/pyiode/lec.pyx
@@ -34,7 +34,7 @@ def execute_lec(lec: str, period: Union[str, int, Period]=None) -> Union[float, 
     >>> variables.load(f"{SAMPLE_DATA_DIR}/fun.var")
 
     >>> equations["ACAF"].lec       # doctest: +NORMALIZE_WHITESPACE
-    '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\\nacaf4*(TIME=1995)'
+    '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
     >>> variables["ACAF", "2000Y1"]
     10.046610792200543
     >>> lec = "(acaf1 + acaf2 * GOSF[-1] + acaf4*(TIME=1995)) * VAF[-1]"

--- a/pyiode/objects/equation.pyx
+++ b/pyiode/objects/equation.pyx
@@ -329,7 +329,7 @@ cdef class Equation:
 
         >>> eq_ACAF = equations["ACAF"]
         >>> eq_ACAF.lec
-        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)'
+        '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)'
 
         >>> # create scalars
         >>> scalars["acaf1"] = 0., 1.
@@ -394,11 +394,12 @@ cdef class Equation:
         ... 
         ValueError: Cannot set LEC '(ACAF_ / VAF[-1]) := acaf2 * GOSF[-1] + acaf4 * (TIME=1995)' to the equation named 'ACAF'
         """
-        return self.c_equation.get_lec().decode()
+        return self.c_equation.get_lec().decode().replace('\n', '')
     
     @lec.setter
     def lec(self, value: str):
         value = value.strip()
+        value = value.replace('\n', '')
         self.c_equation.set_lec(value.encode())
 
     @property
@@ -631,7 +632,7 @@ cdef class Equation:
         >>> equations.load(f"{SAMPLE_DATA_DIR}/fun.eqs")
         >>> equations["ACAF"]           # doctest: +NORMALIZE_WHITESPACE
         Equation(endogenous = 'ACAF',
-                lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)',
+                lec = '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)',
                 method = 'LSQ',
                 from_period = '1980Y1',
                 to_period = '1996Y1',
@@ -649,7 +650,7 @@ cdef class Equation:
                          stdev = 0.0042699},
                 date = '12-06-1998')
         >>> equations["ACAF"]._as_tuple()         # doctest: +NORMALIZE_WHITESPACE
-        ('ACAF', '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995)', 'LSQ', '1980Y1:1996Y1', '', '', 'ACAF', 
+        ('ACAF', '(ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995)', 'LSQ', '1980Y1:1996Y1', '', '', 'ACAF', 
         1.0, 2.329345941543579, 32.273193359375, 83.80752563476562, 0.008184665814042091, 0.8217613697052002, 
         0.7962986826896667, 5.1994487876072526e-05, 0.0019271461060270667, 23.545812606811523, 0.004269900266081095, 
         '12-06-1998')

--- a/tests/test_python/test_iode.py
+++ b/tests/test_python/test_iode.py
@@ -29,7 +29,7 @@ def test_print_equation():
     iode.equations.load(f"{iode.SAMPLE_DATA_DIR}/fun.eqs")
     eq_ACAF = iode.equations["ACAF"]
     string_eq_ACAF = ("Equation(endogenous = ACAF,\n"
-                      "         lec = (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+\nacaf4*(TIME=1995),\n"
+                      "         lec = (ACAF/VAF[-1]) :=acaf1+acaf2*GOSF[-1]+acaf4*(TIME=1995),\n"
                       "         method = LSQ,\n"
                       "         sample = 1980Y1:1996Y1,\n"
                       "         block = ACAF,\n"


### PR DESCRIPTION
The '\n' artefact (originating from the GUI display of equations) should not be displayed in the Python interface. Pytests have been updated accordingly.