### PR TITLE
FIXUP: update Notepad++ syntax highlighting configuration for iode reports

### DIFF
--- a/doc/source/changes/v7.0.4.rst.inc
+++ b/doc/source/changes/v7.0.4.rst.inc
@@ -25,6 +25,9 @@ Fixed Bugs
 - GUI: fixed cascading tabs not working when extracting related IODE objects 
   (closes :issue:`1074`)
 
+- NOTEPAD++: fixed color highlighting not working when opening IODE report files 
+  (except for iode comments) (closes :issue:`521`)
+
 Miscellaneous 
 -------------
 

--- a/resources/syntax/npp_syntax.xml
+++ b/resources/syntax/npp_syntax.xml
@@ -1,92 +1,64 @@
 <NotepadPlus>
-    <UserLang name="Iode Reports" ext="rep">
+    <UserLang name="iode_reports" ext="rep" udlVersion="2.1">
         <Settings>
-            <Global caseIgnored="yes" />
-            <TreatAsSymbol comment="no" commentLine="no" />
-            <Prefix words1="no" words2="no" words3="no" words4="no" />
+            <Global caseIgnored="yes" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />
         </Settings>
         <KeywordLists>
-            <Keywords name="Delimiters">%{0%}0</Keywords>
-            <Keywords name="Folder+"></Keywords>
-            <Keywords name="Folder-"></Keywords>
-            <Keywords name="Operators"></Keywords>
-            <Keywords name="Comment"> 1 2 0# 0$</Keywords>
-            <Keywords name="Words1">$label $goto $ask $abort $quitode $onerror $return $show $msg $beep 
-                                    $system $chdir $mkdir $rmdir $settime $incrtime $shift $define $debug 
-                                    $shellexec $repeat $repeatstring
-            </Keywords>
-            <Keywords name="Words2"> $fileimportvar $fileimportcmt $filedeletecmt $filedeleteeqs  $filedeleteidt  
-                                        $filedeletelst  $filedeletetbl  $filedeletescl  $filedeletevar 
-                                        $filerenamecmt $filerenameeqs $filerenameidt $filerenamelst $filerenametbl 
-                                        $filerenamescl $filerenamevar $filecopycmt $filecopyeqs $filecopyidt $filecopylst 
-                                        $filecopytbl $filecopyscl $filecopyvar $wssample $wsloadcmt $wsloadeqs $wsloadidt 
-                                        $wsloadlst $wsloadtbl $wsloadscl $wsloadvar $wscopycmt $wscopyeqs $wscopyidt 
-                                        $wscopylst $wscopytbl $wscopyscl $wscopyvar $wssavecmt $wssaveeqs $wssaveidt 
-                                        $wssavelst $wssavetbl $wssavescl $wssavevar $wssavecmpcmt $wssavecmpeqs $wssavecmpidt 
-                                        $wssavecmplst $wssavecmptbl $wssavecmpscl $wssavecmpvar $wsimportcmt $wsimporteqs 
-                                        $wsimportidt $wsimportlst $wsimporttbl $wsimportscl $wsimportvar $wsexportcmt 
-                                        $wsexporteqs $wsexportidt $wsexportlst $wsexporttbl $wsexportscl $wsexportvar 
-                                        $wsmergecmt $wsmergeeqs $wsmergeidt $wsmergelst $wsmergetbl $wsmergescl $wsmergevar 
-                                        $wsclearcmt $wscleareqs $wsclearidt $wsclearlst $wscleartbl $wsclearscl $wsclearvar 
-                                        $wsclearall $wsdescr $wsextrapolate $wsaggrchar $wsaggrsum $wsaggrmean $wsaggrprod 
-                                        $wshtollast $wshtolsum $wshtolmean $wsltohflow $wsltohstock $wsseasonadj $wstrend 
-                                        $dataeditcmt $dataediteqs $dataeditidt $dataeditlst $dataedittbl $dataeditscl 
-                                        $dataeditvar $dataupdatecmt $dataupdateeqs $dataupdateidt $dataupdatelst $dataupdatetbl 
-                                        $dataupdatescl $dataupdatevar $dataexistcmt $dataexisteqs $dataexistidt $dataexistlst 
-                                        $dataexisttbl $dataexistscl $dataexistvar $dataappendcmt $dataappendeqs $dataappendidt 
-                                        $dataappendlst $dataappendtbl $dataappendscl $dataappendvar $datacreatecmt $datacreateeqs 
-                                        $datacreateidt $datacreatelst $datacreatetbl $datacreatescl $datacreatevar $datadeletecmt 
-                                        $datadeleteeqs $datadeleteidt $datadeletelst $datadeletetbl $datadeletescl $datadeletevar 
-                                        $datarenamecmt $datarenameeqs $datarenameidt $datarenamelst $datarenametbl $datarenamescl 
-                                        $datarenamevar $datasearchcmt $datasearcheqs $datasearchidt $datasearchlst $datasearchtbl 
-                                        $datasearchscl $datasearchvar $dataduplicatecmt $dataduplicateeqs $dataduplicateidt 
-                                        $dataduplicatelst $dataduplicatetbl $dataduplicatescl $dataduplicatevar $datalistcmt 
-                                        $datalisteqs $datalistidt $datalistlst $datalisttbl $datalistscl $datalistvar $datacomparecmt 
-                                        $datacompareeqs $datacompareidt $datacomparelst $datacomparetbl $datacomparescl $datacomparevar 
-                                        $datalistsort $datadisplaygraph $dataprintgraph $dataeditcnf $datacalcvar $datacalclst $datarasvar 
-                                        $datascancmt $datascaneqs $datascanidt $datascanlst $datascantbl $datascanscl 
-                                        $datascanvar $datapatterncmt $datapatterneqs $datapatternidt $datapatternlst $datapatterntbl 
-                                        $datapatternscl $datapatternvar $excelgetcmt $excelgeteqs $excelgetidt $excelgetlst 
-                                        $excelgettbl $excelgetscl $excelgetvar $excelsetcmt $excelseteqs $excelsetidt 
-                                        $excelsetlst $excelsettbl $excelsetscl $excelsetvar $excelexecute $excelopen $excelnew 
-                                        $excelclose $excelprint $excelsave $excelsaveas $excelwrite $dsimportdb $statunitroot 
-                                        $datawidthvar $datandecvar $datamodevar $datastartvar $datawidthtbl $datawidthscl 
-                                        $datandecscl $viewwidth $viewwidth0 $viewndec $printobjtitle $printobjlec $printobjinfos 
-                                        $printobjdefcmt $printobjdefeqs $printobjdefidt $printobjdeflst $printobjdeftbl 
-                                        $printobjdefscl $printobjdefvar $printdest $printdestnew $printmulti $printnbdec 
-                                        $printlang $printtblfile $printtbl $printvar $viewtblfile $viewtbl $viewvar $viewbytbl 
-                                        $viewgr $printgrall $printgr $modelsimulate $modelsimulateparms $modelexchange 
-                                        $modelcompile $idtexecute $idtexecutevarfiles $idtexecutesclfiles $idtexecutetrace 
-                                        $eqsestimate $eqsstepwise $eqssetmethod $eqssetbloc $eqssetblock $eqssetsample 
-                                        $eqssetinstrs $eqssetcmt $reportexec $reportedit $prompt $minimize $maximize $sleep 
-                                        $printa2mappend $printfont $printtablefont $printtablebox $printtablecolor 
-                                        $printtablewidth $printtablebreak $printtablepage $printbackground $printgraphbox 
-                                        $printgraphbrush $printgraphsize $printgraphpage $printgraphtheme $printgraphband $printrtfhelp 
-                                        $printhtmlhelp $printrtftopic $printrtflevel $printrtftitle $printrtfcopyright 
-                                        $printparanum $printpageheader $printpagefooter $printorientation $printduplex 
-                                        $setprinter $printgiftranscolor $printgifbackcolor $printgifinterlaced $printgiftransparent $printgiffilled 
-                                        $printgiffont $printhtmlstrip $printhtmlstyle $ddeget $sysmovefile $syscopyfile 
-                                        $sysappendfile $sysdeletefile $a2mtohtml $a2mtomif $a2mtocsv $a2mtortf $a2mtoprinter
-                                        $graphdefault
-                     </Keywords>
-            <Keywords name="Words3"></Keywords>
-            <Keywords name="Words4"></Keywords>
+            <Keywords name="Comments">00 01 02 03 04</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1"></Keywords>
+            <Keywords name="Operators2"></Keywords>
+            <Keywords name="Folders in code1, open"></Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close"></Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">$label $goto $ask $abort $quitode $onerror $return $show $msg $beep $system $chdir $mkdir $rmdir $settime $incrtime $shift $define $debug $shellexec $repeat $repeatstring</Keywords>
+            <Keywords name="Keywords2">$fileimportvar $fileimportcmt $filedeletecmt $filedeleteeqs $filedeleteidt $filedeletelst $filedeletetbl $filedeletescl $filedeletevar $filerenamecmt $filerenameeqs $filerenameidt $filerenamelst $filerenametbl $filerenamescl $filerenamevar $filecopycmt $filecopyeqs $filecopyidt $filecopylst $filecopytbl $filecopyscl $filecopyvar $wssample $wsloadcmt $wsloadeqs $wsloadidt $wsloadlst $wsloadtbl $wsloadscl $wsloadvar $wscopycmt $wscopyeqs $wscopyidt $wscopylst $wscopytbl $wscopyscl $wscopyvar $wssavecmt $wssaveeqs $wssaveidt $wssavelst $wssavetbl $wssavescl $wssavevar $wssavecmpcmt $wssavecmpeqs $wssavecmpidt $wssavecmplst $wssavecmptbl $wssavecmpscl $wssavecmpvar $wsimportcmt $wsimporteqs $wsimportidt $wsimportlst $wsimporttbl $wsimportscl $wsimportvar $wsexportcmt $wsexporteqs $wsexportidt $wsexportlst $wsexporttbl $wsexportscl $wsexportvar $wsmergecmt $wsmergeeqs $wsmergeidt $wsmergelst $wsmergetbl $wsmergescl $wsmergevar $wsclearcmt $wscleareqs $wsclearidt $wsclearlst $wscleartbl $wsclearscl $wsclearvar $wsclearall $wsdescr $wsextrapolate $wsaggrchar $wsaggrsum $wsaggrmean $wsaggrprod $wshtollast $wshtolsum $wshtolmean $wsltohflow $wsltohstock $wsseasonadj $wstrend $dataeditcmt $dataediteqs $dataeditidt $dataeditlst $dataedittbl $dataeditscl $dataeditvar $dataupdatecmt $dataupdateeqs $dataupdateidt $dataupdatelst $dataupdatetbl $dataupdatescl $dataupdatevar $dataexistcmt $dataexisteqs $dataexistidt $dataexistlst $dataexisttbl $dataexistscl $dataexistvar $dataappendcmt $dataappendeqs $dataappendidt $dataappendlst $dataappendtbl $dataappendscl $dataappendvar $datacreatecmt $datacreateeqs $datacreateidt $datacreatelst $datacreatetbl $datacreatescl $datacreatevar $datadeletecmt $datadeleteeqs $datadeleteidt $datadeletelst $datadeletetbl $datadeletescl $datadeletevar $datarenamecmt $datarenameeqs $datarenameidt $datarenamelst $datarenametbl $datarenamescl $datarenamevar $datasearchcmt $datasearcheqs $datasearchidt $datasearchlst $datasearchtbl $datasearchscl $datasearchvar $dataduplicatecmt $dataduplicateeqs $dataduplicateidt $dataduplicatelst $dataduplicatetbl $dataduplicatescl $dataduplicatevar $datalistcmt $datalisteqs $datalistidt $datalistlst $datalisttbl $datalistscl $datalistvar $datacomparecmt $datacompareeqs $datacompareidt $datacomparelst $datacomparetbl $datacomparescl $datacomparevar $datalistsort $datadisplaygraph $dataprintgraph $dataeditcnf $datacalcvar $datacalclst $datarasvar $datascancmt $datascaneqs $datascanidt $datascanlst $datascantbl $datascanscl $datascanvar $datapatterncmt $datapatterneqs $datapatternidt $datapatternlst $datapatterntbl $datapatternscl $datapatternvar $excelgetcmt $excelgeteqs $excelgetidt $excelgetlst $excelgettbl $excelgetscl $excelgetvar $excelsetcmt $excelseteqs $excelsetidt $excelsetlst $excelsettbl $excelsetscl $excelsetvar $excelexecute $excelopen $excelnew $excelclose $excelprint $excelsave $excelsaveas $excelwrite $dsimportdb $statunitroot $datawidthvar $datandecvar $datamodevar $datastartvar $datawidthtbl $datawidthscl $datandecscl $viewwidth $viewwidth0 $viewndec $printobjtitle $printobjlec $printobjinfos $printobjdefcmt $printobjdefeqs $printobjdefidt $printobjdeflst $printobjdeftbl $printobjdefscl $printobjdefvar $printdest $printdestnew $printmulti $printnbdec $printlang $printtblfile $printtbl $printvar $viewtblfile $viewtbl $viewvar $viewbytbl $viewgr $printgrall $printgr $modelsimulate $modelsimulateparms $modelexchange $modelcompile $idtexecute $idtexecutevarfiles $idtexecutesclfiles $idtexecutetrace $eqsestimate $eqsstepwise $eqssetmethod $eqssetbloc $eqssetblock $eqssetsample $eqssetinstrs $eqssetcmt $reportexec $reportedit $prompt $minimize $maximize $sleep $printa2mappend $printfont $printtablefont $printtablebox $printtablecolor $printtablewidth $printtablebreak $printtablepage $printbackground $printgraphbox $printgraphbrush $printgraphsize $printgraphpage $printgraphtheme $printgraphband $printrtfhelp $printhtmlhelp $printrtftopic $printrtflevel $printrtftitle $printrtfcopyright $printparanum $printpageheader $printpagefooter $printorientation $printduplex $setprinter $printgiftranscolor $printgifbackcolor $printgifinterlaced $printgiftransparent $printgiffilled $printgiffont $printhtmlstrip $printhtmlstyle $ddeget $sysmovefile $syscopyfile $sysappendfile $sysdeletefile $a2mtohtml $a2mtomif $a2mtocsv $a2mtortf $a2mtoprinter $graphdefault</Keywords>
+            <Keywords name="Keywords3"></Keywords> 
+            <Keywords name="Keywords4"></Keywords> 
+            <Keywords name="Keywords5"></Keywords>
+            <Keywords name="Keywords6"></Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00% 01 02% 03{ 04 05} 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="FOLDEROPEN" styleID="12" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="FOLDERCLOSE" styleID="13" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="KEYWORD1" styleID="5" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" />
-            <WordsStyle name="KEYWORD2" styleID="6" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="KEYWORD3" styleID="7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="KEYWORD4" styleID="8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="808000" bgColor="FFFF80" fontName="" fontStyle="0" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="DELIMINER1" styleID="14" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="DELIMINER2" styleID="15" fgColor="FF00FF" bgColor="FFFFFF" fontName="" fontStyle="0" />
-            <WordsStyle name="DELIMINER3" styleID="16" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="FF0000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="0000FF" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="006400" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="LINE COMMENTS" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="800080" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="006400" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
         </Styles>
     </UserLang>
 </NotepadPlus>

--- a/resources/syntax/npp_syntax_old.xml
+++ b/resources/syntax/npp_syntax_old.xml
@@ -1,0 +1,92 @@
+<NotepadPlus>
+    <UserLang name="Iode Reports" ext="rep">
+        <Settings>
+            <Global caseIgnored="yes" />
+            <TreatAsSymbol comment="no" commentLine="no" />
+            <Prefix words1="no" words2="no" words3="no" words4="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Delimiters">%{0%}0</Keywords>
+            <Keywords name="Folder+"></Keywords>
+            <Keywords name="Folder-"></Keywords>
+            <Keywords name="Operators"></Keywords>
+            <Keywords name="Comment"> 1 2 0# 0$</Keywords>
+            <Keywords name="Words1">$label $goto $ask $abort $quitode $onerror $return $show $msg $beep 
+                                    $system $chdir $mkdir $rmdir $settime $incrtime $shift $define $debug 
+                                    $shellexec $repeat $repeatstring
+            </Keywords>
+            <Keywords name="Words2"> $fileimportvar $fileimportcmt $filedeletecmt $filedeleteeqs  $filedeleteidt  
+                                        $filedeletelst  $filedeletetbl  $filedeletescl  $filedeletevar 
+                                        $filerenamecmt $filerenameeqs $filerenameidt $filerenamelst $filerenametbl 
+                                        $filerenamescl $filerenamevar $filecopycmt $filecopyeqs $filecopyidt $filecopylst 
+                                        $filecopytbl $filecopyscl $filecopyvar $wssample $wsloadcmt $wsloadeqs $wsloadidt 
+                                        $wsloadlst $wsloadtbl $wsloadscl $wsloadvar $wscopycmt $wscopyeqs $wscopyidt 
+                                        $wscopylst $wscopytbl $wscopyscl $wscopyvar $wssavecmt $wssaveeqs $wssaveidt 
+                                        $wssavelst $wssavetbl $wssavescl $wssavevar $wssavecmpcmt $wssavecmpeqs $wssavecmpidt 
+                                        $wssavecmplst $wssavecmptbl $wssavecmpscl $wssavecmpvar $wsimportcmt $wsimporteqs 
+                                        $wsimportidt $wsimportlst $wsimporttbl $wsimportscl $wsimportvar $wsexportcmt 
+                                        $wsexporteqs $wsexportidt $wsexportlst $wsexporttbl $wsexportscl $wsexportvar 
+                                        $wsmergecmt $wsmergeeqs $wsmergeidt $wsmergelst $wsmergetbl $wsmergescl $wsmergevar 
+                                        $wsclearcmt $wscleareqs $wsclearidt $wsclearlst $wscleartbl $wsclearscl $wsclearvar 
+                                        $wsclearall $wsdescr $wsextrapolate $wsaggrchar $wsaggrsum $wsaggrmean $wsaggrprod 
+                                        $wshtollast $wshtolsum $wshtolmean $wsltohflow $wsltohstock $wsseasonadj $wstrend 
+                                        $dataeditcmt $dataediteqs $dataeditidt $dataeditlst $dataedittbl $dataeditscl 
+                                        $dataeditvar $dataupdatecmt $dataupdateeqs $dataupdateidt $dataupdatelst $dataupdatetbl 
+                                        $dataupdatescl $dataupdatevar $dataexistcmt $dataexisteqs $dataexistidt $dataexistlst 
+                                        $dataexisttbl $dataexistscl $dataexistvar $dataappendcmt $dataappendeqs $dataappendidt 
+                                        $dataappendlst $dataappendtbl $dataappendscl $dataappendvar $datacreatecmt $datacreateeqs 
+                                        $datacreateidt $datacreatelst $datacreatetbl $datacreatescl $datacreatevar $datadeletecmt 
+                                        $datadeleteeqs $datadeleteidt $datadeletelst $datadeletetbl $datadeletescl $datadeletevar 
+                                        $datarenamecmt $datarenameeqs $datarenameidt $datarenamelst $datarenametbl $datarenamescl 
+                                        $datarenamevar $datasearchcmt $datasearcheqs $datasearchidt $datasearchlst $datasearchtbl 
+                                        $datasearchscl $datasearchvar $dataduplicatecmt $dataduplicateeqs $dataduplicateidt 
+                                        $dataduplicatelst $dataduplicatetbl $dataduplicatescl $dataduplicatevar $datalistcmt 
+                                        $datalisteqs $datalistidt $datalistlst $datalisttbl $datalistscl $datalistvar $datacomparecmt 
+                                        $datacompareeqs $datacompareidt $datacomparelst $datacomparetbl $datacomparescl $datacomparevar 
+                                        $datalistsort $datadisplaygraph $dataprintgraph $dataeditcnf $datacalcvar $datacalclst $datarasvar 
+                                        $datascancmt $datascaneqs $datascanidt $datascanlst $datascantbl $datascanscl 
+                                        $datascanvar $datapatterncmt $datapatterneqs $datapatternidt $datapatternlst $datapatterntbl 
+                                        $datapatternscl $datapatternvar $excelgetcmt $excelgeteqs $excelgetidt $excelgetlst 
+                                        $excelgettbl $excelgetscl $excelgetvar $excelsetcmt $excelseteqs $excelsetidt 
+                                        $excelsetlst $excelsettbl $excelsetscl $excelsetvar $excelexecute $excelopen $excelnew 
+                                        $excelclose $excelprint $excelsave $excelsaveas $excelwrite $dsimportdb $statunitroot 
+                                        $datawidthvar $datandecvar $datamodevar $datastartvar $datawidthtbl $datawidthscl 
+                                        $datandecscl $viewwidth $viewwidth0 $viewndec $printobjtitle $printobjlec $printobjinfos 
+                                        $printobjdefcmt $printobjdefeqs $printobjdefidt $printobjdeflst $printobjdeftbl 
+                                        $printobjdefscl $printobjdefvar $printdest $printdestnew $printmulti $printnbdec 
+                                        $printlang $printtblfile $printtbl $printvar $viewtblfile $viewtbl $viewvar $viewbytbl 
+                                        $viewgr $printgrall $printgr $modelsimulate $modelsimulateparms $modelexchange 
+                                        $modelcompile $idtexecute $idtexecutevarfiles $idtexecutesclfiles $idtexecutetrace 
+                                        $eqsestimate $eqsstepwise $eqssetmethod $eqssetbloc $eqssetblock $eqssetsample 
+                                        $eqssetinstrs $eqssetcmt $reportexec $reportedit $prompt $minimize $maximize $sleep 
+                                        $printa2mappend $printfont $printtablefont $printtablebox $printtablecolor 
+                                        $printtablewidth $printtablebreak $printtablepage $printbackground $printgraphbox 
+                                        $printgraphbrush $printgraphsize $printgraphpage $printgraphtheme $printgraphband $printrtfhelp 
+                                        $printhtmlhelp $printrtftopic $printrtflevel $printrtftitle $printrtfcopyright 
+                                        $printparanum $printpageheader $printpagefooter $printorientation $printduplex 
+                                        $setprinter $printgiftranscolor $printgifbackcolor $printgifinterlaced $printgiftransparent $printgiffilled 
+                                        $printgiffont $printhtmlstrip $printhtmlstyle $ddeget $sysmovefile $syscopyfile 
+                                        $sysappendfile $sysdeletefile $a2mtohtml $a2mtomif $a2mtocsv $a2mtortf $a2mtoprinter
+                                        $graphdefault
+                     </Keywords>
+            <Keywords name="Words3"></Keywords>
+            <Keywords name="Words4"></Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="FOLDEROPEN" styleID="12" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="FOLDERCLOSE" styleID="13" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="KEYWORD1" styleID="5" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" />
+            <WordsStyle name="KEYWORD2" styleID="6" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="KEYWORD3" styleID="7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="KEYWORD4" styleID="8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="808000" bgColor="FFFF80" fontName="" fontStyle="0" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="DELIMINER1" styleID="14" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="DELIMINER2" styleID="15" fgColor="FF00FF" bgColor="FFFFFF" fontName="" fontStyle="0" />
+            <WordsStyle name="DELIMINER3" styleID="16" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>


### PR DESCRIPTION
fix #521

Note: because UDL (any version used by Notepad++) is based on old technology, [it is not possible to use regex expressions](https://community.notepad-plus-plus.org/topic/23532/creating-a-udl-with-regex-expressions) or to specify a character followed by a whitespace as a indicator for an IODE report comment.

The only way to use regular expressions is to install a plugin called [EnhanceAnyLexer](https://github.com/Ekopalypse/EnhanceAnyLexer) which, for security reason, we do not plan to install on our user PCs.