### PR TITLE
GUI: fixed error message when opening Computed Table window via the $ViewVar IODE command in the GUI

### DIFF
--- a/api/report/undoc/b_view.cpp
+++ b/api/report/undoc/b_view.cpp
@@ -104,7 +104,7 @@ int B_ViewPrintVar(char* arg, int mode)
         tbl = T_create(2);
         if(mode == 0) {
             T_default(tbl, 0L, ((char**) args) + i, ((char**) args) + i, 0, 0, 0);
-            rc = T_view_tbl(tbl, smpl, "of series");
+            rc = T_view_tbl(tbl, smpl, "TABLE_OF_VARIABLES");
         }
         else {
             T_default(tbl, 0L, ((char**) args) + i, ((char**) args) + i, 1, 1, 1);

--- a/doc/source/changes/v7.0.3.rst.inc
+++ b/doc/source/changes/v7.0.3.rst.inc
@@ -24,6 +24,8 @@ Fixed Bugs
   Graphical User Interface (GUI) (closes :issue:`1007`)
 - allowed users to display Computed Table windows to in full screen in the Graphical User 
   Interface (GUI) (closes :issue:`1033`)
+- fixed error message displayed when trying to open a Computed Table window using the 
+  IODE report command `$ViewVar` via the Graphical User Interface (GUI) (closes :issue:`1032`)
 
 Miscellaneous 
 -------------


### PR DESCRIPTION
fix #1032
