### PR TITLE
PYTHON: (pyproject.toml.in) renamed project as iode

### DIFF
--- a/doc/source/changes/v7.0.0.rst.inc
+++ b/doc/source/changes/v7.0.0.rst.inc
@@ -6,7 +6,7 @@ In development
 New Features 
 ------------
 
-  * (PYTHON) release of the first Python iode-python package (version 7.0.0) 
+  * (PYTHON) release of the first Python iode package (version 7.0.0) 
 
 Improvements
 ------------

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "iode"
 version = "${CMAKE_PROJECT_VERSION}"
-description = ""
+description = "IODE is a package dedicated to econometric models and to the management of statistical series."
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -5,9 +5,7 @@ requires = [ "scikit-build-core >=0.4.3", "numpy", "cython>=3.0", "mypy>=1.10" ]
 build-backend = "scikit_build_core.build"
 
 [project]
-# NOTE: The name of the package is "iode-python" but the name of the module is "iode"
-#       The name "iode" was already used in PyPI
-name = "iode-python"
+name = "iode"
 version = "${CMAKE_PROJECT_VERSION}"
 description = ""
 readme = "README.md"


### PR DESCRIPTION
As the existing `iode` package on PyPi has been kindly renamed to another name by @jugangdae 