### PR TITLE
GUI: fixing cells content not visible when editing an IODE table if Windows OS is in dark mode

### DIFF
--- a/doc/source/changes/v7.0.4.rst.inc
+++ b/doc/source/changes/v7.0.4.rst.inc
@@ -14,6 +14,8 @@ Improvements
 Fixed Bugs 
 ----------
 
+- GUI: fixed cells content not visible when editing an IODE table if Windows OS 
+  is in dark mode (closes :issue:`1061`)
 
 Miscellaneous 
 -------------

--- a/gui/iode_gui/iode_objs/edit/edit_table.ui
+++ b/gui/iode_gui/iode_objs/edit/edit_table.ui
@@ -140,7 +140,7 @@
       </sizepolicy>
      </property>
      <property name="alternatingRowColors">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
@@ -149,7 +149,7 @@
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
      <property name="gridStyle">
-      <enum>Qt::DotLine</enum>
+      <enum>Qt::SolidLine</enum>
      </property>
      <property name="sortingEnabled">
       <bool>true</bool>

--- a/gui/iode_gui/iode_objs/edit/edit_table_model.py
+++ b/gui/iode_gui/iode_objs/edit/edit_table_model.py
@@ -98,13 +98,7 @@ class EditTableModel(QAbstractTableModel):
 
         if role == Qt.ItemDataRole.BackgroundRole:
             if line_type == TableLineType.SEP:
-                color = QColor("black")
-            elif line_type == TableLineType.CELL:
-                color = QColor("white")
-            else:
-                color = QColor("lightGray")
-                color.setAlphaF(0.4)
-            return color
+                return QColor("black")
 
         if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
             if line_type == TableLineType.TITLE or line_type == TableLineType.CELL:

--- a/gui/iode_gui/iode_objs/edit/edit_table_view.py
+++ b/gui/iode_gui/iode_objs/edit/edit_table_view.py
@@ -1,6 +1,8 @@
 from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QTableView, QHeaderView
 
+from iode_gui.color_theme import ColorTheme
+from iode_gui.settings import get_color_theme
 from .edit_table_delegate import EditTableDelegate
 from .edit_table_model import EditTableModel
 
@@ -10,10 +12,20 @@ from iode import TableLineType
 class EditTableView(QTableView):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.horizontalHeader().setStyleSheet("font: bold; border: 0.5px solid")
+        self.update_colors()
+
+    def update_colors(self):
+        """
+        Set the highlighting colors according to the current color theme.
+        """
+        color_theme: ColorTheme = get_color_theme()
+        background_color = color_theme.header_background.name()
+        text_color = color_theme.header_text_color.name()
+        stylesheet = f"QHeaderView::section {{ background-color: {background_color}; color: {text_color}, "\
+                     "font: bold; border: 0.5px solid }"
+        self.setStyleSheet(stylesheet)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
         self.verticalHeader().setStyleSheet("border: none")
-        self.setStyleSheet("QHeaderView::section { background-color: lightGray }")
 
     def setup_model(self, table_name: str):
         model = EditTableModel(table_name, self.parent())

--- a/gui/iode_gui/iode_objs/estimation/estimation_coefs.py
+++ b/gui/iode_gui/iode_objs/estimation/estimation_coefs.py
@@ -2,6 +2,8 @@ from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import QDialog
 from PySide6.QtGui import QKeySequence, QShortcut
 
+from iode_gui.color_theme import ColorTheme
+from iode_gui.settings import get_color_theme
 from .ui_estimation_coefs import Ui_EstimationCoefsDialog
 from iode_gui.iode_objs.models.table_model import ScalarsModel
 from iode.compute.estimation import EditAndEstimateEquations
@@ -27,8 +29,7 @@ class EstimationCoefsDialog(QDialog):
         self.ui.setupUi(self)
 
         # Set up the table view
-        stylesheet = "QHeaderView::section { background-color: lightGray; font: bold; border: 0.5px solid }"
-        self.ui.tableView_coefs.setStyleSheet(stylesheet)
+        self.update_colors()
 
         # Create a copy of the estimation scalars database
         scalars_db = edit_est_eqs.scalars_db.copy()
@@ -40,6 +41,17 @@ class EstimationCoefsDialog(QDialog):
         self.full_screen_shortcut = QShortcut(QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_X), self)
         self.full_screen_shortcut.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
         self.full_screen_shortcut.activated.connect(self.toggle_maximize)
+
+    def update_colors(self):
+        """
+        Set the highlighting colors according to the current color theme.
+        """
+        color_theme: ColorTheme = get_color_theme()
+        background_color = color_theme.header_background.name()
+        text_color = color_theme.header_text_color.name()
+        stylesheet = f"QHeaderView::section {{ background-color: {background_color}; color: {text_color}, "\
+                     "font: bold; border: 0.5px solid }"
+        self.ui.tableView_coefs.setStyleSheet(stylesheet)
 
     @Slot()
     def toggle_maximize(self):

--- a/gui/iode_gui/iode_objs/views/computed_table_view.py
+++ b/gui/iode_gui/iode_objs/views/computed_table_view.py
@@ -2,6 +2,8 @@ from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QTableView, QMenu
 from PySide6.QtGui import QContextMenuEvent
 
+from iode_gui.color_theme import ColorTheme
+from iode_gui.settings import get_color_theme
 from .numerical_view import NumericalTableView
 
 
@@ -10,6 +12,18 @@ class ComputedTableView(QTableView, NumericalTableView):
         QTableView.__init__(self, parent)
         NumericalTableView.__init__(self)
         NumericalTableView.setup(self, allow_to_paste=False)
+        self.update_colors()
+
+    def update_colors(self):
+        """
+        Set the highlighting colors according to the current color theme.
+        """
+        color_theme: ColorTheme = get_color_theme()
+        background_color = color_theme.header_background.name()
+        text_color = color_theme.header_text_color.name()
+        stylesheet = f"QHeaderView::section {{ background-color: {background_color}; color: {text_color}, "\
+                     "font: bold; border: 0.5px solid }"
+        self.setStyleSheet(stylesheet)
 
     # override QTableView method
     @Slot(QContextMenuEvent)

--- a/gui/iode_gui/tabs/iode_objs/tab_computed_table.py
+++ b/gui/iode_gui/tabs/iode_objs/tab_computed_table.py
@@ -23,8 +23,6 @@ class ComputedTableDialog(QDialog, NumericalWidget):
         self.table_view.setModel(self.table_model)
         self.set_model_and_view(self.table_model, self.table_view)
         self.table_view.horizontalHeader().setStretchLastSection(False)
-        stylesheet = "QHeaderView::section { background-color: lightGray; font: bold; border: 0.5px solid }"
-        self.table_view.setStyleSheet(stylesheet)
         self.vertical_layout.addWidget(self.table_view)
 
         horizontalSpacer = QSpacerItem(800, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)


### PR DESCRIPTION
Added color theme support to the views of computed tables, estimation coefficients and edition of IODE tables

fix #1061