### PR TITLE
C API: (e_error.c/e_est.c) resurrected the E_msg_n() function

### DIFF
--- a/api/estimation/e_error.c
+++ b/api/estimation/e_error.c
@@ -29,27 +29,38 @@ void E_msg(char* fmt,...)
     
     va_start(myargs, fmt);
     if(fmt == 0) strcpy(buf, B_ERROR_DFT_MSG);  
-    else {
+    else 
+    {
 #ifdef _MSC_VER   
         vsnprintf_s(buf, sizeof(buf) - 1, _TRUNCATE, fmt, myargs);
 #else
         vsnprintf_s(buf, sizeof(buf) - 1, fmt, myargs);
 #endif  
     }
-    
     va_end(myargs);
 
     kmsg("%s\n", buf);
 }
 
 
-//void E_msg_n(int n)
-//{
-//    char    *B_msg();
-//
-//    E_msg(B_msg(200 + n));
-//}
-//
+// see B_seterrn() for code example
+void E_msg_n(int n, ...)
+{
+    char    buf[256];
+    char    *B_msg();
+    va_list myargs;
+    
+    va_start(myargs, n);    
+#ifdef _MSC_VER   
+    vsnprintf_s(buf, sizeof(buf) - 1, _TRUNCATE, B_msg(200 + n), myargs);
+#else
+    vsnprintf_s(buf, sizeof(buf) - 1, B_msg(200 + n), myargs);
+#endif    
+    va_end(myargs);
+
+    kmsg("%s\n", buf);
+}
+
 
 /**
  *  Displays an estimation error message using B_seterror().
@@ -67,10 +78,10 @@ void E_error(char* fmt,...)
     
     va_start(myargs, fmt);
     if(fmt == 0) strcpy(buf, B_ERROR_DFT_MSG);
-    else {
+    else 
+    {
 #if defined(_MSC_VER)  
         vsnprintf_s(buf, sizeof(buf) - 1, _TRUNCATE, fmt, myargs);
-        
 #else
         vsnprintf_s(buf, sizeof(buf) - 1, fmt, myargs);
 #endif  
@@ -87,10 +98,20 @@ void E_error(char* fmt,...)
  *  @param [in] int n   Estimation error number (identified par 1200+n in iode_msg_map) 
  *  
  */
- 
-void E_error_n(int n)
+// see B_seterrn() for code example
+void E_error_n(int n, ...)
 {
+    char    buf[256];
     char    *B_msg();
+    va_list myargs;
+    
+    va_start(myargs, n);
+#if defined(_MSC_VER)  
+        vsnprintf_s(buf, sizeof(buf) - 1, _TRUNCATE, B_msg(200 + n), myargs);
+#else
+        vsnprintf_s(buf, sizeof(buf) - 1, B_msg(200 + n), myargs);
+#endif  
+    va_end(myargs);
 
-    E_error("%s", B_msg(200 + n));
+    B_seterror(buf);
 }

--- a/api/estimation/e_est.c
+++ b/api/estimation/e_est.c
@@ -550,7 +550,7 @@ again: /* first step of all methods and second step for Zellner and 3 stages met
     return((E_CONV == 1) ? 0 : -1);
 
 err :
-    E_msg("Estimation: error %d", E_errno);
+    E_msg_n(E_errno);
     return(-1);
 }
 

--- a/api/iodebase.h
+++ b/api/iodebase.h
@@ -457,10 +457,10 @@ extern void E_free_work(void);
 //extern int E_prep_reset(void);
 
 /* e_error.c */
-//extern void E_msg_n(int );
-extern void E_error_n(int );
-extern void E_msg(char* fmt,...);
-extern void E_error(char* fmt,...);
+extern void E_msg_n(int, ...);
+extern void E_error_n(int, ...);
+extern void E_msg(char* fmt, ...);
+extern void E_error(char* fmt, ...);
 
 /* e_print.c */
 //extern void E_print_enum(void);

--- a/api/messages.hpp
+++ b/api/messages.hpp
@@ -215,9 +215,9 @@ const static std::map<int, std::string> iode_msg_map = {
     {1209, "Estimation : Singular Matrix (GMG)"},
     {1210, "Estimation : No current estimation"},
     {1211, "Estimation : Memory Full"},
-    {1211, "Estimation : Equation %.80s : compiling error %.80s"},
-    {1212, "Estimation : Instrument %.80s : error %.80s"},
-    {1213, "Block: syntax error"},
+    {1212, "Estimation : Equation %.80s : compiling error %.80s"},
+    {1213, "Estimation : Instrument %.80s : error %.80s"},
+    {1214, "Block: syntax error"},
     
     {1250, "Report : Memory Full"},
     {1251, "Report : Define of %.80s (%.80s) not possible"},


### PR DESCRIPTION
@jmpplan Do you remenber why the function `E_msg_n()` was commented ?

A (new) IODE user complained that 'Estimation: error 6' is not very very *helpful* (if you know what I mean?) ;)