### PR TITLE
C API: moved attributes k_objs, db_parent and subset_instances from KDB to KDBTemplate

### DIFF
--- a/api/ascii/k_cccmt.cpp
+++ b/api/ascii/k_cccmt.cpp
@@ -122,7 +122,7 @@ bool KDBComments::load_asc(const std::string& filename)
                 {
                     char asc_filename[1024];
                     K_set_ext_asc(asc_filename, c_filename, COMMENTS);
-                    K_set_kdb_fullpath(this, (U_ch*) asc_filename);
+                    this->set_fullpath(asc_filename);
                 }
                 YY_close(yy);
                 return true;

--- a/api/ascii/k_cceqs.cpp
+++ b/api/ascii/k_cceqs.cpp
@@ -312,7 +312,7 @@ bool KDBEquations::load_asc(const std::string& filename)
                 {
                     char asc_filename[1024];
                     K_set_ext_asc(asc_filename, c_filename, EQUATIONS);
-                    K_set_kdb_fullpath(this, (U_ch*) asc_filename); // JMP 03/12/2022
+                    this->set_fullpath(asc_filename); // JMP 03/12/2022
                 }
                 YY_close(yy);
                 return true;

--- a/api/ascii/k_ccidt.cpp
+++ b/api/ascii/k_ccidt.cpp
@@ -65,7 +65,7 @@ bool KDBIdentities::load_asc(const std::string& filename)
     clear();  /* clear current KDB */
 
     /* READ FILE */
-    K_set_kdb_fullpath(this, (U_ch*) c_filename);
+    this->set_fullpath(c_filename);
     while(1) 
     {
         switch(YY_lex(yy)) 
@@ -75,7 +75,7 @@ bool KDBIdentities::load_asc(const std::string& filename)
                 {
                     char asc_filename[1024];
                     K_set_ext_asc(asc_filename, c_filename, IDENTITIES);
-                    K_set_kdb_fullpath(this, (U_ch*) asc_filename); // JMP 03/12/2022
+                    this->set_fullpath(asc_filename); // JMP 03/12/2022
                 }
                 YY_close(yy);
                 return true;

--- a/api/ascii/k_cclst.cpp
+++ b/api/ascii/k_cclst.cpp
@@ -122,7 +122,7 @@ bool KDBLists::load_asc(const std::string& filename)
     clear();  /* clear current KDB */
 
     /* READ FILE */
-    K_set_kdb_fullpath(this, (U_ch*) c_filename);
+    this->set_fullpath(c_filename);
     while(1) 
     {
         switch(YY_lex(yy)) 
@@ -132,7 +132,7 @@ bool KDBLists::load_asc(const std::string& filename)
                 {
                     char asc_filename[1024];
                     K_set_ext_asc(asc_filename, c_filename, LISTS);
-                    K_set_kdb_fullpath(this, (U_ch*) asc_filename);
+                    this->set_fullpath(asc_filename);
                 }
                 YY_close(yy);
                 return true;

--- a/api/ascii/k_ccscl.cpp
+++ b/api/ascii/k_ccscl.cpp
@@ -114,7 +114,7 @@ bool KDBScalars::load_asc(const std::string& filename)
     clear();  /* clear current KDB */
 
     /* READ FILE */ 
-    K_set_kdb_fullpath(this, (U_ch*) c_filename);
+    this->set_fullpath(c_filename);
     while(1) 
     {
         switch(YY_lex(yy)) 
@@ -124,7 +124,7 @@ bool KDBScalars::load_asc(const std::string& filename)
                 {
                     char asc_filename[1024];
                     K_set_ext_asc(asc_filename, c_filename, SCALARS);
-                    K_set_kdb_fullpath(this, (U_ch*) asc_filename);
+                    this->set_fullpath(asc_filename);
                 }            
                 YY_close(yy);
                 return true;

--- a/api/ascii/k_cctbl.cpp
+++ b/api/ascii/k_cctbl.cpp
@@ -136,7 +136,7 @@ static void read_div(Table* tbl, YYFILE* yy)
  *  Reads a Table line on a YY stream. Each line has as many Cells as the number 
  *  of columns in the table.
  *  
- *  @see https://iode.plan.be/doku.php?id=format_ascii_des_tableaux for the full syntax.
+ * for the full syntax.
  *
  *  Partial syntax of a TABLE LINE 
  *  -------------------------------
@@ -268,7 +268,7 @@ static int read_line(Table* tbl, YYFILE* yy)
 /**
  *  Reads on the stream yy the full definition of a Table.
  *  
- *  @see https://iode.plan.be/doku.php?id=format_ascii_des_tableaux for the full syntax.
+ * for the full syntax.
  *  
  *  @param [in]     yy  YYFILE*     stream to be read
  *  @return             Table*        new allocated table
@@ -372,7 +372,7 @@ static Table* read_tbl(YYFILE* yy)
 /**
  *  Loads Tables definition from an ASCII file into a new KDB of Tables.
  *  
- *  @see https://iode.plan.be/doku.php?id=format_ascii_des_tableaux for the full syntax.
+ * for the full syntax.
  *  
  *  Errors are displayed by a call to the function kerror().
  *  For each read Table, kmsg() is called to send a message to the user. 
@@ -418,7 +418,7 @@ bool KDBTables::load_asc(const std::string& filename)
     clear();  /* clear current KDB */
 
     /* READ FILE */
-    K_set_kdb_fullpath(this, (U_ch*) c_filename);
+    this->set_fullpath(c_filename);
     char asc_filename[1024];
     while(1) 
     {
@@ -428,7 +428,7 @@ bool KDBTables::load_asc(const std::string& filename)
                 if(cmpt) 
                 {
                     K_set_ext_asc(asc_filename, c_filename, TABLES);
-                    K_set_kdb_fullpath(this, (U_ch*) asc_filename); // JMP 03/12/2022
+                    this->set_fullpath(asc_filename); // JMP 03/12/2022
                 }
                 YY_close(yy);
                 return true;

--- a/api/ascii/k_ccvar.cpp
+++ b/api/ascii/k_ccvar.cpp
@@ -232,7 +232,7 @@ bool KDBVariables::load_asc(const std::string& filename)
     bool success = load_asc_type_ask(std::string(asc_filename), 0, 0);
 
     if(success)
-        K_set_kdb_fullpath(this, (U_ch*) asc_filename);
+        this->set_fullpath(asc_filename);
 
     return success;
 }

--- a/api/gsample/c_calc.cpp
+++ b/api/gsample/c_calc.cpp
@@ -5,13 +5,13 @@
  *  --------------------------------------
  *  
  *  This module calculates the values of table cells based on:
- *  - a list of files loaded in memory and stored in K_RWS[VARIABLES].
+ *  - a list of files loaded in memory and stored in global_ref_var.
  *  - a group of column definitions (COLS = GSample compiled by COL_cc(gsample))
  *      where each column defines:
  *          - the period(s) to be used for the calculations (1 or 2 periods)
  *          - an optional operation between the periods (ex growth rates)
- *          - the position in K_RWS[VARIABLES][...] of the (max 2) files to be used for the calculations: 
- *              1 for the WS, 2 for the file K_RWS[VARIABLES][0]...
+ *          - the position in global_ref_var[...] of the (max 2) files to be used for the calculations: 
+ *              1 for the WS, 2 for the file global_ref_var[0]...
  *          - an optional operation between the files (ex: diff in %)
  *  - the LEC formulas defined in the table cells 
  *  
@@ -64,17 +64,17 @@ static CLEC *COL_cp_clec(CLEC* clec)
 
 
 /**
- *  Links a CLEC. The VAR KDB file is K_RWS[VARIABLES][i - 1]. The Scalar KDB is the current workspace. 
+ *  Links a CLEC. The VAR KDB file is global_ref_var[i - 1]. The Scalar KDB is the current workspace. 
  *  
- *  @param [in] int     i       position of the KBD pointer in K_RWS[VARIABLES], starting at 1 for pos 0
- *  @param [in] CLEC*   clec    Compiled LEC to link with K_RWS[VARIABLES]]i - 1]
+ *  @param [in] int     i       position of the KBD pointer in global_ref_var, starting at 1 for pos 0
+ *  @param [in] CLEC*   clec    Compiled LEC to link with global_ref_var]i - 1]
  *  @return     int             0 on success, 
  *                              -1 on error. A message is sent to kmsg() if the file is not present.
  *  
  */
 static int COL_link(int i, CLEC* clec)
 {
-    KDBVariables* kdbv = (KDBVariables*) K_RWS[VARIABLES][i - 1];
+    KDBVariables* kdbv = (KDBVariables*) global_ref_var[i - 1];
     if(!kdbv) 
     {
         kmsg("File [%d] not present", i);
@@ -121,7 +121,7 @@ static int COL_calc(COL* cl, CLEC* clec, CLEC* dclec)
         if(dclec && COL_link(cl->cl_fnb[i], dclec)) 
             return(-1);
         
-        kdb = (KDBVariables*) K_RWS[VARIABLES][cl->cl_fnb[i] - 1];
+        kdb = (KDBVariables*) global_ref_var[cl->cl_fnb[i] - 1];
 
         for(j = 0 ; j < 2 ; j++) 
         {

--- a/api/gsample/gsample.h
+++ b/api/gsample/gsample.h
@@ -57,7 +57,7 @@ struct COL
     short   cl_opy;             // operator on periods => cl_per[0] cl_opy cl_per[1])
     Period  cl_per[2];          // period 1 , period 2
     short   cl_opf;             // operator on files => cl_fnb[0] cl_opf cl_fnb[1]
-    short   cl_fnb[2];          // position in K_RWS of file1 and file2 (starts at 1)
+    short   cl_fnb[2];          // position in global_ref_xxx of file1 and file2 (starts at 1)
     double  cl_val[2][2];       // computed values of the LEC formulas on periods / files => max 4 values see table below
     double  cl_res;             // computed value (v00 op_per v10) op_file (v01 op_per v11)
 

--- a/api/io/k_imain.cpp
+++ b/api/io/k_imain.cpp
@@ -269,7 +269,7 @@ err:
  */
 static int IMP_RuleImportCmt(char* trace, char* rule, char* ode, char* asc, int fmt, int lang)
 {
-    KDB* kdb;
+    KDBComments* kdb;
     ImportCmtFromFile* impdef;
 
     SCR_strip((unsigned char*) trace);
@@ -329,7 +329,7 @@ static int IMP_RuleImportCmt(char* trace, char* rule, char* ode, char* asc, int 
 static int IMP_RuleImportVar(char* trace, char* rule, char* ode, char* asc, char* from, char* to, int fmt)
 {
     Sample* smpl;
-    KDB* kdb;
+    KDBVariables* kdb;
     ImportVarFromFile* impdef;
 
     SCR_strip((unsigned char*) trace);

--- a/api/k_exec.cpp
+++ b/api/k_exec.cpp
@@ -408,7 +408,7 @@ static int KI_read_vars_db(KDBVariables* dbv, KDBVariables* dbv_tmp, char* sourc
 
         // allocate the VAR in dbv
         handle = (SWHDL) KV_alloc_var(vsmpl->nb_periods);
-        dbv->k_objs[name] = handle;
+        dbv->set_handle(name, handle);
 
         // copy the VAR from dbv_tmp to dbv
         memcpy(dbv->get_var_ptr(name, start), dbv_tmp->get_var_ptr(name, start_tmp), 
@@ -607,7 +607,7 @@ static int KI_read_scls_db(KDBScalars* dbs, KDBScalars* dbs_tmp, char* source_na
 
         // allocate the Scalar in dbs
         handle = (SWHDL) KS_alloc_scl();
-        dbs->k_objs[name] = handle;
+        dbs->set_handle(name, handle);
         
         // copy the scalar from dbs_tmp to dbs
         memcpy(dbs->get_obj(name), dbs_tmp->get_obj(name), sizeof(Scalar));

--- a/api/lec/k_lec.cpp
+++ b/api/lec/k_lec.cpp
@@ -3,11 +3,11 @@
  *
  * Functions implementing the interface between the LEC functions and the IODE KDB's.
  *  
- *      double *L_getvar(KDBVariables* kdb, int pos)  Retrieves a pointer to the first element of a VAR.
- *      double L_getscl(KDBScalars* kdb, int pos)   Retrieves a scalar value.
- *      Sample *L_getsmpl(KDB* kdb)             Retrieves the sample of a KDB.
- *      int L_findscl(KDBScalars* kdb, char *name)     Retrieves a scalar position.
- *      int L_findvar(KDBVariables* kdb, char* name)     Retrieves a variable position.
+ *      double *L_getvar(KDBVariables* kdb, int pos)    Retrieves a pointer to the first element of a VAR.
+ *      double L_getscl(KDBScalars* kdb, int pos)       Retrieves a scalar value.
+ *      Sample *L_getsmpl(KDBVariables* kdb)            Retrieves the sample of a KDB.
+ *      int L_findscl(KDBScalars* kdb, char *name)      Retrieves a scalar position.
+ *      int L_findvar(KDBVariables* kdb, char* name)    Retrieves a variable position.
  */
 
 #include "api/lec/lec.h"

--- a/api/objs/comments.h
+++ b/api/objs/comments.h
@@ -45,6 +45,19 @@ struct KDBComments : public KDBTemplate<char>
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBComments from(false);    
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found)
+    {
+        KDBComments from(false);
+        return KDB::copy_from_file(from, file, objs_names, v_found);
+    }
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -57,6 +70,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBComments> global_ws_cmt = std::make_unique<KDBComments>(true);
+inline std::array<KDBComments*, 5> global_ref_cmt = { nullptr };
 
 /*------------------------- FUNCS ----------------------------*/
 

--- a/api/objs/compare.h
+++ b/api/objs/compare.h
@@ -12,7 +12,7 @@
 inline double K_CMP_EPS = 1e-7;            // Threshold for VAR comparisons 
 
 /* k_cmp.c */
-int K_cmp(char *,KDB *,KDB *);
+int K_cmp(char*, KDB*, KDB*);
 int K_cmp_eqs(Equation* eq1, Equation* eq2, char* name);
 int K_cmp_scl(Scalar* scl1, Scalar* scl2);
 int K_cmp_tbl(Table* tbl1, Table* tbl2);

--- a/api/objs/equations.h
+++ b/api/objs/equations.h
@@ -584,6 +584,19 @@ struct KDBEquations : public KDBTemplate<Equation>
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBEquations from(false);
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found)
+    {
+        KDBEquations from(false);
+        return KDB::copy_from_file(from, file, objs_names, v_found);
+    }
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -596,6 +609,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBEquations> global_ws_eqs = std::make_unique<KDBEquations>(true);
+inline std::array<KDBEquations*, 5> global_ref_eqs = { nullptr };
 
 /*----------------------- FUNCS ----------------------------*/
 

--- a/api/objs/identities.h
+++ b/api/objs/identities.h
@@ -130,6 +130,19 @@ public:
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBIdentities from(false);
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found)
+    {
+        KDBIdentities from(false);
+        return KDB::copy_from_file(from, file, objs_names, v_found);
+    }
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -142,6 +155,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBIdentities> global_ws_idt = std::make_unique<KDBIdentities>(true);
+inline std::array<KDBIdentities*, 5> global_ref_idt = { nullptr };
 
 /*----------------------- FUNCTIONS ----------------------------*/
 

--- a/api/objs/k_cmp.cpp
+++ b/api/objs/k_cmp.cpp
@@ -227,7 +227,7 @@ int K_cmp(char* name, KDB* kdb1, KDB* kdb2)
     int res=0;
 
     if(kdb1->k_type != kdb2->k_type) 
-        return(-1);
+        return -1;
 
     SWHDL handle_1 = kdb1->get_handle(name);
     SWHDL handle_2 = kdb2->get_handle(name);

--- a/api/objs/k_cmt.cpp
+++ b/api/objs/k_cmt.cpp
@@ -98,7 +98,7 @@ bool KDBComments::print_obj_def(const std::string& name)
 
 void KDBComments::update_reference_db()
 {
-    if(K_RWS[this->k_type][0]) 
-        delete K_RWS[this->k_type][0];
-    K_RWS[this->k_type][0] = new KDBComments(this, "*", false);      
+    if(global_ref_cmt[0]) 
+        delete global_ref_cmt[0];
+    global_ref_cmt[0] = new KDBComments(this, "*", false);      
 }

--- a/api/objs/k_eqs.cpp
+++ b/api/objs/k_eqs.cpp
@@ -384,9 +384,9 @@ bool KDBEquations::print_obj_def(const std::string& name)
 
 void KDBEquations::update_reference_db()
 {
-    if(K_RWS[this->k_type][0]) 
-        delete K_RWS[this->k_type][0];
-    K_RWS[this->k_type][0] = new KDBEquations(this, "*", false);      
+    if(global_ref_eqs[0]) 
+        delete global_ref_eqs[0];
+    global_ref_eqs[0] = new KDBEquations(this, "*", false);      
 }
 
 /**

--- a/api/objs/k_idt.cpp
+++ b/api/objs/k_idt.cpp
@@ -232,7 +232,7 @@ bool KDBIdentities::print_obj_def(const std::string& name)
 
 void KDBIdentities::update_reference_db()
 {
-    if(K_RWS[this->k_type][0]) 
-        delete K_RWS[this->k_type][0];
-    K_RWS[this->k_type][0] = new KDBIdentities(this, "*", false);      
+    if(global_ref_idt[0]) 
+        delete global_ref_idt[0];
+    global_ref_idt[0] = new KDBIdentities(this, "*", false);      
 }

--- a/api/objs/k_lst.cpp
+++ b/api/objs/k_lst.cpp
@@ -442,7 +442,7 @@ bool KDBLists::print_obj_def(const std::string& name)
 
 void KDBLists::update_reference_db()
 {
-    if(K_RWS[this->k_type][0]) 
-        delete K_RWS[this->k_type][0];
-    K_RWS[this->k_type][0] = new KDBLists(this, "*", false);      
+    if(global_ref_lst[0]) 
+        delete global_ref_lst[0];
+    global_ref_lst[0] = new KDBLists(this, "*", false);      
 }

--- a/api/objs/k_scl.cpp
+++ b/api/objs/k_scl.cpp
@@ -122,7 +122,7 @@ bool KDBScalars::print_obj_def(const std::string& name)
 
 void KDBScalars::update_reference_db()
 {
-    if(K_RWS[this->k_type][0]) 
-        delete K_RWS[this->k_type][0];
-    K_RWS[this->k_type][0] = new KDBScalars(this, "*", false);      
+    if(global_ref_scl[0]) 
+        delete global_ref_scl[0];
+    global_ref_scl[0] = new KDBScalars(this, "*", false);      
 }

--- a/api/objs/k_tbl.cpp
+++ b/api/objs/k_tbl.cpp
@@ -888,7 +888,7 @@ bool KDBTables::print_obj_def(const std::string& name)
 
 void KDBTables::update_reference_db()
 {
-    if(K_RWS[this->k_type][0]) 
-        delete K_RWS[this->k_type][0];
-    K_RWS[this->k_type][0] = new KDBTables(this, "*", false);      
+    if(global_ref_tbl[0]) 
+        delete global_ref_tbl[0];
+    global_ref_tbl[0] = new KDBTables(this, "*", false);      
 }

--- a/api/objs/k_ws.cpp
+++ b/api/objs/k_ws.cpp
@@ -5,10 +5,10 @@
  *
  * Globals
  * -------
- * K_RWS = table of max 5 KDB* per object type, used for ws comparison, for printing...
+ * global_ref_var = table of max 5 KDB* per object type, used for ws comparison, for printing...
  * Only used for Vars at the moment (print vars, print tables with comparison)
- *     - K_RWS[6][0] = first WS of VARS for comparison (ws)  
- *     - K_RWS[6][1] = second WS of VARS for comparison (file 1)
+ *     - global_ref_var[6][0] = first WS of VARS for comparison (ws)  
+ *     - global_ref_var[6][1] = second WS of VARS for comparison (file 1)
  *     - ...
  *
  * 
@@ -37,8 +37,23 @@
  */
 void K_init_ws(int ws)
 {
-    for(int i = 0; i < IODE_NB_TYPES; i++) 
-        if(ws) K_cat(get_global_db(i), I_DEFAULT_FILENAME);
+    if(ws == 0) 
+        return;
+
+    for(int i = 0; i < IODE_NB_TYPES; i++)
+    {
+        try
+        {
+            get_global_db(i).merge_from(I_DEFAULT_FILENAME);
+        }
+        catch(const std::exception& e)
+        {
+            std::string error_msg = "Error initializing the global " + v_iode_types[i] + " database from file '";
+            error_msg += std::string(I_DEFAULT_FILENAME) + "':\n\t";
+            error_msg += e.what();
+            kwarning(error_msg.c_str());
+        }
+    } 
 }
 
 /**
@@ -46,15 +61,30 @@ void K_init_ws(int ws)
  */
 void K_end_ws(int ws)
 {
+    if(ws == 0) 
+        return;
+
     for(int i = 0; i < IODE_NB_TYPES; i++)
-        if(ws) get_global_db(i)->save_binary(I_DEFAULT_FILENAME, false);
+    {
+        try
+        {
+            get_global_db(i).save_binary(I_DEFAULT_FILENAME, false);
+        }
+        catch(const std::exception& e)
+        {
+            std::string error_msg = "Error saving the global " + v_iode_types[i] + " database to file '";
+            error_msg += std::string(I_DEFAULT_FILENAME) + "':\n\t";
+            error_msg += e.what();
+            kwarning(error_msg.c_str());
+        }
+    }
 }
 
 
 /**
  *  Loads a VAR file for use in GSample (print tables and graphs).
- *  Stores its KDB pointer in K_RWS[VARIABLES][ref - 1]. 
- *  If filename is NULL, frees K_RWS[VARIABLES][ref - 1].
+ *  Stores its KDB pointer in global_ref_var[ref - 1]. 
+ *  If filename is NULL, frees global_ref_var[ref - 1].
  *  
  *  Example: the files [1], [2] and [3] used in a GSample "2000Y1[1,2,3]" are loaded:
  *      - [1] == current content of the VAR workspace
@@ -64,7 +94,7 @@ void K_end_ws(int ws)
  *  @param [in] int     ref         reference number that will be used in GSample. 
  *                                  Restriction : 2 <= ref <= 5
  *  @param [in] char*   filename    file to load. 
- *                                  If NULL, frees K_RWS[VARIABLES][ref-1]
+ *                                  If NULL, frees global_ref_var[ref-1]
  *  @return     int                 0 on success, -1 on error (file not found, ref out of range...)
  *  
  */
@@ -80,23 +110,23 @@ int K_load_RWS(int ref, char *filename)
     
     if(filename == NULL) 
     {
-        if(K_RWS[VARIABLES][ref - 1])
-            delete K_RWS[VARIABLES][ref - 1];
-        K_RWS[VARIABLES][ref - 1] = nullptr;
+        if(global_ref_var[ref - 1])
+            delete global_ref_var[ref - 1];
+        global_ref_var[ref - 1] = nullptr;
         std::string msg = "Filepath for the Variables 'reference file' number " + 
                           std::to_string(ref) + " is empty";
         kwarning(msg.c_str());
         return 0;
     }
 
-    if(K_RWS[VARIABLES][ref - 1])
-        delete K_RWS[VARIABLES][ref - 1];
-    K_RWS[VARIABLES][ref - 1] = new KDBVariables(false);
-    bool success = K_RWS[VARIABLES][ref - 1]->load(std::string(filename));
+    if(global_ref_var[ref - 1])
+        delete global_ref_var[ref - 1];
+    global_ref_var[ref - 1] = new KDBVariables(false);
+    bool success = global_ref_var[ref - 1]->load(std::string(filename));
     if(!success)
     {
-        delete K_RWS[VARIABLES][ref - 1];
-        K_RWS[VARIABLES][ref - 1] = nullptr;
+        delete global_ref_var[ref - 1];
+        global_ref_var[ref - 1] = nullptr;
         std::string msg = "Error loading the variables file '";
         msg += std::string(filename) + "' required to compute the table";
         kwarning(msg.c_str());

--- a/api/objs/lists.h
+++ b/api/objs/lists.h
@@ -52,6 +52,19 @@ struct KDBLists : public KDBTemplate<char>
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBLists from(false);
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found)
+    {
+        KDBLists from(false);
+        return KDB::copy_from_file(from, file, objs_names, v_found);
+    }
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -64,6 +77,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBLists> global_ws_lst = std::make_unique<KDBLists>(true);
+inline std::array<KDBLists*, 5> global_ref_lst = { nullptr };
 
 /*----------------------- FUNCS ----------------------------*/
 

--- a/api/objs/macros.h
+++ b/api/objs/macros.h
@@ -4,21 +4,36 @@
 #include "api/objs/kdb.h"
 
 
-struct KDBMacros : public KDB
+struct KDBMacros : public KDBTemplate<char>
 {
     // global or standalone database
-    KDBMacros(const bool is_global) : KDB(OBJECTS, is_global) {}
+    KDBMacros(const bool is_global) : KDBTemplate(OBJECTS, is_global) {}
 
     // subset (shallow or deep copy) 
     KDBMacros(KDBMacros* db_parent, const std::string& pattern, const bool copy) 
-        : KDB(db_parent, pattern, copy) {}
+        : KDBTemplate(db_parent, pattern, copy) {}
 
     // copy constructor
-    KDBMacros(const KDBMacros& other): KDB(other) {}
+    KDBMacros(const KDBMacros& other): KDBTemplate(other) {}
 
     char* get_macro(const SWHDL handle) const;
     char* get_macro(const std::string& name) const;
     bool set_macro(const std::string& name, char* value, const int length);
+
+    char* get_obj(const SWHDL handle) const override
+    {
+        return get_macro(handle);
+    }
+
+    char* get_obj(const std::string& name) const override
+    {
+        return get_macro(name);
+    }
+
+    bool set_obj(const std::string& name, const char* value) override
+    {
+        return set_macro(name, (char*) value, (int) strlen(value));
+    }
 
     bool load_asc(const std::string& filename) override;
     bool save_asc(const std::string& filename) override;

--- a/api/objs/objs.h
+++ b/api/objs/objs.h
@@ -15,12 +15,12 @@ inline char K_LABELX[] = "KOBJS 564A\032";  // Version 3
 inline char K_LABEL[]  = "KOBJS 564A\032";  // Version 0 = Current version = Version 3
 
 /* k_objs.c */
-int K_upd_eqs(char* name, char* lec, char* cmt, int method, Sample* smpl, char* instr, char* blk, float* tests, int date);
+int K_upd_eqs(char* name, char* lec, char* cmt, int method, Sample* smpl, 
+              char* instr, char* blk, float* tests, int date);
 int K_upd_tbl(char* name, char* arg);
 
 /* k_objvers.c */
 int K_calcvers(char *);
-void K_setvers(KDB* kdb, int i, int vers);
 
 /* k_objfile.c */
 char *K_add_ext(char* filename, char* ext);
@@ -29,10 +29,6 @@ int K_has_ext(char* filename);
 char *K_set_ext(char *,char *,int );
 char *K_set_ext_asc(char *,char *,int );
 void K_strip(char *);
-int K_merge(KDB *,KDB *,int );
-int K_merge_del(KDB *,KDB *,int );
-int K_copy(KDB *,int ,char **,int ,char **,Sample *);
-int K_cat(KDB *,char *);
 int K_set_backup_on_save(int take_backup);
 int K_get_backup_on_save();
 int K_backup(char *);

--- a/api/objs/scalars.h
+++ b/api/objs/scalars.h
@@ -112,6 +112,19 @@ struct KDBScalars : public KDBTemplate<Scalar>
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBScalars from(false);  
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found)
+    {
+        KDBScalars from(false);
+        return KDB::copy_from_file(from, file, objs_names, v_found);
+    }
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -124,6 +137,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBScalars> global_ws_scl = std::make_unique<KDBScalars>(true);
+inline std::array<KDBScalars*, 5> global_ref_scl = { nullptr };
 
 /*----------------------- FUNCTIONS ----------------------------*/
 

--- a/api/objs/tables.h
+++ b/api/objs/tables.h
@@ -946,6 +946,19 @@ struct KDBTables : public KDBTemplate<Table>
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBTables from(false);
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found)
+    {
+        KDBTables from(false);
+        return KDB::copy_from_file(from, file, objs_names, v_found);
+    }
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -958,6 +971,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBTables> global_ws_tbl = std::make_unique<KDBTables>(true);
+inline std::array<KDBTables*, 5> global_ref_tbl = { nullptr };
 
 /*----------------------- FUNCS ----------------------------*/
 

--- a/api/objs/variables.h
+++ b/api/objs/variables.h
@@ -178,12 +178,6 @@ public:
     std::vector<float> get_list_periods_as_float(const std::string& from = "", 
         const std::string& to = "") const;
 
-    void copy_from(const std::string& input_file, const std::string& from = "", 
-        const std::string& to = "", const std::string objects_names = "");
-    
-    void copy_from(const std::string& input_file, const Period* from = nullptr, 
-        const Period* to = nullptr, const std::string& objects_names = "");
-
     /**
      *  Syntax: $WsExtrapolate [method] from to [variable list]
      *          where 
@@ -198,7 +192,7 @@ public:
      *              from, to := periods
      *
      *  
-     *  @see https://iode.plan.be/doku.php?id=wsextrapolate
+     *
      */
     void extrapolate(const VariablesInitialization method, const std::string& from, 
         const std::string& to, const std::string& variables_list="");
@@ -217,7 +211,7 @@ public:
      *              from, to := periods
      *
      *  
-     *  @see https://iode.plan.be/doku.php?id=wsextrapolate
+     *
      */
     void extrapolate(const VariablesInitialization method, const Period& from, 
         const Period& to, const std::string& variables_list="");
@@ -226,7 +220,7 @@ public:
     /**
      * @brief $WsSeasAdj Filename VarList Eps
      * 
-     * @see https://iode.plan.be/doku.php?id=wsseasonadj and
+     * and
      *      https://iode.plan.be/doku.php?id=wsseasadj 
      */
     void seasonal_adjustment(std::string& input_file, const std::string& series, const double eps_test);
@@ -240,7 +234,7 @@ public:
      *        $WsTrendStd VarFilename Lambda series1 series2 ...
      *        
      * 
-     * @see https://iode.plan.be/doku.php?id=wstrend and
+     * and
      *      https://iode.plan.be/doku.php?id=wstrendstd 
      */
     void trend_correction(std::string& input_file, const double lambda, const std::string& series, const bool log);
@@ -254,6 +248,21 @@ public:
 
     bool print_obj_def(const std::string& name) override;
 
+    void merge_from(const std::string& input_file) override
+    {
+        KDBVariables from(false);
+        KDB::merge_from(from, input_file);
+    }
+
+    bool copy_from(const std::vector<std::string>& input_files, const std::string& from, 
+        const std::string& to, const std::string& objects_names);
+    
+    bool copy_from_file(const std::string& file, const std::string& objs_names, 
+        std::set<std::string>& v_found, const Sample* copy_sample = nullptr);
+
+    bool copy_from(const std::string& input_files, const std::string& from, 
+        const std::string& to, const std::string& objects_names);
+
 private:
     bool grep_obj(const std::string& name, const SWHDL handle, 
         const std::string& pattern, const bool ecase, const bool forms, 
@@ -266,6 +275,7 @@ private:
 // unique_ptr -> automatic memory management
 //            -> no need to delete KDB workspaces manually
 inline std::unique_ptr<KDBVariables> global_ws_var = std::make_unique<KDBVariables>(true);
+inline std::array<KDBVariables*, 5> global_ref_var = { nullptr };
 
 /*----------------------- FUNCS ----------------------------*/
 

--- a/api/print/k_graph.cpp
+++ b/api/print/k_graph.cpp
@@ -117,10 +117,12 @@ int T_GraphEnd()
 /**
  *  Generates one graph in A2M format from a Table struct and a GSample.
  *  
- *  @param [in] Table*    tbl     source Table
+ *  @param [in] Table*  tbl     source Table
  *  @param [in] char*   gsmpl   GSample definition
- *  @param [in] int     mode    0 for view mode, not null for print mode (generates A2M RTF topic)
- *  @return     int             0 on success, -1 on error (more than 2 cols in tbl or one of the ref files is not in K_RWS)
+ *  @param [in] int     mode    0 for view mode, not null for print mode 
+ *                              (generates A2M RTF topic)
+ *  @return     int             0 on success, -1 on error (more than 2 cols in tbl 
+ *                              or one of the ref files is not in global_ref_xxx)
  */
 int T_graph_tbl_1(Table *tbl, char *gsmpl, int mode)
 {

--- a/api/print/k_print.cpp
+++ b/api/print/k_print.cpp
@@ -275,7 +275,7 @@ int T_print_line(Table* tbl, int i, COLS* cls)
  *  Retrieves the filenames used in the COLS (from GSample) needed to print the special table line TABLE_LINE_FILES. 
  *   
  *  @param [in] COLS*   cls     list of columns (from GSample)
- *  @return     char**          NULL if one of the ref files is not loaded in K_RWS
+ *  @return     char**          NULL if one of the ref files is not loaded in global_ref_xxx
  *                              table of filenames in the form "[<file number>] <filename>" if all files are in mem
  *  
  */
@@ -301,7 +301,7 @@ char **T_find_files(COLS* cls)
         if(files[i] == 0) 
             continue;
         
-        kdb = K_RWS[VARIABLES][i - 1];
+        kdb = global_ref_var[i - 1];
         if(!kdb) 
         {
             std::string error_msg = "File " + std::to_string(i) + " not present";

--- a/api/report/commands/b_file.cpp
+++ b/api/report/commands/b_file.cpp
@@ -27,7 +27,7 @@
  *  
  *       $FileCopy<type> source_file dest_file
  *
- *  @see https://iode.plan.be/doku.php?id=filecopy for details
+ * for details
  *  
  *  @params See b_data.c for details
  *  @return int     0 on success, -1 on error (file not found, syntax error...)
@@ -90,7 +90,7 @@ fin:
  *  
  *      $FileRename<type> source_file dest_file
  *
- *  @see https://iode.plan.be/doku.php?id=filerename for details
+ * for details
  *  
  *  @params See b_data.c for details
  *  @return int     0 on success, -1 on error (file not found, syntax error...)
@@ -154,7 +154,7 @@ static int wrapper_B_unlink_1(char* arg, void *type)
  *  
  *      $FileDelete<type> filename [filename...]
  *  
- *  @see https://iode.plan.be/doku.php?id=filedelete for details
+ * for details
  *  
  *  @params see b_data.c 
  *  @return int 0 always 

--- a/api/report/commands/b_fsys.cpp
+++ b/api/report/commands/b_fsys.cpp
@@ -24,7 +24,7 @@
  *  
  *  Syntax: $SysMoveFile filein fileout
  *  
- *  @see https://iode.plan.be/doku.php?id=sysmovefile
+ *
  *  
  *  @params See b_data.c for details
  *  @return int     0 on success, -1 on error (file not found, syntax error...)
@@ -56,7 +56,7 @@ fin:
 /**
  *  Syntax: $SysCopyFile filein fileout
  *  
- *  @see https://iode.plan.be/doku.php?id=syscopyfile
+ *
  */
 int B_SysCopy(char* arg, int unused) 
 {
@@ -84,7 +84,7 @@ fin:
 /**
  *  Syntax: $SysAppendFile filein fileout
  *  
- *  @see https://iode.plan.be/doku.php?id=sysappendfile
+ *
  */
 int B_SysAppend(char* arg, int unused) 
 {
@@ -112,7 +112,7 @@ fin:
 /**
  *  Syntax: $SysDeleteFile file1 file2 ...
  *  
- *  @see https://iode.plan.be/doku.php?id=sysdeletefile
+ *
  */
 int B_SysDelete(char* arg, int unused) 
 {
@@ -177,7 +177,7 @@ fin:
 /**
  *  Syntax: $SysOemToUTF8 inputfile outputfile
  *  
- *  @see https://iode.plan.be/doku.php?id=sysoemtoutf8
+ *
  */
 int B_SysOemToUTF8(char *arg, int unused)
 {
@@ -188,7 +188,7 @@ int B_SysOemToUTF8(char *arg, int unused)
 /**
  *  Syntax: $SysAnsiToUTF8 inputfile outputfile
  *  
- *  @see https://iode.plan.be/doku.php?id=sysansitoutf8
+ *
  */
 int B_SysAnsiToUTF8(char *arg, int unused)
 {
@@ -256,7 +256,7 @@ fin:
 /**
  *  Syntax: $SysAnsiToOem inputfile outputfile
  *  
- *  @see https://iode.plan.be/doku.php?id=sysansitooem
+ *
  */
 int B_SysAnsiToOem(char *arg, int unused)
 {
@@ -266,7 +266,7 @@ int B_SysAnsiToOem(char *arg, int unused)
 /**
  *  Syntax: $SysOemToAnsi inputfile outputfile
  *  
- *  @see https://iode.plan.be/doku.php?id=sysoemtoansi
+ *
  */
 int B_SysOemToAnsi(char *arg, int unused)
 {

--- a/api/report/commands/b_htol.cpp
+++ b/api/report/commands/b_htol.cpp
@@ -306,7 +306,7 @@ done:
 /**
  *  Syntax: $WsHtoLLast Filename VarList
  *  
- *  @see https://iode.plan.be/doku.php?id=WsHtoLLast
+ *
  */
 int B_WsHtoLLast(char* arg, int unused)
 {
@@ -317,7 +317,7 @@ int B_WsHtoLLast(char* arg, int unused)
 /**
  *  Syntax: $WsHtoLMean Filename VarList
  *  
- *  @see https://iode.plan.be/doku.php?id=WsHtoLMean
+ *
  */
 int B_WsHtoLMean(char* arg, int unused)
 {
@@ -328,7 +328,7 @@ int B_WsHtoLMean(char* arg, int unused)
 /**
  *  Syntax: $WsHtoLSum Filename VarList
  *  
- *  @see https://iode.plan.be/doku.php?id=WsHtoLSum
+ *
  */
 int B_WsHtoLSum(char* arg, int unused)
 {

--- a/api/report/commands/b_idt.cpp
+++ b/api/report/commands/b_idt.cpp
@@ -28,7 +28,7 @@
  *  
  *  Syntax: $IdtExecute period_from period_to [idt1 idt2...]
  *  
- *  @see https://iode.plan.be/doku.php?id=idtexecute
+ *
  *  
  *  At the end of the function, the VarFiles and SclFiles defined by calls to B_IdtExecuteVarFiles() and
  *  B_IdtExecuteSclFiles() are reset to NULL.
@@ -82,7 +82,7 @@ int B_IdtExecute(char* arg, int unused)
  *  At the end of the functions, KEXEC_VFILES and KEXEC_SFILES are reset to NULL.
  *  The resulting variables are copied into global_ws_var.
  *  
- *  @see https://iode.plan.be/doku.php?id=idtexecute
+ *
  *  
  *  @param   [in]   Sample* smpl    Sample on which the identities must be calculated.
  *  @param   [in]   char**  idts    list of identity names or NULL to execute all the idts present in global_ws_idt.
@@ -150,7 +150,7 @@ int B_IdtExecuteIdts(Sample* smpl, char** c_idts)
  *  
  *  Syntax: $IdtExecuteVarFiles file1 [file2 ...]
  *  
- *  @see https://iode.plan.be/doku.php?id=idtexecuteVarFiles
+ *
  *  
  *  @params See b_data.c for details on arg syntax
  *  
@@ -171,7 +171,7 @@ int B_IdtExecuteVarFiles(char* arg, int unused)
  *  
  *  Syntax: $IdtExecuteSclFiles file1 [file2 ...]
  *  
- *  @see https://iode.plan.be/doku.php?id=idtexecuteSclFiles
+ *
  *  
  *  @params See b_data.c for details on arg syntax
  *  
@@ -193,7 +193,7 @@ int B_IdtExecuteSclFiles(char* arg, int unused)
  *  
  *  Syntax:  $IdtExecuteTrace {Yes | No}
  *  
- *  @see https://iode.plan.be/doku.php?id=idtexecuteTrace
+ *
  *  
  *  @params See b_data.c for details on arg syntax
  *  

--- a/api/report/commands/b_ltoh.cpp
+++ b/api/report/commands/b_ltoh.cpp
@@ -435,7 +435,7 @@ done:
  *         C stands fot Cubic Spliness
  *         S for interpolation by Steps
  *  
- *  @see https://iode.plan.be/doku.php?id=WsLtoHStock
+ *
  */
 int B_WsLtoHStock(char* arg, int unused)
 {
@@ -450,7 +450,7 @@ int B_WsLtoHStock(char* arg, int unused)
  *         C stands fot Cubic Splines
  *         S for interpolation by Steps
  *  
- *  @see https://iode.plan.be/doku.php?id=WsLtoHFlow
+ *
  */
 int B_WsLtoHFlow(char* arg, int unused)
 {

--- a/api/report/commands/b_model.cpp
+++ b/api/report/commands/b_model.cpp
@@ -76,7 +76,7 @@ static int B_ModelSimulateEqs(Sample* smpl, char** c_eqs)
 /**
  *  Syntax: $ModelSimulate per_from per_to equation_list
  *  
- *  @see https://iode.plan.be/doku.php?id=modelsimulate
+ *
  */
 int B_ModelSimulate(char *const_arg, int unused)
 {
@@ -125,7 +125,7 @@ err:
  *              eps  := convergence threshold
  *              0.1 <= relax <= 1.0
  *          
- *  @see https://iode.plan.be/doku.php?id=modelsimulateparms
+ *
  */
 int B_ModelSimulateParms(char* arg, int unused)
 {
@@ -168,7 +168,7 @@ fin :
  *           where eqname1, eqname2 are equation names (thus also endogenous vars)
  *                 varname1, varname2 are exogenous variables
  *  
- *  @see https://iode.plan.be/doku.php?id=modelexchange
+ *
  */
 int B_ModelExchange(char* const_arg, int unused)
 {
@@ -224,7 +224,7 @@ int KE_compile(KDBEquations* dbe)
 /**
  *  Syntax: $ModelCompile [eqname1, eqname2, ... ]
  *  
- *  @see https://iode.plan.be/doku.php?id=modelsimulate
+ *
  */
 int B_ModelCompile(char* arg, int unused)
 {
@@ -257,7 +257,7 @@ int B_ModelCompile(char* arg, int unused)
 /**
  *  Syntax: $ModelCalcSCC nbtris prename intername postname [eqs]
  *  
- *  @see https://iode.plan.be/doku.php?id=ModelCalcSCC
+ *
  */
 int B_ModelCalcSCC(char *const_arg, int unused)
 {
@@ -308,7 +308,7 @@ int B_ModelCalcSCC(char *const_arg, int unused)
  *  
  *  Syntax: $ModelSimulateSCC from to pre inter post
  *  
- *  @see https://iode.plan.be/doku.php?id=ModelSimulateSCC
+ *
  */
 int B_ModelSimulateSCC(char *const_arg, int unused)
 {
@@ -490,7 +490,7 @@ static int B_CreateVarFromVecOfInts(char *name, int *vec)
  *  
  *  Syntax: $ModelSimulateSaveNiters varname
  *  
- *  @see https://iode.plan.be/doku.php?id=ModelSimulateSaveNIters
+ *
  */
 int B_ModelSimulateSaveNIters(char *arg, int unused)
 {
@@ -503,7 +503,7 @@ int B_ModelSimulateSaveNIters(char *arg, int unused)
  *  
  *  Syntax: $ModelSimulateSaveNorms varname
  *  
- *  @see https://iode.plan.be/doku.php?id=ModelSimulateSaveNorms
+ *
  */
 int B_ModelSimulateSaveNorms(char *arg, int unused)
 {

--- a/api/report/commands/b_xode.cpp
+++ b/api/report/commands/b_xode.cpp
@@ -29,7 +29,7 @@
  *      language =  {E,F,D}
  *      trace = debug file (optional)
  *  
- *  @see https://iode.plan.be/doku.php?id=fileimportcmt
+ *
  */
 int B_FileImportCmt(char* arg, int unused)
 {
@@ -78,7 +78,7 @@ fin:
  *      language =  {E,F,D}
  *      trace = debug file (optional)
  *  
- *  @see https://iode.plan.be/doku.php?id=fileimportvar
+ *
  */
 int B_FileImportVar(char* arg, int unused)
 {

--- a/api/report/engine/b_rep_cmds.cpp
+++ b/api/report/engine/b_rep_cmds.cpp
@@ -78,8 +78,6 @@ extern "C" int  SCR_sleep(int);
 
 
 // $vseps <seps> 
-// @see https://iode.plan.be/doku.php?id=vseps
-
 int RP_vseps(char* seps, int unused)  
 {
     if(seps == 0 || strlen(seps) == 0) seps = ";, ";

--- a/api/report/engine/b_rep_engine.cpp
+++ b/api/report/engine/b_rep_engine.cpp
@@ -698,7 +698,7 @@ int RP_evaltime()
     if(RP_PER.year == 0) 
         return(0);
     
-    KDB* kdb_var = global_ws_var.get();
+    KDBVariables* kdb_var = global_ws_var.get();
     if(!kdb_var)
         return 0;
     Sample* sample = kdb_var->sample;

--- a/api/report/undoc/b_view.cpp
+++ b/api/report/undoc/b_view.cpp
@@ -373,14 +373,14 @@ int B_ViewTblFile(char* arg, int unused)
             goto err;
         }
 
-        if(K_RWS[VARIABLES][ref - 1])
-            delete K_RWS[VARIABLES][ref - 1];
-        K_RWS[VARIABLES][ref - 1] = new KDBVariables(false);
-        success = K_RWS[VARIABLES][ref - 1]->load(std::string((char*) args[1]));
+        if(global_ref_var[ref - 1])
+            delete global_ref_var[ref - 1];
+        global_ref_var[ref - 1] = new KDBVariables(false);
+        success = global_ref_var[ref - 1]->load(std::string((char*) args[1]));
         if(!success) 
         {
-            delete K_RWS[VARIABLES][ref - 1];
-            K_RWS[VARIABLES][ref - 1] = nullptr;
+            delete global_ref_var[ref - 1];
+            global_ref_var[ref - 1] = nullptr;
             std::string msg = "Error loading the variables file '";
             msg += std::string((char*) args[1]) + "'";
             kwarning(msg.c_str());
@@ -400,9 +400,9 @@ int B_ViewTblEnd()
 {
     for(int i = 1; i < 5; i++) 
     {
-        if(K_RWS[VARIABLES][i])
-            delete K_RWS[VARIABLES][i];
-        K_RWS[VARIABLES][i] = nullptr;
+        if(global_ref_var[i])
+            delete global_ref_var[i];
+        global_ref_var[i] = nullptr;
     }
     
     ODE_VIEW = 0;

--- a/api/simulation/k_sim_main.cpp
+++ b/api/simulation/k_sim_main.cpp
@@ -776,18 +776,17 @@ double CSimulation::K_calc_clec(int eqnb, int t, int varnb, int msg)
  */
 void CSimulation::K_lstorder_1(char* lstname, int eq1, int eqn)
 {
-    U_ch 	        **lst = 0,                     
-                    **tbl_todel;
-    U_ch            *lst_todel,
-                    buf[256];
-    int   	        i, 
-                    nlst = 0, 
-                    nb = eqn - eq1 + 1,  
-                    maxl = 1000;
+    U_ch** lst = NULL;                     
+    U_ch** tbl_todel = NULL;
+    U_ch* lst_todel = NULL;
+    U_ch buf[256];
+    int i = 0; 
+    int nlst = 0; 
+    int nb = eqn - eq1 + 1;  
+    int maxl = 1000;
 
-    // Détruit la liste cible et les sous-listes
+    // delete the list 'lstname' and all sub-lists
     sprintf((char*) buf, "%s*", lstname);
-    //B_DataDelete(buf, LISTS); // Old version usign B_*() fns
     lst_todel = (unsigned char*) K_expand(LISTS, NULL, (char*) buf, '*');
     if(lst_todel) 
     {

--- a/api/time/sample.h
+++ b/api/time/sample.h
@@ -104,7 +104,7 @@ public:
 		return periods;
 	}
 
-	Sample intersection(const Sample& other)
+	Sample intersection(const Sample& other) const
 	{
 		std::string error_msg = "Cannot calculate the intersection between the samples '" + 
 								to_string() + "' and '" + other.to_string() + "'.\n";

--- a/cpp_api/KDB/kdb_global.cpp
+++ b/cpp_api/KDB/kdb_global.cpp
@@ -4,10 +4,17 @@
 
 bool is_global_database_loaded(const IodeType iodeType) 
 { 
-    if(!get_global_db(iodeType)) 
+    try
+    {
+        KDB& kdb = get_global_db(iodeType);
+        if(kdb.size() == 0) 
+            return false;
+    }
+    catch(const std::exception& e)
+    {
         return false;
-    if(get_global_db(iodeType)->size() == 0) 
-        return false;
+    }
+
     return true; 
 }
 

--- a/cpp_api/KDB/kdb_global.h
+++ b/cpp_api/KDB/kdb_global.h
@@ -30,7 +30,7 @@ bool is_global_database_loaded(const IodeType iodeType);
  *      language =  {E,F,D}
  *      trace = debug file (optional)
  *  
- *  @see https://iode.plan.be/doku.php?id=fileimportcmt
+ *
  */
 void import_cmt(const std::string& input_file, const std::string& save_file, const std::string& rule_file, 
                 const TableLang lang = TABLE_ENGLISH, const std::string& debug_file = "");
@@ -52,7 +52,7 @@ void import_cmt(const std::string& input_file, const std::string& save_file, con
  *      to   = end of sample
  *      trace = debug file (optional)
  *  
- *  @see https://iode.plan.be/doku.php?id=fileimportcmt
+ *
  */
 void import_var(const std::string& input_file, const std::string& save_file, const std::string& from, const std::string& to, 
                 const std::string& rule_file, const std::string& debug_file = "");
@@ -75,7 +75,7 @@ void import_var(const std::string& input_file, const std::string& save_file, con
  *      to   = end of sample
  *      trace = debug file (optional)
  *  
- *  @see https://iode.plan.be/doku.php?id=fileimportvar
+ *
  */
 void import_var(const std::string& input_file, const std::string& save_file, const Period& from, const Period& to, 
                 const std::string& rule_file, const std::string& debug_file = "");
@@ -102,7 +102,7 @@ void import_var(const std::string& input_file, const std::string& save_file, con
  *      separator = character used to separate value (CSV only)
  *      trace = debug file (optional)
  *  
- *  @see https://iode.plan.be/doku.php?id=export
+ *
  */
 void export_as(const std::string& var_file, const std::string cmt_file, const std::string& from, const std::string& to, 
                const IodeExportFormat format, const std::string& save_file, const std::string& rule_file, 

--- a/cpp_api/KDB/kdb_reference.cpp
+++ b/cpp_api/KDB/kdb_reference.cpp
@@ -1,22 +1,21 @@
 #include "kdb_reference.h"
 
 
-void load_reference_kdb(const int ref, IodeType iode_type, std::string& filepath)
+void load_reference_kdb(const int ref, std::string& filepath)
 {
-    filepath = check_filepath(filepath, (IodeFileType) iode_type, "load", true);
+    filepath = check_filepath(filepath, FILE_VARIABLES, "load", true);
     K_load_RWS(ref, (char*) filepath.c_str());
 }
 
-void clear_reference_kdb(const int ref, IodeType iode_type)
+void clear_reference_kdb(const int ref)
 {
-    if(K_RWS[iode_type][ref - 1])
-        delete K_RWS[iode_type][ref - 1];
-    K_RWS[iode_type][ref - 1] = nullptr;
+    if(global_ref_var[ref - 1])
+        delete global_ref_var[ref - 1];
+    global_ref_var[ref - 1] = nullptr;
 }
 
 void clear_all_reference_kdbs()
 {
-    for(int iode_type = COMMENTS; iode_type <= VARIABLES; iode_type++)
-        for(int ref = 2; ref <= 5; ref++)
-            clear_reference_kdb(ref, (IodeType) iode_type);
+    for(int ref = 2; ref <= 5; ref++)
+        clear_reference_kdb(ref);
 }

--- a/cpp_api/KDB/kdb_reference.h
+++ b/cpp_api/KDB/kdb_reference.h
@@ -2,10 +2,10 @@
 #include "cpp_api/common.h"
 
 
-// TODO ALD: remove K_RWS and make KDB classes to be able to represent a reference kdb
+// TODO ALD: remove global_ref_xxx and make KDB classes to be able to represent a reference kdb
 
-void load_reference_kdb(const int ref, IodeType iode_type, std::string& filepath);
+void load_reference_kdb(const int ref, std::string& filepath);
 
-void clear_reference_kdb(const int ref, IodeType iode_type);
+void clear_reference_kdb(const int ref);
 
 void clear_all_reference_kdbs();

--- a/cpp_api/computed_table/computed_table.cpp
+++ b/cpp_api/computed_table/computed_table.cpp
@@ -63,12 +63,12 @@ void ComputedTable::initialize()
         files_usage[column.cl_fnb[1]] = 1;
     }
 
-    KDB* kdb = nullptr;
+    KDBVariables* kdb = nullptr;
     for(int ref=1; ref < K_MAX_FREF + 1; ref++) 
     {
         if(files_usage.test(ref))
         {
-            kdb = K_RWS[VARIABLES][ref - 1];
+            kdb = global_ref_var[ref - 1];
             if(!kdb) 
                 throw std::invalid_argument("file[" + std::to_string(ref) + "] is not present");
             files.push_back(kdb->filepath);

--- a/doc/dev/DESCRIPTION.md
+++ b/doc/dev/DESCRIPTION.md
@@ -284,15 +284,6 @@ Functions to retrieve the current IODE version.
 
 ## Group "KDB management" {#T20}
 
-### k\_kdb.c {#T21}
-
-Function to manage KDB, i.e. IODE object groups.
-
-|Syntax|Description|
-|:---|:---|
-|`int K_merge(KDB* kdb1, KDB* kdb2, int replace)`|merges two databases : kdb1 <\- kdb1 \+ kdb2.|
-|`int K_merge_del(KDB* kdb1, KDB* kdb2, int replace)`|merges two databases : kdb1 <\- kdb1 \+ kdb2 then deletes kdb2.|
-
 ### k\_ws.c {#T22}
 
 Variables and functions for initializing and cleaning up the "in memory" workspaces.
@@ -357,7 +348,6 @@ Functions to detect IODE object file version and to convert an object to the cur
 |Syntax|Description|
 |:---|:---|
 |`int K_calcvers(char* label):`|returns the current object version (0\-2) from an IODE file header.|
-|`void K_setvers(KDB* kdb, int i, int vers)`|converts an IODE object from IODE objects version 1 or 2 to the current version (0).|
 
 ### k\_pack.c {#T28}
 
@@ -483,8 +473,6 @@ Functions to manipulate IODE object files.
 |`void K_strip(char* filename)`|deletes left and right spaces in a filename. Keeps the space inside the filename.|
 |`int K_filetype(char* filename, char* descr, int* nobjs, Sample* smpl)`|retrieves infos on an IODE file: type, number of objects, Sample|
 |`int X_findtype(char* filename)`|Returns the type of content of filename according to its extension|
-|`int K_copy(KDB* kdb, int nf, char** files, int no, char** objs, Sample* smpl)`|reads a list of objects from a list of IODE object files and adds them to an existing KDB.|
-|\`cint K\_cat(KDB\* ikdb, char\* filename)|concatenates the content of a file to an existing kdb.|
 |\`cint K\_set\_backup\_on\_save(int take\_backup)|sets the backup choice before saving a kdb.|
 |\`cint K\_get\_backup\_on\_save()|indicates if a backup must be taken before saving a kdb.|
 |`int K_backup(char* filename)`|takes a backup of a file by renaming the file: filename.xxx => filename.xx$.|

--- a/pyiode/computed_table/computed_table.pxd
+++ b/pyiode/computed_table/computed_table.pxd
@@ -20,7 +20,7 @@ cdef extern from "api/all.h":
         short    cl_opy              # operator on periods => cl_per[0] cl_opy cl_per[1])
         CPeriod  cl_per[2]           # period 1 , period 2
         short    cl_opf              # operator on files => cl_fnb[0] cl_opf cl_fnb[1]
-        short    cl_fnb[2]           # position in K_RWS of file1 and file2 (starts at 1)
+        short    cl_fnb[2]           # position in global_ref_xxx of file1 and file2 (starts at 1)
         double   cl_val[2][2]        # computed values of the LEC formulas on periods / files => max 4 values see table below
         double   cl_res              # computed value (v00 opp v10) opf (v01 opp v11)
 

--- a/pyiode/iode/iode_database/comments_database.py
+++ b/pyiode/iode/iode_database/comments_database.py
@@ -383,16 +383,14 @@ class Comments(IodeDatabase):
 
         >>> # load all comments with a name starting with 'A'
         >>> comments.copy_from(f"{SAMPLE_DATA_DIR}/fun.cmt", "A*")      # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-        Loading ...\fun.cmt
-        317 objects loaded
+        4 comment read from file '...fun.cmt'
         >>> comments.get_names("A*")
         ['ACAF', 'ACAG', 'AOUC', 'AQC']
 
         >>> comments.clear()
         >>> # load all comments
         >>> comments.copy_from(f"{SAMPLE_DATA_DIR}/fun.cmt")            # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-        Loading ...\fun.cmt
-        317 objects loaded
+        317 comment read from file '...fun.cmt' 
         >>> len(comments)
         317
         """

--- a/pyiode/iode_database/cpp_api_database.pxd
+++ b/pyiode/iode_database/cpp_api_database.pxd
@@ -96,7 +96,7 @@ cdef extern from "api/all.h":
 
         # Other methods
         void merge(const KDB& other, const bool overwrite) except +
-        void copy_from(const string& input_file, const string objects_names) except +
+        void copy_from(const string& input_files, const string objects_names) except +
         void merge_from(const string& input_file) except +
         vector[string] search(const string& pattern, const bool word, const bool case_sensitive, 
             const bool in_name, const bool in_formula, const bool in_text, const string& list_result) except +
@@ -131,8 +131,8 @@ cdef extern from "cpp_api/KDB/kdb_global.h":
     void high_to_low(IodeHighToLow type_, string& filepath, string& var_list) except +
 
 cdef extern from "cpp_api/KDB/kdb_reference.h":
-    void load_reference_kdb(int index, IodeType iode_type, string& filepath) except +
-    void clear_reference_kdb(int index, IodeType iode_type) except +
+    void load_reference_kdb(int index, string& filepath) except +
+    void clear_reference_kdb(int index) except +
     void clear_all_reference_kdbs() except +
 
 cdef extern from "cpp_api/compute/simulation.h":
@@ -329,7 +329,7 @@ cdef extern from "api/objs/variables.h":
         vector[string] get_list_periods(string& from_period, string& to_period) except +
         vector[float] get_list_periods_as_float(string& from_period, string& to_period) except +
 
-        void copy_from(string& input_file, string& from_period, string& to_period, string objects_names) except +
+        void copy_from(string& input_files, string& from_period, string& to_period, string objects_names) except +
 
         void extrapolate(VariablesInitialization method, string& from_period, string& to, string& variables_list) except +
         void seasonal_adjustment(string& input_file, string& series, double eps_test) except +

--- a/pyiode/iode_database/extra_files.pyx
+++ b/pyiode/iode_database/extra_files.pyx
@@ -5,7 +5,7 @@ from pyiode.iode_database.cpp_api_database cimport load_reference_kdb, clear_all
 
 def cython_load_extra_files(extra_files: Union[str, Path, List[Union[str, Path]]]) -> List[Path]:    
     for i, extra_file in enumerate(extra_files):
-        load_reference_kdb(i + 2, IodeType.VARIABLES, str(extra_file).encode())
+        load_reference_kdb(i + 2, str(extra_file).encode())
     return extra_files
 
 

--- a/tests/test_big_files/test_big_files.cpp
+++ b/tests/test_big_files/test_big_files.cpp
@@ -9,6 +9,7 @@
 
 TEST(BigFilesTest, Tests_BIG_WS)
 {
+    bool success;
     int nb_names = 0;
     int all_nb_names = 0;
     KDB* kdb_var = nullptr;
@@ -86,7 +87,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(STANDALONE - ALL VARS)  loaded " << std::to_string(kdb_var->size()) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl; 
+                  << " variables in " << elapsed.count() << " seconds" << std::endl; 
         delete kdb_var;
         kdb_var = nullptr;
 
@@ -103,7 +104,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(GLOBAL - SOME VARS)     loaded " << std::to_string(nb_names) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl;  
+                  << " variables in " << elapsed.count() << " seconds" << std::endl;  
         delete kdb_var; 
         kdb_var = nullptr;
 
@@ -118,7 +119,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(STANDALONE - SOME VARS) loaded " << std::to_string(nb_names) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl; 
+                  << " variables in " << elapsed.count() << " seconds" << std::endl; 
         delete kdb_var;
         kdb_var = nullptr;
 
@@ -131,7 +132,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(B_WsLoad)               loaded " << std::to_string(global_ws_var->size()) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl;
+                  << " variables in " << elapsed.count() << " seconds" << std::endl;
 
         // **** K_refer and K_quick_refer performance tests ****
 
@@ -141,7 +142,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(K_refer)                created a shallow copy of " << std::to_string(nb_names) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl;
+                  << " variables in " << elapsed.count() << " seconds" << std::endl;
         EXPECT_TRUE(kdb_shallow_copy != nullptr);
         EXPECT_EQ(kdb_shallow_copy->size(), nb_names);
         kdb_shallow_copy->clear(false);
@@ -151,7 +152,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(K_quick_refer)          created a shallow copy of " << std::to_string(nb_names) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl;
+                  << " variables in " << elapsed.count() << " seconds" << std::endl;
         EXPECT_TRUE(kdb_shallow_copy != nullptr);
         EXPECT_EQ(kdb_shallow_copy->size(), nb_names);
         kdb_shallow_copy->clear(false);
@@ -172,7 +173,7 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(K_quick_refer)          created a shallow copy of " << std::to_string(all_nb_names) 
-                    << " variables in " << elapsed.count() << " seconds" << std::endl;
+                  << " variables in " << elapsed.count() << " seconds" << std::endl;
         EXPECT_TRUE(kdb_shallow_copy != nullptr);
         EXPECT_EQ(kdb_shallow_copy->size(), all_nb_names);
         kdb_shallow_copy->clear(false);
@@ -188,14 +189,14 @@ TEST(BigFilesTest, Tests_BIG_WS)
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "loaded " << std::to_string(global_ws_var->size()) << " variables in " 
-                    << elapsed.count() << " seconds" << std::endl;
+                  << elapsed.count() << " seconds" << std::endl;
 
         start = std::chrono::high_resolution_clock::now();
         std::size_t hash_val = hash_value(*global_ws_var);
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "hashed " << std::to_string(global_ws_var->size()) << " variables in " 
-                    << elapsed.count() << " seconds" << std::endl;
+                  << elapsed.count() << " seconds" << std::endl;
         global_ws_var->clear();
 
         // **** save() performance tests ****
@@ -203,11 +204,12 @@ TEST(BigFilesTest, Tests_BIG_WS)
         memset(out_filename, 0, sizeof(out_filename));
         sprintf(out_filename,  "%s%s", str_data_dir.c_str(), "big_save.var");
         start = std::chrono::high_resolution_clock::now();
-        global_ws_var->save_binary(out_filename);
+        success = global_ws_var->save_binary(out_filename);
+        EXPECT_TRUE(success);
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(K_save) [.var file]  saved " << std::to_string(global_ws_var->size()) 
-                << " variables in " << elapsed.count() << " seconds" << std::endl;
+                  << " variables in " << elapsed.count() << " seconds" << std::endl;
     }
     else
     {
@@ -252,7 +254,8 @@ TEST(BigFilesTest, Tests_BIG_WS)
         memset(out_filename, 0, sizeof(out_filename));
         sprintf(out_filename,  "%s%s", str_data_dir.c_str(), "big_save.av");
         start = std::chrono::high_resolution_clock::now();
-        global_ws_var->save_asc(out_filename);
+        success = global_ws_var->save_asc(out_filename);
+        EXPECT_TRUE(success);
         end = std::chrono::high_resolution_clock::now();
         elapsed = end - start;
         std::cout << "(K_save) [.av file]  saved " << std::to_string(global_ws_var->size()) 

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -364,8 +364,8 @@ public:
 	    sprintf(fullfilename,  "%s%s", input_test_dir, filename);
 	    rc = B_WsLoad(fullfilename, type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), expected_nb_objects);
-	    return rc == 0 && get_global_db(type)->size() == expected_nb_objects;
+	    EXPECT_EQ(get_global_db(type).size(), expected_nb_objects);
+	    return rc == 0 && get_global_db(type).size() == expected_nb_objects;
 	}
 
 	bool U_test_B_WsSave(char* source_file, char* out_file, int type, int expected_nb_objects)
@@ -382,8 +382,8 @@ public:
 	    B_WsClear("", type);
 	    rc = B_WsLoad(out_file, type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), expected_nb_objects);
-	    return rc == 0 && get_global_db(type)->size() == expected_nb_objects;
+	    EXPECT_EQ(get_global_db(type).size(), expected_nb_objects);
+	    return rc == 0 && get_global_db(type).size() == expected_nb_objects;
 	}
 
 	bool U_test_B_WsSaveCmp(char* source_file, char* out_file, int type, int expected_nb_objects)
@@ -403,8 +403,8 @@ public:
 	    B_WsClear("", type);
 	    rc = B_WsLoad(out_fullfilename, type);
 	    EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), expected_nb_objects);
-	    return rc == 0 && get_global_db(type)->size() == expected_nb_objects;
+	    EXPECT_EQ(get_global_db(type).size(), expected_nb_objects);
+	    return rc == 0 && get_global_db(type).size() == expected_nb_objects;
 	}
 
 	bool U_test_B_WsExport(char* source_file, char* out_file, int type)
@@ -437,8 +437,8 @@ public:
 	    sprintf(fullfilename, "%s%s", input_test_dir, source_file);
 	    rc = B_WsImport(fullfilename, type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), expected_nb_objects);
-	    return rc == 0 && get_global_db(type)->size() == expected_nb_objects;
+	    EXPECT_EQ(get_global_db(type).size(), expected_nb_objects);
+	    return rc == 0 && get_global_db(type).size() == expected_nb_objects;
 	}
 
 	bool U_test_B_WsClear(int type)
@@ -447,8 +447,8 @@ public:
 	
 	    rc = B_WsClear("", type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), 0);
-	    return get_global_db(type)->size() == 0;
+	    EXPECT_EQ(get_global_db(type).size(), 0);
+	    return get_global_db(type).size() == 0;
 	}
 
 	bool U_test_B_WsDescr(char* descr, int type)
@@ -457,8 +457,8 @@ public:
 	
 	    rc = B_WsDescr(descr, type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->description, descr);
-	    return rc == 0 && get_global_db(type)->description == descr;
+	    EXPECT_EQ(get_global_db(type).description, descr);
+	    return rc == 0 && get_global_db(type).description == descr;
 	}
 
 	bool U_test_B_WsName(char* c_name, int type)
@@ -467,7 +467,7 @@ public:
 	
 	    rc = B_WsName(c_name, type);
         EXPECT_EQ(rc, 0);
-	    std::string name = get_global_db(type)->filepath;
+	    std::string name = get_global_db(type).filepath;
 	    EXPECT_EQ(name, std::string(c_name));
 	    return rc == 0 && name == std::string(c_name);
 	}
@@ -508,13 +508,13 @@ public:
 	    // 2.2 Copy ACAF and ACAG on 1992 & 1993 (does not replace 1991 for example)
 	    sprintf(arg,  "%sfun.av 1992Y1 1993Y1 ACAF ACAG", input_test_dir);
 	    rc = B_WsCopy(arg, VARIABLES);
-	
+        EXPECT_EQ(rc, 0);
+
 	    // 2.3 Tests
 	    ACAF91 = U_test_calc_lec("ACAF[1991Y1]", 0);
 	    ACAF92 = U_test_calc_lec("ACAF[1992Y1]", 0);
 	    ACAG90 = U_test_calc_lec("ACAG[1990Y1]", 0);
 	    ACAG92 = U_test_calc_lec("ACAG[1992Y1]", 0);
-        EXPECT_EQ(rc, 0);
 	    EXPECT_DOUBLE_EQ(ACAF91, 1.0);
 	    EXPECT_DOUBLE_EQ(ACAF92, 30.159000);
 	    EXPECT_DOUBLE_EQ(ACAG90, IODE_NAN);	    
@@ -528,9 +528,10 @@ public:
 	    // Copy ACAF and ACAG (does not specify a sample)
 	    sprintf(arg,  "%sfun.av ACAF ACAG", input_test_dir);
 	    rc = B_WsCopy(arg, VARIABLES);
+        EXPECT_EQ(rc, 0);
+        
 	    ACAF92 = U_test_calc_lec("ACAF[1992Y1]", 0);
 	    ACAG92 = U_test_calc_lec("ACAG[1992Y1]", 0);
-        EXPECT_EQ(rc, 0);
 	    EXPECT_DOUBLE_EQ(ACAF92, 30.159000);
 	    EXPECT_DOUBLE_EQ(ACAG92, -40.285998999999997);
 	
@@ -547,8 +548,8 @@ public:
 	    sprintf(arg,  "%s%s *", input_test_dir, filename);
 	    rc = B_WsCopy(arg, type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), expected_nb_objects);
-	    return rc == 0 && get_global_db(type)->size() == expected_nb_objects;
+	    EXPECT_EQ(get_global_db(type).size(), expected_nb_objects);
+	    return rc == 0 && get_global_db(type).size() == expected_nb_objects;
 	}
 
 	bool U_test_B_WsMergeVar()
@@ -602,8 +603,8 @@ public:
 	    sprintf(arg,  "%s%s *", input_test_dir, filename);
 	    rc = B_WsMerge(arg, type);
         EXPECT_EQ(rc, 0);
-	    EXPECT_EQ(get_global_db(type)->size(), expected_nb_objects);
-	    return rc == 0 && get_global_db(type)->size() == expected_nb_objects;
+	    EXPECT_EQ(get_global_db(type).size(), expected_nb_objects);
+	    return rc == 0 && get_global_db(type).size() == expected_nb_objects;
 	}
 
 	bool U_test_B_WsExtrapolate(int method, double expected_value)
@@ -1237,16 +1238,16 @@ TEST_F(LegacyAPITest, Tests_PrintTablesAndVars)
     // Load the VAR workspace
     U_test_load(VARIABLES, "fun.av");
     kdbv = global_ws_var.get();
-    K_RWS[VARIABLES][0] = new KDBVariables(*kdbv);
+    global_ref_var[0] = new KDBVariables(*kdbv);
     EXPECT_NE(kdbv, nullptr);
 
     // Load the Table workspace
     U_test_load(TABLES, "fun.at");
     kdbt = global_ws_tbl.get();
-    K_RWS[TABLES][0] = new KDBTables(*kdbt);
+    global_ref_tbl[0] = new KDBTables(*kdbt);
     EXPECT_NE(kdbt, nullptr);
 
-    // Load a second VAR workspace in K_RWS[VARIABLES][2]
+    // Load a second VAR workspace in global_ref_var[2]
     sprintf(fullfilename,  "%s%s", input_test_dir, "fun.av");
     rc = K_load_RWS(2, fullfilename);
     EXPECT_EQ(rc, 0);
@@ -1500,22 +1501,21 @@ TEST_F(LegacyAPITest, Tests_B_DATA)
     // B_DataDuplicate(char* arg, int type)
     // B_DataRename(char* arg, int type)
     // B_DataDelete(char* arg, int type)
-    KDB* kdb;
     int pos;
     char* ptr_obj;
     for(i = 0; i < 7 ; i++) 
     {
-        kdb = get_global_db(i);
+        KDB& kdb = get_global_db(i);
         char* x_name = (i == SCALARS) ? (char*) "xxx" : (char*) "XXX";
         rc = B_DataCreate(x_name, i);
         EXPECT_EQ(rc, 0);
-        found = kdb->contains(x_name);
+        found = kdb.contains(x_name);
         EXPECT_TRUE(found);
-        pos = kdb->index_of(x_name);
+        pos = kdb.index_of(x_name);
         EXPECT_TRUE(pos >= 0);
-        handle = kdb->get_handle(x_name);
+        handle = kdb.get_handle(x_name);
         EXPECT_TRUE(handle > 0);
-        ptr_obj = kdb->get_ptr_obj(x_name);
+        ptr_obj = kdb.get_ptr_obj(x_name);
         EXPECT_STRNE(ptr_obj, "");
 
         // Equations cannot be renamed or duplicated
@@ -1525,26 +1525,26 @@ TEST_F(LegacyAPITest, Tests_B_DATA)
             char* dup_names = (i == SCALARS) ? (char*) "xxx yyy" : (char*) "XXX YYY";
             rc = B_DataDuplicate(dup_names, i);
             EXPECT_EQ(rc, 0);
-            found = kdb->contains(y_name);
+            found = kdb.contains(y_name);
             EXPECT_TRUE(found);
-            pos = kdb->index_of(y_name);
+            pos = kdb.index_of(y_name);
             EXPECT_TRUE(pos >= 0);
-            handle = kdb->get_handle(y_name);
+            handle = kdb.get_handle(y_name);
             EXPECT_TRUE(handle > 0);
-            ptr_obj = kdb->get_ptr_obj(y_name);
+            ptr_obj = kdb.get_ptr_obj(y_name);
             EXPECT_STRNE(ptr_obj, "");
 
             char* z_name = (i == SCALARS) ? (char*) "zzz" : (char*) "ZZZ";
             char* ren_name = (i == SCALARS) ? (char*) "yyy zzz" : (char*) "YYY ZZZ";
             rc = B_DataRename(ren_name, i);
             EXPECT_EQ(rc, 0);
-            found = kdb->contains(z_name);
+            found = kdb.contains(z_name);
             EXPECT_TRUE(found);
         }
 
         rc = B_DataDelete(x_name, i);
         EXPECT_EQ(rc, 0);
-        found = kdb->contains(x_name);
+        found = kdb.contains(x_name);
         EXPECT_TRUE(!found);
     }
 
@@ -1661,16 +1661,20 @@ TEST_F(LegacyAPITest, Tests_B_DATA)
     rc = B_DataCompare(buf, LISTS);
     EXPECT_EQ(rc, 0);
     // names only in current WS
+    EXPECT_TRUE(global_ws_lst->contains("WS_ONLY"));
     expected_list = "AB;BC;L1;L2;L3;LC;LIST1;LIST2;LST1;LST2;NEWLIST;RC;RES;U;ZZZ;_EXO;_RES";
     EXPECT_EQ(std::string(global_ws_lst->get_obj("WS_ONLY")), expected_list);
     // names only in file
+    EXPECT_TRUE(global_ws_lst->contains("FILE_ONLY"));
     expected_list = "COPY;COPY0;COPY1;ENDO;ENDO0;ENDO1;ENVI;IDT;MAINEQ;MYLIST;TOTAL;TOTAL0;";
     expected_list += "TOTAL1;XENVI;XSCENARIO;_SEARCH";
     EXPECT_EQ(std::string(global_ws_lst->get_obj("FILE_ONLY")), expected_list);
     // names in both current WS and file and IODE obj in WS == IODE obj in file
+    EXPECT_TRUE(global_ws_lst->contains("BOTH_EQ"));
     expected_list = "";
     EXPECT_EQ(std::string(global_ws_lst->get_obj("BOTH_EQ")), expected_list);
     // names in both current WS and file but IODE obj in WS != IODE obj in file
+    EXPECT_TRUE(global_ws_lst->contains("BOTH_DIFF"));
     expected_list = "_SCAL";
     EXPECT_EQ(std::string(global_ws_lst->get_obj("BOTH_DIFF")), expected_list);
 

--- a/tests/test_c_api/test_kdb_tables.cpp
+++ b/tests/test_c_api/test_kdb_tables.cpp
@@ -522,7 +522,7 @@ TEST_F(KDBTablesTest, Search)
 
 TEST_F(KDBTablesTest, PrintToFile)
 {
-    // WARNING: B_PrintTable() resets K_RWS (reference files)
+    // WARNING: B_PrintTable() resets global_ref_xxx (reference files)
 
     int res;
     std::string arg;
@@ -558,7 +558,7 @@ TEST_F(KDBTablesTest, PrintToFile)
     arg = gsample + " " + names;
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     global_ws_tbl->print_to_file(str_output_test_dir + "cpp_api_file.csv", gsample, names, 4, 'C');
     compare_files(str_output_test_dir + "c_api_file.csv", str_output_test_dir + "cpp_api_file.csv");
 
@@ -570,7 +570,7 @@ TEST_F(KDBTablesTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     global_ws_tbl->print_to_file(str_output_test_dir + "cpp_api_file.html", gsample, names, 4, 'H');
     compare_files(str_output_test_dir + "c_api_file.html", str_output_test_dir + "cpp_api_file.html");
 
@@ -585,7 +585,7 @@ TEST_F(KDBTablesTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     global_ws_tbl->print_to_file(str_output_test_dir + "cpp_api_file.csv", gsample, names, 4, 'C');
     compare_files(str_output_test_dir + "c_api_file.csv", str_output_test_dir + "cpp_api_file.csv");
 
@@ -597,7 +597,7 @@ TEST_F(KDBTablesTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     global_ws_tbl->print_to_file(str_output_test_dir + "cpp_api_file.html", gsample, names, 4, 'H');
     compare_files(str_output_test_dir + "c_api_file.html", str_output_test_dir + "cpp_api_file.html");
 
@@ -612,7 +612,7 @@ TEST_F(KDBTablesTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     global_ws_tbl->print_to_file(str_output_test_dir + "cpp_api_file.csv", gsample, names, 4, 'C');
     compare_files(str_output_test_dir + "c_api_file.csv", str_output_test_dir + "cpp_api_file.csv");
 
@@ -624,7 +624,7 @@ TEST_F(KDBTablesTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
     
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     global_ws_tbl->print_to_file(str_output_test_dir + "cpp_api_file.html", gsample, names, 4, 'H');
     compare_files(str_output_test_dir + "c_api_file.html", str_output_test_dir + "cpp_api_file.html");
 }

--- a/tests/test_c_api/test_subsets.cpp
+++ b/tests/test_c_api/test_subsets.cpp
@@ -6,20 +6,20 @@ protected:
     void SetUp() override 
     {
         global_ws_cmt->clear();
-        if(K_RWS[COMMENTS][0])
+        if(global_ref_cmt[0])
         {
-            delete K_RWS[COMMENTS][0];
-            K_RWS[COMMENTS][0] = nullptr;
+            delete global_ref_cmt[0];
+            global_ref_cmt[0] = nullptr;
         }
     }
 
     void TearDown() override 
     {
         global_ws_cmt->clear();
-        if(K_RWS[COMMENTS][0])
+        if(global_ref_cmt[0])
         {
-            delete K_RWS[COMMENTS][0];
-            K_RWS[COMMENTS][0] = nullptr;
+            delete global_ref_cmt[0];
+            global_ref_cmt[0] = nullptr;
         }
     }
 };
@@ -27,19 +27,21 @@ protected:
 
 TEST_F(SubsetsTest, Subset)
 {
+    KDBComments* ref_db_cmt = nullptr;
     std::string pattern = "A*";
     std::string modified = "modified";
 
     // GLOBAL KDB
     global_ws_cmt->load(str_input_test_dir + "fun.ac");
+    ref_db_cmt = (KDBComments*) global_ref_cmt[0];      // updated in the load() method
     std::string cmt_ACAF = std::string(global_ws_cmt->get_obj("ACAF"));
     std::string cmt_ACAG = std::string(global_ws_cmt->get_obj("ACAG"));
 
     EXPECT_EQ(global_ws_cmt->size(), 317);
     EXPECT_TRUE(global_ws_cmt->is_global_database());
-    // global_ws_cmt->subset_instances contains the pointer to K_RWS[COMMENTS]
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 1);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
+    // global_ws_cmt->children_db contains the pointer to global_ref_cmt
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 1);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
 
     std::set<std::string> names = global_ws_cmt->filter_names(pattern);
 
@@ -55,10 +57,10 @@ TEST_F(SubsetsTest, Subset)
     EXPECT_EQ(subset_deep_copy->get_names(), expected_names);
     EXPECT_TRUE(subset_deep_copy->is_local_database());
     EXPECT_TRUE(subset_deep_copy->db_parent == nullptr);
-    EXPECT_TRUE(subset_deep_copy->subset_instances.empty());
-    // global_ws_cmt->subset_instances contains the pointer to K_RWS[COMMENTS]
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 1);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
+    EXPECT_TRUE(subset_deep_copy->children_db.empty());
+    // global_ws_cmt->children_db contains the pointer to global_ref_cmt
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 1);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
 
     // ---- add in deep copy subset only ----
     std::string new_comment = "new comment";
@@ -112,9 +114,10 @@ TEST_F(SubsetsTest, Subset)
 
     global_ws_cmt->clear();
     global_ws_cmt->load(str_input_test_dir + "fun.ac");
-    // global_ws_cmt->subset_instances contains the pointer to K_RWS[COMMENTS]
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 1);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
+    ref_db_cmt = (KDBComments*) global_ref_cmt[0];      // updated in the load() method
+    // global_ws_cmt->children_db contains the pointer to global_ref_cmt
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 1);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
 
     KDBComments* subset_shallow_copy = new KDBComments(global_ws_cmt.get(), pattern, false);
     EXPECT_EQ(subset_shallow_copy->size(), names.size());
@@ -122,9 +125,9 @@ TEST_F(SubsetsTest, Subset)
     EXPECT_TRUE(subset_shallow_copy->is_shallow_copy_database());
     EXPECT_TRUE(subset_shallow_copy->db_parent == global_ws_cmt.get());
 
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 2);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_shallow_copy));
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 2);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_shallow_copy));
 
     // ---- add in shallow copy subset ----
     new_comment = "new comment";
@@ -177,16 +180,18 @@ TEST_F(SubsetsTest, Subset)
 
     delete subset_shallow_copy;
 
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 1);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 1);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
 }
 
 TEST_F(SubsetsTest, MultiSubsets)
 {
+    KDBComments* ref_db_cmt = nullptr;
     std::string modified = "modified";
     std::string description = "Global comments KDB";
 
     global_ws_cmt->load(str_input_test_dir + "fun.ac");
+    ref_db_cmt = (KDBComments*) global_ref_cmt[0];      // updated in the load() method
     global_ws_cmt->description = description;
     std::string cmt_BENEF = std::string(global_ws_cmt->get_obj("BENEF"));
 
@@ -204,10 +209,10 @@ TEST_F(SubsetsTest, MultiSubsets)
     EXPECT_TRUE(subset_0->is_shallow_copy_database());
     EXPECT_TRUE(subset_0->db_parent == global_ws_cmt.get());
     EXPECT_EQ(subset_0->db_parent->description, description);
-    // global_ws_cmt->subset_instances contains the pointer to K_RWS[COMMENTS]
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 2);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_0));
+    // global_ws_cmt->children_db contains the pointer to global_ref_cmt
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 2);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_0));
 
     // ==== subset of subset ====
     std::string pattern_1 = "B*;*_";
@@ -224,10 +229,10 @@ TEST_F(SubsetsTest, MultiSubsets)
     EXPECT_TRUE(subset_1->db_parent == global_ws_cmt.get());
     EXPECT_EQ(subset_1->db_parent->description, description);
 
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 3);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_0));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_1));
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 3);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_0));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_1));
 
     // ==== subset of subset of subset ====
     std::string pattern_2 = "B*;C*";
@@ -244,11 +249,11 @@ TEST_F(SubsetsTest, MultiSubsets)
     EXPECT_TRUE(subset_2->db_parent == global_ws_cmt.get());
     EXPECT_EQ(subset_2->db_parent->description, description);
 
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 4);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_0));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_1));
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(subset_2));
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 4);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_0));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_1));
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(subset_2));
 
     // ==== add, modify, rename, remove ====
     // ---- add in subset ----
@@ -324,6 +329,6 @@ TEST_F(SubsetsTest, MultiSubsets)
     delete subset_1;
     delete subset_0;
 
-    EXPECT_EQ(global_ws_cmt->subset_instances.size(), 1);
-    EXPECT_TRUE(global_ws_cmt->subset_instances.contains(K_RWS[COMMENTS][0]));
+    EXPECT_EQ(global_ws_cmt->children_db.size(), 1);
+    EXPECT_TRUE(global_ws_cmt->children_db.contains(ref_db_cmt));
 }

--- a/tests/test_cpp_api/test_computed_table.cpp
+++ b/tests/test_cpp_api/test_computed_table.cpp
@@ -31,7 +31,7 @@ protected:
         }
         kdb_ref->save(ref_file);
 
-        load_reference_kdb(2, VARIABLES, ref_file);
+        load_reference_kdb(2, ref_file);
     }
 
     // void TearDown() override {}
@@ -729,7 +729,7 @@ TEST_F(ComputedTableTest, InitializePrinting)
 
 TEST_F(ComputedTableTest, PrintToFile)
 {
-    // WARNING: B_PrintTable() resets K_RWS (reference files)
+    // WARNING: B_PrintTable() resets global_ref_xxx (reference files)
 
     int res;
     std::string arg;
@@ -803,7 +803,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_simple.print_to_file(output_test_dir + "cpp_api_file.csv", 'C');
     compare_files(output_test_dir + "c_api_file.csv", output_test_dir + "cpp_api_file.csv");
     
@@ -814,7 +814,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     arg = gsample + " " + table_name;
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_simple.print_to_file(output_test_dir + "cpp_api_file.html", 'H');
     compare_files(output_test_dir + "c_api_file.html", output_test_dir + "cpp_api_file.html");
 
@@ -830,7 +830,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_grt.print_to_file(output_test_dir + "cpp_api_file.csv", 'C');
     compare_files(output_test_dir + "c_api_file.csv", output_test_dir + "cpp_api_file.csv");
 
@@ -842,7 +842,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_grt.print_to_file(output_test_dir + "cpp_api_file.html", 'H');
     compare_files(output_test_dir + "c_api_file.html", output_test_dir + "cpp_api_file.html");
 
@@ -858,7 +858,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_2_files.print_to_file(output_test_dir + "cpp_api_file.csv", 'C');
     compare_files(output_test_dir + "c_api_file.csv", output_test_dir + "cpp_api_file.csv");
 
@@ -870,7 +870,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_2_files.print_to_file(output_test_dir + "cpp_api_file.html", 'H');
     compare_files(output_test_dir + "c_api_file.html", output_test_dir + "cpp_api_file.html");
 
@@ -944,7 +944,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
 
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_simple_bin.print_to_file(output_test_dir + "bin_cpp_file.csv", 'C');
     compare_files(output_test_dir + "bin_file.csv", output_test_dir + "bin_cpp_file.csv");
     
@@ -955,7 +955,7 @@ TEST_F(ComputedTableTest, PrintToFile)
     arg = gsample + " " + table_name;
     res = B_PrintTbl(to_char_array(arg));
     EXPECT_EQ(res, 0);
-    load_reference_kdb(2, VARIABLES, ref_file);
+    load_reference_kdb(2, ref_file);
     table_simple_bin.print_to_file(output_test_dir + "bin_cpp_file.html", 'H');
     compare_files(output_test_dir + "bin_file.html", output_test_dir + "bin_cpp_file.html");
 


### PR DESCRIPTION
- moved attributes k_objs, db_parent and subset_instances from KDB to KDBTemplate
- removed K_RWS global and replaced with global_ref_xxx
- made functions K_set_kdb_fullpath(), K_merge(), K_merge_del(), K_setvers(), K_cat() and K_copy() as methods of KDB

Part of issue #1012