### PR TITLE
PYTHON: fixed wheeler files containing pyd files for all three supported Python versions instead of one

### DIFF
--- a/pyiode/CMakeLists.txt
+++ b/pyiode/CMakeLists.txt
@@ -75,7 +75,7 @@ if(Python_FOUND)
     # after the iode_cython target is built
     add_custom_command(TARGET iode_cython POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:iode_cython> ${CMAKE_CURRENT_BINARY_DIR}/iode
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:iode_cython> ${CMAKE_CURRENT_SOURCE_DIR}/iode
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:iode_cython> ${CMAKE_CURRENT_SOURCE_DIR}/iode/iode_cython.pyd
         COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/generate_stub_files.py)
     
     install(TARGETS iode_cython LIBRARY DESTINATION iode)

--- a/pyiode/pyproject.toml.in
+++ b/pyiode/pyproject.toml.in
@@ -78,7 +78,7 @@ wheel.license-files = ["LICENSE.md"]
 # the source distribution. However, sdist.include and sdist.exclude can be used to 
 # override this behavior
 sdist.include = [ "**/__init__.py", "**/*.pyi", "./iode/tests/data", "./iode/doc" ]
-sdist.exclude = [ "**/*.in", "dist", "dist_build" ]
+sdist.exclude = [ "**/*.in", "iode_cython.pyd", "dist", "dist_build" ]
 
 # The build directory. Defaults to a temporary directory, but can be set.
 build-dir = "../out/build/python/{wheel_tag}"


### PR DESCRIPTION
fix #932