### PR TITLE
GUI PYTHON: save settings to QSettings(Scope.UserScope) when the GUI is opened using the view_workspace() function

### DIFF
--- a/.github/workflows/github-actions-python.yml
+++ b/.github/workflows/github-actions-python.yml
@@ -89,7 +89,7 @@ jobs:
             run: |
               conda config --add channels conda-forge
               conda config --add channels larray-project
-              conda install "numpy<2.0" pandas larray "cython>=3.0" "mypy>=1.10" pandoc ipython ipykernel nbsphinx scikit-build-core pytest
+              conda install "numpy<2.0" pandas larray "cython>=3.0" "mypy>=1.10" pandoc ipython ipykernel nbsphinx "scikit-build-core>=0.10" pytest
           - name: Configure CMake
             shell: bash -el {0}
             # cmake --preset <configurePreset> where <configurePreset> is the name of the active Configure Preset.

--- a/.github/workflows/github-actions-python.yml
+++ b/.github/workflows/github-actions-python.yml
@@ -89,7 +89,7 @@ jobs:
             run: |
               conda config --add channels conda-forge
               conda config --add channels larray-project
-              conda install "numpy<2.0" pandas larray "cython>=3.0" "mypy>=1.10" pandoc ipython ipykernel nbsphinx "scikit-build-core>=0.10" pytest
+              conda install --file doc/requirements.txt
           - name: Configure CMake
             shell: bash -el {0}
             # cmake --preset <configurePreset> where <configurePreset> is the name of the active Configure Preset.

--- a/.github/workflows/github-actions-python.yml
+++ b/.github/workflows/github-actions-python.yml
@@ -89,7 +89,7 @@ jobs:
             run: |
               conda config --add channels conda-forge
               conda config --add channels larray-project
-              conda install "numpy<2.0" pandas larray cython mypy pandoc ipython ipykernel nbsphinx scikit-build-core pytest
+              conda install "numpy<2.0" pandas larray "cython>=3.0" mypy pandoc ipython ipykernel nbsphinx scikit-build-core pytest
           - name: Configure CMake
             shell: bash -el {0}
             # cmake --preset <configurePreset> where <configurePreset> is the name of the active Configure Preset.
@@ -102,11 +102,14 @@ jobs:
               cmake --preset ${{ env.os }}-${{ inputs.build-config }}
           - name: Build target iode_cython before pip wheel to make sure it compiles
             shell: bash -el {0}
-            run: cmake --build --preset ${{ env.os }}-${{ inputs.build-config }} --target iode_cython
+            run: | 
+              cython --version
+              cmake --build --preset ${{ env.os }}-${{ inputs.build-config }} --target iode_cython
           - name: Build iode wheel file
             shell: bash -el {0}
             run: |
               cd pyiode 
+              cython --version
               pip wheel --verbose .
           - name: Install iode package
             shell: bash -el {0}

--- a/.github/workflows/github-actions-python.yml
+++ b/.github/workflows/github-actions-python.yml
@@ -89,7 +89,7 @@ jobs:
             run: |
               conda config --add channels conda-forge
               conda config --add channels larray-project
-              conda install "numpy<2.0" pandas larray "cython>=3.0" mypy pandoc ipython ipykernel nbsphinx scikit-build-core pytest
+              conda install "numpy<2.0" pandas larray "cython>=3.0" "mypy>=1.10" pandoc ipython ipykernel nbsphinx scikit-build-core pytest
           - name: Configure CMake
             shell: bash -el {0}
             # cmake --preset <configurePreset> where <configurePreset> is the name of the active Configure Preset.
@@ -104,12 +104,14 @@ jobs:
             shell: bash -el {0}
             run: | 
               cython --version
+              mypy --version
               cmake --build --preset ${{ env.os }}-${{ inputs.build-config }} --target iode_cython
           - name: Build iode wheel file
             shell: bash -el {0}
             run: |
               cd pyiode 
               cython --version
+              mypy --version
               pip wheel --verbose .
           - name: Install iode package
             shell: bash -el {0}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,6 @@ pandas
 matplotlib
 larray
 
-cmake
 cython >= 3.0
 scikit-build-core >= 0.10
 mypy >=1.10

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,7 +7,7 @@ larray
 cmake
 cython >= 3.0
 scikit-build-core
-mypy
+mypy >=1.10
 
 # dependencies to actually build the documentation
 sphinx

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ matplotlib
 larray
 
 cmake
-cython
+cython >= 3.0
 scikit-build-core
 mypy
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,7 @@ larray
 
 cmake
 cython >= 3.0
-scikit-build-core
+scikit-build-core >= 0.10
 mypy >=1.10
 
 # dependencies to actually build the documentation

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,7 @@ numpy < 2.0     # numpy >= 2.0 makes mypy (1.11) to crash (21/08/2024)
 pandas 
 matplotlib
 larray
+pytest
 
 cython >= 3.0
 scikit-build-core >= 0.10

--- a/gui/iode_gui/abstract_main_window.py
+++ b/gui/iode_gui/abstract_main_window.py
@@ -27,7 +27,7 @@ class AbstractMainWindow(QMainWindow):
         # ---- user settings ----
         # location if QSettings::UserScope -> FOLDERID_RoamingAppData
         # see https://doc.qt.io/qt-6/qsettings.html#setPath
-        self.user_settings: QSettings = QSettings(QSettings.Scope.UserScope, self)
+        self.user_settings: QSettings = QSettings(QSettings.Scope.UserScope)
         self.project_path: str = None
         self.recent_projects: List[str] = self.user_settings.value("recent_projects", [])
         self.font_family: List[str] = self.user_settings.value("font_family", DEFAULT_FONT_FAMILY)

--- a/gui/iode_gui/iode_objs/views/abstract_table_view.py
+++ b/gui/iode_gui/iode_objs/views/abstract_table_view.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (QTableView, QLineEdit, QMessageBox, QDialog, QSiz
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.abstract_main_window import AbstractMainWindow
-from iode_gui.settings import ProjectSettings, PRINT_DESTINATION
+from iode_gui.settings import ProjectSettings, PRINT_TO_FILE
 from iode_gui.iode_objs.models.abstract_table_model import IodeAbstractTableModel
 from iode_gui.iode_objs.delegates.base_delegate import BaseDelegate
 from iode_gui.iode_objs.edit.edit_vars_sample import EditIodeSampleDialog
@@ -406,7 +406,7 @@ class IodeAbstractTableView(QTableView):
         if project_settings is None:
             b_print_to_file = False    
         else:
-            b_print_to_file = project_settings.value(PRINT_DESTINATION, type=bool)
+            b_print_to_file = project_settings.value(PRINT_TO_FILE, type=bool)
 
         try:
             if b_print_to_file:

--- a/gui/iode_gui/iode_objs/views/abstract_table_view.py
+++ b/gui/iode_gui/iode_objs/views/abstract_table_view.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (QTableView, QLineEdit, QMessageBox, QDialog, QSiz
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.abstract_main_window import AbstractMainWindow
-from iode_gui.settings import ProjectSettings, PRINT_TO_FILE
+from iode_gui.settings import get_settings, PRINT_TO_FILE
 from iode_gui.iode_objs.models.abstract_table_model import IodeAbstractTableModel
 from iode_gui.iode_objs.delegates.base_delegate import BaseDelegate
 from iode_gui.iode_objs.edit.edit_vars_sample import EditIodeSampleDialog
@@ -402,11 +402,11 @@ class IodeAbstractTableView(QTableView):
     @Slot()
     def print(self):
         """Prints the objects."""
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
+        settings: QSettings = get_settings()
+        if settings is None:
             b_print_to_file = False    
         else:
-            b_print_to_file = project_settings.value(PRINT_TO_FILE, type=bool)
+            b_print_to_file = settings.value(PRINT_TO_FILE, type=bool)
 
         try:
             if b_print_to_file:

--- a/gui/iode_gui/iode_objs/views/table_view.py
+++ b/gui/iode_gui/iode_objs/views/table_view.py
@@ -4,7 +4,7 @@ from PySide6.QtGui import QShortcut, QKeySequence, QContextMenuEvent, QAction
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.abstract_main_window import AbstractMainWindow
-from iode_gui.settings import ProjectSettings, PRINT_DESTINATION
+from iode_gui.settings import ProjectSettings, PRINT_TO_FILE
 
 from iode_gui.iode_objs.delegates.comments_delegate import CommentsDelegate
 from iode_gui.iode_objs.delegates.equations_delegate import EquationsDelegate

--- a/gui/iode_gui/main_widgets/iode_command.py
+++ b/gui/iode_gui/main_widgets/iode_command.py
@@ -2,9 +2,8 @@ from PySide6.QtCore import Qt, QSettings, Slot, Signal
 from PySide6.QtWidgets import QTextEdit, QMessageBox
 from PySide6.QtGui import QKeyEvent
 
-from iode_gui.utils import Context
 from iode_gui.abstract_main_window import AbstractMainWindow
-from iode_gui.settings import ProjectSettings, class_name_to_settings_group_name
+from iode_gui.settings import get_settings, class_name_to_settings_group_name
 from iode_gui.text_edit.complete_line_edit import IodeAutoCompleteLineEdit
 
 from typing import List
@@ -89,47 +88,41 @@ class IodeCommandLine(IodeAutoCompleteLineEdit):
         Store the last MAX_NB_COMMANDS_TO_REMEMBER executed commands 
         to the project settings file.
         """
-        if Context.called_from_python_script:
-            return
-        
-        user_settings: QSettings = ProjectSettings.project_settings
-        if not user_settings:
+        settings: QSettings = get_settings()
+        if not settings:
             return
         
         # end all groups to be sure we are at the top level
-        while user_settings.group():
-            user_settings.endGroup()
+        while settings.group():
+            settings.endGroup()
 
-        user_settings.beginGroup(self.settings_group_name)
+        settings.beginGroup(self.settings_group_name)
 
         nb_commands_to_save = min(len(self.executed_commands_list), self.MAX_NB_COMMANDS_TO_REMEMBER)
         commands_to_save = self.executed_commands_list[-nb_commands_to_save:]
-        user_settings.setValue("LAST_EXECUTED_COMMANDS", commands_to_save)
+        settings.setValue("LAST_EXECUTED_COMMANDS", commands_to_save)
 
-        user_settings.endGroup()
+        settings.endGroup()
 
     def load_settings(self):
         """
         Load the list of the last MAX_NB_COMMANDS_TO_REMEMBER commands executed 
         in the previous GUI session.
         """
-        if Context.called_from_python_script:
-            return
-        
-        user_settings: QSettings = ProjectSettings.project_settings
-        if not user_settings:
+        settings: QSettings = get_settings()
+        if not settings:
             return
     
         # end all groups to be sure we are at the top level
-        while user_settings.group():
-            user_settings.endGroup()
+        while settings.group():
+            settings.endGroup()
 
-        user_settings.beginGroup(self.settings_group_name)
+        settings.beginGroup(self.settings_group_name)
 
-        self.executed_commands_list = user_settings.value("LAST_EXECUTED_COMMANDS", [])
+        self.executed_commands_list = settings.value("LAST_EXECUTED_COMMANDS", [])
         self.iterator = len(self.executed_commands_list)
 
-        user_settings.endGroup()
+        settings.endGroup()
 
     @Slot()
     def run_command(self):

--- a/gui/iode_gui/main_window.py
+++ b/gui/iode_gui/main_window.py
@@ -439,11 +439,12 @@ class MainWindow(AbstractMainWindow):
         else:
             if not Context.called_from_python_script:
                 self.user_settings.setValue("project_path", self.project_path)
-                self.user_settings.setValue("font_family", self.font_family)
-                self.user_settings.setValue("geometry", self.saveGeometry())
-                self.user_settings.setValue("windowState", self.saveState())
-                self.user_settings.setValue("dockWidget_file_explorer_geometry", self.ui.dockWidget_file_explorer.saveGeometry())
-                self.user_settings.setValue("dockWidget_tools_geometry", self.ui.dockWidget_tools.saveGeometry())
+            
+            self.user_settings.setValue("font_family", self.font_family)
+            self.user_settings.setValue("geometry", self.saveGeometry())
+            self.user_settings.setValue("windowState", self.saveState())
+            self.user_settings.setValue("dockWidget_file_explorer_geometry", self.ui.dockWidget_file_explorer.saveGeometry())
+            self.user_settings.setValue("dockWidget_tools_geometry", self.ui.dockWidget_tools.saveGeometry())
 
             for dialog in self.dialogs: 
                 dialog.close()

--- a/gui/iode_gui/menu/file/file_settings.py
+++ b/gui/iode_gui/menu/file/file_settings.py
@@ -2,7 +2,7 @@ from PySide6.QtCore import Qt, Slot, QSettings
 from PySide6.QtWidgets import QWidget
 
 from iode_gui.print.file_print_preferences import FilePrintPreferences
-from iode_gui.settings import (ProjectSettings, MixinSettingsDialog, 
+from iode_gui.settings import (get_settings, MixinSettingsDialog, 
                                PRINT_TO_FILE, RUN_REPORTS_FROM_PROJECT_DIR)
 from .ui_file_settings import Ui_MenuFileSettings
 
@@ -39,12 +39,12 @@ class MenuFileSettings(MixinSettingsDialog):
         """
         Applies the changes made in the settings.
         """
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is not None:
+        settings: QSettings = get_settings()
+        if settings is not None:
             print_to_file: bool = self.ui.comboBox_print_dest.currentText() == "File"
-            project_settings.setValue(PRINT_TO_FILE, print_to_file)
-            project_settings.setValue(RUN_REPORTS_FROM_PROJECT_DIR, 
-                                      self.ui.radioButton_run_from_project_dir.isChecked())
+            settings.setValue(PRINT_TO_FILE, print_to_file)
+            settings.setValue(RUN_REPORTS_FROM_PROJECT_DIR, 
+                              self.ui.radioButton_run_from_project_dir.isChecked())
         self.accept()
 
     @Slot()

--- a/gui/iode_gui/menu/file/file_settings.py
+++ b/gui/iode_gui/menu/file/file_settings.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QWidget
 
 from iode_gui.print.file_print_preferences import FilePrintPreferences
 from iode_gui.settings import (ProjectSettings, MixinSettingsDialog, 
-                               PRINT_DESTINATION, RUN_REPORTS_FROM_PROJECT_DIR)
+                               PRINT_TO_FILE, RUN_REPORTS_FROM_PROJECT_DIR)
 from .ui_file_settings import Ui_MenuFileSettings
 
 
@@ -16,8 +16,8 @@ class MenuFileSettings(MixinSettingsDialog):
         self.ui.setupUi(self)
         self.prepare_settings(self.ui)
 
-        print_destinations = ["Printer", "File"]
-        self.ui.comboBox_print_dest.addItems(print_destinations)
+        PRINT_TO_FILEs = ["Printer", "File"]
+        self.ui.comboBox_print_dest.addItems(PRINT_TO_FILEs)
         self.ui.comboBox_print_dest.setCurrentIndex(0)
 
         self.load_settings()
@@ -42,7 +42,7 @@ class MenuFileSettings(MixinSettingsDialog):
         project_settings: QSettings = ProjectSettings.project_settings
         if project_settings is not None:
             print_to_file: bool = self.ui.comboBox_print_dest.currentText() == "File"
-            project_settings.setValue(PRINT_DESTINATION, print_to_file)
+            project_settings.setValue(PRINT_TO_FILE, print_to_file)
             project_settings.setValue(RUN_REPORTS_FROM_PROJECT_DIR, 
                                       self.ui.radioButton_run_from_project_dir.isChecked())
         self.accept()

--- a/gui/iode_gui/menu/print_graph/print_tables.py
+++ b/gui/iode_gui/menu/print_graph/print_tables.py
@@ -4,7 +4,7 @@ from PySide6.QtGui import QCloseEvent, QTextDocument
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.utils import TMP_FILENAME
-from iode_gui.settings import MixinSettingsDialog, ProjectSettings, PRINT_TO_FILE
+from iode_gui.settings import MixinSettingsDialog, get_settings, PRINT_TO_FILE
 from iode_gui.menu.file.file_settings import MenuFileSettings
 from iode_gui.tabs.iode_objs.tab_computed_table import ComputedTableDialog
 from iode_gui.print.print_file_dialog import PrintFileDialog
@@ -107,11 +107,11 @@ class MenuPrintTables(MixinSettingsDialog):
             # check list of tables is valid
             table_names: List[str] = tables.get_names(pattern_table_names)
 
-            project_settings: QSettings = ProjectSettings.project_settings
-            if project_settings is None:
+            settings: QSettings = get_settings()
+            if settings is None:
                 b_print_to_file = False
             else:
-                b_print_to_file = project_settings.value(PRINT_TO_FILE, type=bool)
+                b_print_to_file = settings.value(PRINT_TO_FILE, type=bool)
 
             if b_print_to_file:
                 # Ask the user to set the output file and format

--- a/gui/iode_gui/menu/print_graph/print_tables.py
+++ b/gui/iode_gui/menu/print_graph/print_tables.py
@@ -4,7 +4,7 @@ from PySide6.QtGui import QCloseEvent, QTextDocument
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.utils import TMP_FILENAME
-from iode_gui.settings import MixinSettingsDialog, ProjectSettings, PRINT_DESTINATION
+from iode_gui.settings import MixinSettingsDialog, ProjectSettings, PRINT_TO_FILE
 from iode_gui.menu.file.file_settings import MenuFileSettings
 from iode_gui.tabs.iode_objs.tab_computed_table import ComputedTableDialog
 from iode_gui.print.print_file_dialog import PrintFileDialog
@@ -111,7 +111,7 @@ class MenuPrintTables(MixinSettingsDialog):
             if project_settings is None:
                 b_print_to_file = False
             else:
-                b_print_to_file = project_settings.value(PRINT_DESTINATION, type=bool)
+                b_print_to_file = project_settings.value(PRINT_TO_FILE, type=bool)
 
             if b_print_to_file:
                 # Ask the user to set the output file and format

--- a/gui/iode_gui/menu/print_graph/print_variables.py
+++ b/gui/iode_gui/menu/print_graph/print_variables.py
@@ -4,7 +4,7 @@ from PySide6.QtGui import QCloseEvent, QTextDocument
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.utils import TMP_FILENAME
-from iode_gui.settings import MixinSettingsDialog, ProjectSettings, PRINT_DESTINATION
+from iode_gui.settings import MixinSettingsDialog, ProjectSettings, PRINT_TO_FILE
 from iode_gui.menu.file.file_settings import MenuFileSettings
 from iode_gui.tabs.iode_objs.tab_computed_table import ComputedTableDialog
 from iode_gui.print.print_file_dialog import PrintFileDialog
@@ -111,7 +111,7 @@ class MenuPrintVariables(MixinSettingsDialog):
             if project_settings is None:
                 b_print_to_file = False
             else:
-                b_print_to_file = project_settings.value(PRINT_DESTINATION, type=bool)
+                b_print_to_file = project_settings.value(PRINT_TO_FILE, type=bool)
 
             if b_print_to_file:
                 # Ask the user to set the output file and format

--- a/gui/iode_gui/menu/print_graph/print_variables.py
+++ b/gui/iode_gui/menu/print_graph/print_variables.py
@@ -4,7 +4,7 @@ from PySide6.QtGui import QCloseEvent, QTextDocument
 from PySide6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 
 from iode_gui.utils import TMP_FILENAME
-from iode_gui.settings import MixinSettingsDialog, ProjectSettings, PRINT_TO_FILE
+from iode_gui.settings import MixinSettingsDialog, get_settings, PRINT_TO_FILE
 from iode_gui.menu.file.file_settings import MenuFileSettings
 from iode_gui.tabs.iode_objs.tab_computed_table import ComputedTableDialog
 from iode_gui.print.print_file_dialog import PrintFileDialog
@@ -107,11 +107,11 @@ class MenuPrintVariables(MixinSettingsDialog):
             variable_names: List[str] = variables.get_names(pattern_variable_names)
             tables[table_name] = Table(2, "Variables", variable_names)
 
-            project_settings: QSettings = ProjectSettings.project_settings
-            if project_settings is None:
+            settings: QSettings = get_settings()
+            if settings is None:
                 b_print_to_file = False
             else:
-                b_print_to_file = project_settings.value(PRINT_TO_FILE, type=bool)
+                b_print_to_file = settings.value(PRINT_TO_FILE, type=bool)
 
             if b_print_to_file:
                 # Ask the user to set the output file and format

--- a/gui/iode_gui/print/print_file_dialog.py
+++ b/gui/iode_gui/print/print_file_dialog.py
@@ -89,6 +89,10 @@ class PrintFileDialog(MixinSettingsDialog):
         if self.iode_type == IodeType.TABLES:
             if self.ui.comboBox_print_table_as.currentIndex() < 0:
                 self.ui.comboBox_print_table_as.setCurrentIndex(0)
+        
+        # Adjust the size of the dialog
+        self.adjustSize()
+
 
     @property
     def file_format(self) -> str:
@@ -198,7 +202,7 @@ class PrintFileDialog(MixinSettingsDialog):
         self.ui.label_nb_decimals.hide()
         self.ui.spinBox_nb_decimals.hide()
         layout.removeItem(self.ui.horizontalSpacer_nb_decimals)
-    
+ 
     def _show_nb_decimals(self):
         layout: QGridLayout = self.layout()
         self.ui.label_nb_decimals.show()
@@ -216,6 +220,8 @@ class PrintFileDialog(MixinSettingsDialog):
             else:
                 self._hide_generalized_sample()
                 self._hide_nb_decimals()
+            # Adjust the size of the dialog
+            self.adjustSize()
 
     # Will automatically save to settings -> see IodeSettingsDialog::closeEvent()
     @Slot()

--- a/gui/iode_gui/print/print_file_dialog.ui
+++ b/gui/iode_gui/print/print_file_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>468</width>
+    <width>506</width>
     <height>322</height>
    </rect>
   </property>
@@ -14,14 +14,20 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="label_print_format">
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="text">
       <string>Format</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="4">
+   <item row="0" column="2" colspan="4">
     <widget class="QComboBox" name="comboBox_print_format">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -43,7 +49,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="5" colspan="3">
+   <item row="0" column="6" colspan="2">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -66,7 +72,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -75,7 +81,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3" colspan="3">
+   <item row="1" column="2" colspan="3">
     <widget class="QComboBox" name="comboBox_print_eq_as">
      <property name="minimumSize">
       <size>
@@ -85,7 +91,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="6" colspan="2">
+   <item row="1" column="5" colspan="3">
     <spacer name="horizontalSpacer_print_eq_as">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -108,7 +114,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -117,7 +123,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="3" colspan="3">
+   <item row="2" column="2" colspan="3">
     <widget class="QComboBox" name="comboBox_print_eq_lec_as">
      <property name="minimumSize">
       <size>
@@ -127,7 +133,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="6" colspan="2">
+   <item row="2" column="5" colspan="3">
     <spacer name="horizontalSpacer_print_eq_lec_as">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -150,7 +156,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -159,7 +165,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="3" colspan="3">
+   <item row="3" column="2" colspan="3">
     <widget class="QComboBox" name="comboBox_print_table_as">
      <property name="minimumSize">
       <size>
@@ -169,7 +175,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="6" colspan="2">
+   <item row="3" column="5" colspan="3">
     <spacer name="horizontalSpacer_print_table_as">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -186,13 +192,13 @@
     <widget class="QLabel" name="label_generalized_sample">
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>140</width>
        <height>16</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -211,7 +217,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="5" colspan="2">
+   <item row="4" column="5" colspan="3">
     <spacer name="horizontalSpacer_generalized_sample">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -224,11 +230,11 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="0">
+   <item row="5" column="0" colspan="2">
     <widget class="QLabel" name="label_nb_decimals">
      <property name="minimumSize">
       <size>
-       <width>70</width>
+       <width>140</width>
        <height>16</height>
       </size>
      </property>
@@ -243,7 +249,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="2">
+   <item row="5" column="2">
     <widget class="QSpinBox" name="spinBox_nb_decimals">
      <property name="minimumSize">
       <size>
@@ -259,7 +265,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="3" colspan="4">
+   <item row="5" column="3" colspan="5">
     <spacer name="horizontalSpacer_nb_decimals">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -272,14 +278,20 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="0">
+   <item row="6" column="0" colspan="2">
     <widget class="QLabel" name="label_output_file">
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="text">
       <string>File</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="7">
+   <item row="6" column="2" colspan="6">
     <widget class="IodeFileChooser" name="fileChooser_output_file" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -314,7 +326,7 @@
      </property>
     </spacer>
    </item>
-   <item row="7" column="1" colspan="2">
+   <item row="7" column="1">
     <widget class="QPushButton" name="pushButton_apply">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -342,7 +354,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="3">
+   <item row="7" column="2">
     <widget class="QPushButton" name="pushButton_cancel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -370,7 +382,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="4">
+   <item row="7" column="3">
     <widget class="QPushButton" name="pushButton_options">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -398,7 +410,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="5" colspan="2">
+   <item row="7" column="4" colspan="3">
     <widget class="QPushButton" name="pushButton_help">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/gui/iode_gui/settings.py
+++ b/gui/iode_gui/settings.py
@@ -29,6 +29,13 @@ class ProjectSettings:
         return cls.project_settings
 
 
+def get_settings() -> QSettings:
+    if Context.called_from_python_script:
+        return QSettings(QSettings.Scope.UserScope) 
+    else:
+        return ProjectSettings.project_settings
+
+
 def class_name_to_settings_group_name(object: Any) -> str:
         menu_class_name: str = object.__class__.__name__
         # remove the Ui_ part of the class name
@@ -72,11 +79,8 @@ class MixinSettingsDialog(QDialog):
 
     @Slot()
     def load_settings(self):
-        if Context.called_from_python_script:
-            return
-        
-        project_settings = ProjectSettings.project_settings
-        if not project_settings:
+        settings: QSettings = get_settings()
+        if not settings:
             return
         
         dict_ui = vars(self.ui_obj)
@@ -84,40 +88,37 @@ class MixinSettingsDialog(QDialog):
             return
 
         # end all groups to be sure we are at the top level
-        while project_settings.group():
-            project_settings.endGroup()
+        while settings.group():
+            settings.endGroup()
 
-        project_settings.beginGroup("MENU")
-        project_settings.beginGroup(self.menu_class_name)
+        settings.beginGroup("MENU")
+        settings.beginGroup(self.menu_class_name)
 
         for attr_name, attr_value in dict_ui.items():
             if isinstance(attr_value, (QComboBox, QFontComboBox)):
-                attr_value.setCurrentIndex(project_settings.value(attr_name, type=int))
+                attr_value.setCurrentIndex(settings.value(attr_name, type=int))
             elif isinstance(attr_value, (QCheckBox, QRadioButton)):
-                attr_value.setChecked(project_settings.value(attr_name, type=bool))
+                attr_value.setChecked(settings.value(attr_name, type=bool))
             elif isinstance(attr_value, QSpinBox):
-                attr_value.setValue(project_settings.value(attr_name, type=int))
+                attr_value.setValue(settings.value(attr_name, type=int))
             elif isinstance(attr_value, QDoubleSpinBox):
-                attr_value.setValue(project_settings.value(attr_name, type=float))
+                attr_value.setValue(settings.value(attr_name, type=float))
             elif isinstance(attr_value, QLineEdit):
-                attr_value.setText(project_settings.value(attr_name, type=str))
+                attr_value.setText(settings.value(attr_name, type=str))
             elif isinstance(attr_value, (QTextEdit, QPlainTextEdit)):
-                attr_value.setPlainText(project_settings.value(attr_name, type=str))
+                attr_value.setPlainText(settings.value(attr_name, type=str))
             elif isinstance(attr_value, IodeFileChooser):
-                attr_value.filepath = project_settings.value(attr_name, type=str)
+                attr_value.filepath = settings.value(attr_name, type=str)
             elif isinstance(attr_value, IodeSampleEdit):
-                attr_value.setText(project_settings.value(attr_name, type=str))
+                attr_value.setText(settings.value(attr_name, type=str))
 
-        project_settings.endGroup()
-        project_settings.endGroup()
+        settings.endGroup()
+        settings.endGroup()
 
     @Slot()
     def save_settings(self):
-        if Context.called_from_python_script:
-            return
-        
-        project_settings = ProjectSettings.project_settings
-        if not project_settings:
+        settings: QSettings = get_settings()
+        if not settings:
             return
 
         dict_ui = vars(self.ui_obj) if hasattr(self.ui_obj, '__dict__') else None
@@ -125,30 +126,30 @@ class MixinSettingsDialog(QDialog):
             return
         
         # end all groups to be sure we are at the top level
-        while project_settings.group():
-            project_settings.endGroup()
+        while settings.group():
+            settings.endGroup()
 
-        project_settings.beginGroup("MENU")
-        project_settings.beginGroup(self.menu_class_name)
+        settings.beginGroup("MENU")
+        settings.beginGroup(self.menu_class_name)
 
         for attr_name, attr_value in dict_ui.items():
             if isinstance(attr_value, (QComboBox, QFontComboBox)):
-                project_settings.setValue(attr_name, attr_value.currentIndex())
+                settings.setValue(attr_name, attr_value.currentIndex())
             elif isinstance(attr_value, (QCheckBox, QRadioButton)):
-                project_settings.setValue(attr_name, attr_value.isChecked())
+                settings.setValue(attr_name, attr_value.isChecked())
             elif isinstance(attr_value, (QSpinBox, QDoubleSpinBox)):
-                project_settings.setValue(attr_name, attr_value.value())
+                settings.setValue(attr_name, attr_value.value())
             elif isinstance(attr_value, QLineEdit):
-                project_settings.setValue(attr_name, attr_value.text())
+                settings.setValue(attr_name, attr_value.text())
             elif isinstance(attr_value, (QTextEdit, QPlainTextEdit)):
-                project_settings.setValue(attr_name, attr_value.toPlainText())
+                settings.setValue(attr_name, attr_value.toPlainText())
             elif isinstance(attr_value, IodeFileChooser):
-                project_settings.setValue(attr_name, attr_value.filepath)
+                settings.setValue(attr_name, attr_value.filepath)
             elif isinstance(attr_value, IodeSampleEdit):
-                project_settings.setValue(attr_name, attr_value.text())
+                settings.setValue(attr_name, attr_value.text())
 
-        project_settings.endGroup()
-        project_settings.endGroup()
+        settings.endGroup()
+        settings.endGroup()
 
     @Slot()
     def help(self):

--- a/gui/iode_gui/settings.py
+++ b/gui/iode_gui/settings.py
@@ -13,7 +13,7 @@ import re
 from typing import Any
 
 RUN_REPORTS_FROM_PROJECT_DIR = "run_reports_from_project_dir"
-PRINT_DESTINATION = "print_destination"
+PRINT_TO_FILE = "print_to_file"
 
 
 class ProjectSettings:

--- a/gui/iode_gui/tabs/iode_objs/tab_computed_table.py
+++ b/gui/iode_gui/tabs/iode_objs/tab_computed_table.py
@@ -2,8 +2,7 @@ from PySide6.QtCore import Qt, Slot, QSettings
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QSpacerItem, QSizePolicy
 from PySide6.QtGui import QCloseEvent
 
-from iode_gui.utils import Context
-from iode_gui.settings import ProjectSettings, class_name_to_settings_group_name
+from iode_gui.settings import get_settings, class_name_to_settings_group_name
 from iode_gui.tabs.iode_objs.tab_numerical_values import NumericalWidget
 from iode_gui.iode_objs.models.computed_table_model import ComputedTableModel
 from iode_gui.iode_objs.views.computed_table_view import ComputedTableView
@@ -50,34 +49,28 @@ class ComputedTableDialog(QDialog, NumericalWidget):
 
     @Slot()
     def load_settings(self):
-        if Context.called_from_python_script:
-            return
-        
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
+        settings: QSettings = get_settings()
+        if settings is None:
             return
         
         # end all groups to be sure we are at the top level
-        while project_settings.group():
-            project_settings.endGroup()
+        while settings.group():
+            settings.endGroup()
         
-        project_settings.beginGroup(self.settings_group_name)
-        self.load_numeric_settings(project_settings)
-        project_settings.endGroup()
+        settings.beginGroup(self.settings_group_name)
+        self.load_numeric_settings(settings)
+        settings.endGroup()
 
     @Slot()
     def save_settings(self):
-        if Context.called_from_python_script:
-            return
-        
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
+        settings: QSettings = get_settings()
+        if settings is None:
             return
         
         # end all groups to be sure we are at the top level
-        while project_settings.group():
-            project_settings.endGroup()
+        while settings.group():
+            settings.endGroup()
 
-        project_settings.beginGroup(self.settings_group_name)
-        self.save_numeric_settings(project_settings)
-        project_settings.endGroup()
+        settings.beginGroup(self.settings_group_name)
+        self.save_numeric_settings(settings)
+        settings.endGroup()

--- a/gui/iode_gui/tabs/iode_objs/tab_database.py
+++ b/gui/iode_gui/tabs/iode_objs/tab_database.py
@@ -2,8 +2,7 @@ from PySide6.QtCore import Qt, Slot, QSettings
 from PySide6.QtWidgets import QLabel, QComboBox, QLineEdit, QSpacerItem, QSizePolicy
 from PySide6.QtGui import QShortcut, QKeySequence
 
-from iode_gui.utils import Context
-from iode_gui.settings import ProjectSettings
+from iode_gui.settings import get_settings
 from iode_gui.tabs.iode_objs.tab_database_abstract import AbstractIodeObjectWidget
 from iode_gui.tabs.iode_objs.tab_numerical_values import NumericalWidget
 from iode_gui.iode_objs.models.table_model import  VariablesModel
@@ -99,25 +98,17 @@ class ScalarsWidget(AbstractIodeObjectWidget, NumericalWidget):
 
     # NOTE: automatically called from IodeTabWidget.load_settings()
     def load_settings(self):
-        if Context.called_from_python_script:
+        settings: QSettings = get_settings()
+        if settings is None:
             return
-        
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
-            return
-        
-        self.load_numeric_settings(project_settings)
+        self.load_numeric_settings(settings)
 
     # NOTE: automatically called from IodeTabWidget.save_settings()
     def save_settings(self):
-        if Context.called_from_python_script:
+        settings: QSettings = get_settings()
+        if settings is None:
             return
-        
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
-            return
-        
-        self.save_numeric_settings(project_settings)
+        self.save_numeric_settings(settings)
 
 
 class TablesWidget(AbstractIodeObjectWidget):
@@ -222,15 +213,12 @@ class VariablesWidget(AbstractIodeObjectWidget, NumericalWidget):
         """
         Loads settings from a QSettings object.
         """
-        if Context.called_from_python_script:
-            return
-        
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
+        settings: QSettings = get_settings()
+        if settings is None:
             return
 
-        self.load_numeric_settings(project_settings)
-        mode = project_settings.value("mode", 0, type=int)
+        self.load_numeric_settings(settings)
+        mode = settings.value("mode", 0, type=int)
         self.combo_mode.setCurrentIndex(mode)
 
     # NOTE: automatically called from IodeTabWidget.save_settings()
@@ -238,15 +226,12 @@ class VariablesWidget(AbstractIodeObjectWidget, NumericalWidget):
         """
         Saves settings to a QSettings object.
         """
-        if Context.called_from_python_script:
+        settings: QSettings = get_settings()
+        if settings is None:
             return
         
-        project_settings: QSettings = ProjectSettings.project_settings
-        if project_settings is None:
-            return
-        
-        self.save_numeric_settings(project_settings)
-        project_settings.setValue("mode", self.combo_mode.currentIndex())
+        self.save_numeric_settings(settings)
+        settings.setValue("mode", self.combo_mode.currentIndex())
 
     @Slot(int)
     def update_mode(self, index):

--- a/gui/iode_gui/tabs/tab_abstract.py
+++ b/gui/iode_gui/tabs/tab_abstract.py
@@ -132,15 +132,13 @@ class IodeAbstractWidget(QWidget):
         """
         Load settings for the current tab from a QSettings object.
         """
-        if Context.called_from_python_script:
-            return
+        pass
 
     def save_settings(self):
         """
         Save settings for the current tab to a QSettings object.
         """
-        if Context.called_from_python_script:
-            return
+        pass
 
     def _check_new_filepath(self, filepath: str) -> bool:
         try:

--- a/gui/iode_gui/tabs/tab_report.py
+++ b/gui/iode_gui/tabs/tab_report.py
@@ -4,8 +4,8 @@ from PySide6.QtPrintSupport import QPrintPreviewDialog
 
 from iode import IodeFileType, TableLang
 
-from iode_gui.utils import IODE_REPORT_EXTENSION, Context
-from iode_gui.settings import ProjectSettings
+from iode_gui.utils import IODE_REPORT_EXTENSION
+from iode_gui.settings import get_settings
 from iode_gui.abstract_main_window import AbstractMainWindow
 from iode_gui.text_edit.report_editor import IodeReportEditor
 from iode_gui.tabs.tab_text_abstract import AbstractTextWidget
@@ -76,16 +76,13 @@ class ReportWidget(AbstractTextWidget):
         """
         Load the settings for the report from the given project settings.
         """
-        if Context.called_from_python_script:
-            return
-        
-        project_settings = ProjectSettings.project_settings
-        if not project_settings:
+        settings: QSettings = get_settings()
+        if not settings:
             return
 
-        parameters = project_settings.value("report_parameters", "")
-        language_index = project_settings.value("report_language", 0, type=int)
-        nb_decimals = project_settings.value("report_nb_decimals", 2, type=int)
+        parameters = settings.value("report_parameters", "")
+        language_index = settings.value("report_language", 0, type=int)
+        nb_decimals = settings.value("report_nb_decimals", 2, type=int)
 
         self.ui.lineEdit_parameters.setText(parameters)
         self.ui.comboBox_language.setCurrentIndex(language_index)
@@ -95,20 +92,17 @@ class ReportWidget(AbstractTextWidget):
         """
         Save the settings for the report to the given project settings.
         """
-        if Context.called_from_python_script:
-            return
-        
-        project_settings = ProjectSettings.project_settings
-        if not project_settings:
+        settings: QSettings = get_settings()
+        if not settings:
             return
 
         parameters = self.ui.lineEdit_parameters.text()
         language_index = self.ui.comboBox_language.currentIndex()
         nb_decimals = self.ui.spinBox_nbDecimals.value()
 
-        project_settings.setValue("report_parameters", parameters)
-        project_settings.setValue("report_language", language_index)
-        project_settings.setValue("report_nb_decimals", nb_decimals)
+        settings.setValue("report_parameters", parameters)
+        settings.setValue("report_language", language_index)
+        settings.setValue("report_nb_decimals", nb_decimals)
 
     @Slot()
     def run(self):

--- a/gui/iode_gui/text_edit/report_editor.py
+++ b/gui/iode_gui/text_edit/report_editor.py
@@ -1,7 +1,7 @@
-from PySide6.QtCore import Qt, QDir, QFileInfo
+from PySide6.QtCore import Qt, QDir, QFileInfo, QSettings
 from PySide6.QtWidgets import QTextEdit, QMessageBox
 
-from iode_gui.settings import ProjectSettings, RUN_REPORTS_FROM_PROJECT_DIR
+from iode_gui.settings import get_settings, RUN_REPORTS_FROM_PROJECT_DIR
 from .highlighter import IodeHighlighter
 from .completer import IodeCompleter
 from .text_editor import IodeTextEditor
@@ -49,10 +49,10 @@ class IodeReportEditor(IodeTextEditor):
         """
         saved_current_dir: str = QDir.currentPath()
         
-        project_settings = ProjectSettings.project_settings
-        if project_settings:
-            run_from_project_dir = project_settings.value(RUN_REPORTS_FROM_PROJECT_DIR, 
-                                                          defaultValue=True, type=bool)
+        settings: QSettings = get_settings()
+        if settings:
+            run_from_project_dir = settings.value(RUN_REPORTS_FROM_PROJECT_DIR, 
+                                                  defaultValue=True, type=bool)
         else:
             run_from_project_dir = True
         

--- a/pyiode/pyproject.toml.in
+++ b/pyiode/pyproject.toml.in
@@ -1,7 +1,7 @@
 # configuration file for the iode python package
 
 [build-system]
-requires = [ "scikit-build-core >=0.4.3", "numpy", "pandas", "cython>=3.0", "mypy>=1.10" ]
+requires = [ "scikit-build-core>=0.10", "numpy", "pandas", "cython>=3.0", "mypy>=1.10" ]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
fix #854