### PR TITLE
PYTHON: updating the global Tables database when the syntax tables[name].attribute = value is used

### DIFF
--- a/pyiode/iode_database/abstract_database.pyx
+++ b/pyiode/iode_database/abstract_database.pyx
@@ -1487,8 +1487,7 @@ cdef class _AbstractDatabase:
         <BLANKLINE>
 
         >>> # b) -------- update table --------
-        >>> table = tables["TABLE_CELL_LECS"]
-        >>> table                   # doctest: +NORMALIZE_WHITESPACE
+        >>> tables["TABLE_CELL_LECS"]               # doctest: +NORMALIZE_WHITESPACE
         DIVIS | 1              |
         TITLE |         "New Table"
         ----- | ----------------------------
@@ -1517,45 +1516,43 @@ cdef class _AbstractDatabase:
         <BLANKLINE>
 
         >>> # set graph axis type
-        >>> table.graph_axis = TableGraphAxis.SEMILOG
+        >>> tables["TABLE_CELL_LECS"].graph_axis = TableGraphAxis.SEMILOG
         >>> # print first line
-        >>> table[0]
+        >>> tables["TABLE_CELL_LECS"][0]
         New Table
         >>> # print last line
-        >>> table[-1]
+        >>> tables["TABLE_CELL_LECS"][-1]
         <DATE>
         >>> # delete last line
-        >>> del table[-1]
+        >>> del tables["TABLE_CELL_LECS"][-1]
         >>> # get index of line containing YSSG+COTRES
-        >>> index = table.index("YSSG+COTRES")
+        >>> index = tables["TABLE_CELL_LECS"].index("YSSG+COTRES")
         >>> index
         9
-        >>> table[index]
+        >>> tables["TABLE_CELL_LECS"][index]
         ('"YSSG+COTRES:"', 'YSSG+COTRES')
         >>> # get line type
-        >>> table[index].line_type
+        >>> tables["TABLE_CELL_LECS"][index].line_type
         'CELL'
         >>> # get line graph type
-        >>> table[index].graph_type
+        >>> tables["TABLE_CELL_LECS"][index].graph_type
         'LINE'
         >>> # know if axis is left
-        >>> table[index].axis_left
+        >>> tables["TABLE_CELL_LECS"][index].axis_left
         True
         >>> # update cells
         >>> # double quotes "    -> STRING cell
         >>> # no double quotes   -> LEC cell
-        >>> table[index] = ('"YSSG:"', 'YSSG')
-        >>> table[index]
+        >>> tables["TABLE_CELL_LECS"][index] = ('"YSSG:"', 'YSSG')
+        >>> tables["TABLE_CELL_LECS"][index]
         ('"YSSG:"', 'YSSG')
         >>> # insert a new title line surrounded by two separator lines
-        >>> table.insert(index + 1, '-')
-        >>> table.insert(index + 2, "New Title")
-        >>> table.insert(index + 3, '-')
+        >>> tables["TABLE_CELL_LECS"].insert(index + 1, '-')
+        >>> tables["TABLE_CELL_LECS"].insert(index + 2, "New Title")
+        >>> tables["TABLE_CELL_LECS"].insert(index + 3, '-')
         >>> # append a new sepatator line
-        >>> table += '-'
+        >>> tables["TABLE_CELL_LECS"] += '-'
 
-        >>> # warning: do not forget to actually update the IODE Table database  
-        >>> tables["TABLE_CELL_LECS"] = table
         >>> tables["TABLE_CELL_LECS"]                # doctest: +NORMALIZE_WHITESPACE
         DIVIS | 1       |
         TITLE |  "New Table"

--- a/pyiode/iode_database/abstract_database.pyx
+++ b/pyiode/iode_database/abstract_database.pyx
@@ -1373,13 +1373,11 @@ cdef class _AbstractDatabase:
         >>> scalars["acaf3"]
         Scalar(0.8, 0.9, 0.87301)
         >>> # update value and/or relax (Scalar object)
-        >>> acaf4 = scalars["acaf4"]
-        >>> acaf4
+        >>> # NOTE: the standard deviation (std) cannot be changed manually
+        >>> scalars["acaf4"]
         Scalar(-0.00850518, 1, 0.0020833)
-        >>> acaf4.value = 0.8
-        >>> acaf4.relax = 0.9
-        >>> # WARNING: the standard deviation (std) cannot be changed manually
-        >>> scalars["acaf4"] = acaf4
+        >>> scalars["acaf4"].value = 0.8
+        >>> scalars["acaf4"].relax = 0.9
         >>> scalars["acaf4"]
         Scalar(0.8, 0.9, 0.0020833)
 

--- a/pyiode/iode_database/tables_database.pyx
+++ b/pyiode/iode_database/tables_database.pyx
@@ -108,7 +108,7 @@ cdef class Tables(_AbstractDatabase):
     def _get_object(self, key: str):
         key = key.strip()
         cdef CTable* c_table = self.database_ptr.get(key.encode())
-        py_table = Table._from_ptr(c_table, <bint>True) 
+        py_table = Table._from_ptr(c_table, <bint>True, key.encode(), self.database_ptr) 
         return py_table
 
     def _set_object(self, key, value):

--- a/pyiode/objects/table.pxd
+++ b/pyiode/objects/table.pxd
@@ -6,6 +6,44 @@ from libcpp.vector cimport vector
 from pyiode.common cimport (TableLang, TableCellType, TableCellAlign, TableCellFont, TableLineType, 
                             TableGraphAlign, TableGraphAxis, TableGraphGrid, TableGraphType)
 
+cdef extern from "api/iode.h":
+    # Define the TCELL structure
+    cdef struct TCELL:
+        char* tc_val
+        char  tc_type
+        char  tc_attr
+        char  tc_pad[2]
+
+    # Define the TLINE structure
+    cdef struct TLINE:
+        char*         tl_val
+        char          tl_type
+        char          tl_graph
+        unsigned char tl_axis
+        unsigned char tl_pbyte
+        char          tl_pad[1]
+
+    # Define the TBL structure
+    cdef struct TBL:
+        short  t_lang
+        short  t_free
+        short  t_nc
+        short  t_nl
+        TLINE  t_div
+        TLINE* t_line
+        float  t_zmin
+        float  t_zmax
+        float  t_ymin
+        float  t_ymax
+        char   t_attr
+        char   t_box
+        char   t_shadow
+        char   t_gridx
+        char   t_gridy
+        char   t_axis
+        char   t_align
+        char   t_pad[13]
+
 
 cdef extern from "cpp_api/objects/table.h":
 


### PR DESCRIPTION
fix #694