### PR TITLE
C API: (lec) use a std::deque<double> object instead of a double* array for the execution stack

### DIFF
--- a/api/lec/l_common.h
+++ b/api/lec/l_common.h
@@ -8,8 +8,9 @@
 #include "api/objs/scalars.h"
 #include "api/objs/variables.h"
 #include "api/utils/utils.h"
-
 #include "api/lec/l_err.h"
+
+#include <deque>        // for the execution stack
 
 
 constexpr int L_SPECIAL = 10;
@@ -63,8 +64,8 @@ inline std::vector<int> V_EXEC_POS;
 
 /* l_exec.cpp */
 int L_intlag(double lag);
-bool L_stack_is_nan(double* stack, const int pos_stack, int nargs);
-double L_exec_sub(unsigned char* expr, int lg, int t, double* stack);
+bool L_stack_is_nan(const std::deque<double>& stack);
+double L_exec_sub(unsigned char* expr, int lg, int t);
 
 /* l_debug.cpp */
 void L_debug(char*, ...);
@@ -127,10 +128,9 @@ public:
         representation = std::to_string(value);
     }
 
-    void add_to_stack(double* stack, int& pos_stack) const
+    void add_to_stack(std::deque<double>& stack) const
     {
-        pos_stack++;
-        stack[pos_stack] = value;
+        stack.push_back(value);
     }
 
     void add_to_buffer(unsigned char* buffer, int& pos_buffer) const override
@@ -166,10 +166,9 @@ public:
         representation = std::to_string(value);
     }
 
-    void add_to_stack(double* stack, int& pos_stack) const
+    void add_to_stack(std::deque<double>& stack) const
     {
-        pos_stack++;
-        stack[pos_stack] = (double) value;
+        stack.push_back(static_cast<double>(value));
     }
 
     void add_to_buffer(unsigned char* buffer, int& pos_buffer) const override
@@ -204,14 +203,12 @@ public:
         pos_buffer += sizeof(int);
     }
 
-    bool add_to_stack(double* stack, int& pos_stack) const
+    bool add_to_stack(std::deque<double>& stack) const
     {
         double value = L_getscl(L_EXEC_DBS, V_EXEC_POS[pos]);
         if(!IODE_IS_A_NUMBER(value)) 
             return false;
-
-        pos_stack++;
-        stack[pos_stack] = L_getscl(L_EXEC_DBS, V_EXEC_POS[pos]);
+        stack.push_back(value);
         return true;
     }
 
@@ -267,7 +264,7 @@ public:
             ref += per.difference(sample.start_period);
     }
 
-    bool add_to_stack(double* stack, int& pos_stack, const int t) const
+    bool add_to_stack(std::deque<double>& stack, const int t) const
     {
         double* d_ptr = L_getvar(L_EXEC_DBV, V_EXEC_POS[pos]);
         if(!d_ptr) 
@@ -277,12 +274,10 @@ public:
         if(per.year == 0)  
             len += t;
         
-        pos_stack++;
-        if(len < 0 || len >= (L_getsmpl(L_EXEC_DBV))->nb_periods) 
-            stack[pos_stack] = IODE_NAN;
-        else 
-            stack[pos_stack] = d_ptr[len];
-
+        double value = IODE_NAN;
+        if(len >= 0 && len < (L_getsmpl(L_EXEC_DBV))->nb_periods) 
+            value = d_ptr[len];
+        stack.push_back(value);
         return true;
     }
 
@@ -337,10 +332,9 @@ public:
         pos = period.difference(sample.start_period);
     }
 
-    void add_to_stack(double* stack, int& pos_stack) const
+    void add_to_stack(std::deque<double>& stack) const
     {
-        pos_stack++;
-        stack[pos_stack] = (double) pos;
+        stack.push_back(static_cast<double>(pos));
     }
 
     void add_to_buffer(unsigned char* buffer, int& pos_buffer) const override
@@ -445,6 +439,7 @@ struct LEC_EXECUTABLE: public LEC_ABSTRACT
 {
     int nb_args;        // number of arguments of the function
     int pos;            // position of the function in the corresponding table (L_FN, L_TFN or L_MTFN)
+    std::string fn_name;    // name of the function (for debugging purposes)
 
 protected:
     LEC_EXECUTABLE(const int type, const int nb_args) : LEC_ABSTRACT(type), nb_args(nb_args), pos(-1) {}

--- a/api/lec/l_exec.cpp
+++ b/api/lec/l_exec.cpp
@@ -1,13 +1,3 @@
-/**
- * @header4iode
- *
- * Functions to evaluate a compiled and linked LEC expression. 
- *  
- *   - double L_exec_sub(unsigned char* expr, int lg, int t, double* stack)     Execution of a CLEC sub expression.
- *   - double L_exec(KDBVariablesPtr dbv, KDBScalarsPtr dbs, CLEC* clec, int t)                     Execution of a compiled and linked CLEC expression.
- *   - double* L_cc_link_exec(char* lec, KDB* dbv, KDB* dbs)                    Compiles, links and executes a LEC expression.
- */
-
 #include <setjmp.h>
 #include <signal.h>
 #include <time.h>
@@ -72,16 +62,15 @@ void L_fperror(int)
 /**
  *  Checks if at least one of the last nargs values on the stack is IODE_NAN.
  *      
- *  @param [in, out] p_stack     double**    pointer to the pointer to the stack
- *  @param [in]      nargs       int         number of arguments
+ *  @param [in, out] stack       double**    pointer to the pointer to the stack
  *  @return                      int         1 if IODE_NAN has been found and the stack is modified
  *                                           0 otherwise
  */
-bool L_stack_is_nan(double* stack, const int pos_stack, int nargs)
+bool L_stack_is_nan(const std::deque<double>& stack)
 {
-    for(int i = 0; i < nargs; i++)
+    for(const double& value : stack)
     {
-        if(!IODE_IS_A_NUMBER(stack[pos_stack - i])) 
+        if(!IODE_IS_A_NUMBER(value)) 
             return true;
     }
 
@@ -120,17 +109,16 @@ static std::string get_l_exec_sub_error_message(unsigned char* expr, int t)
  *  @param [in] expr    unsigned char*  pointer to the beginning of the sub expression (heterogeneous container)
  *  @param [in] lg      int             length of the sub expression
  *  @param [in] t       int             time (index in dbv) of execution
- *  @param [in] stack   double*         execution stack
  *  @return             double          result of the computation
  *  
  */
-double L_exec_sub(unsigned char* expr, int lg, int t, double* stack)
+double L_exec_sub(unsigned char* expr, int lg, int t)
 {
     int j;
     int type;
     int previous_j;
     int pos_stack = 0;  
-    bool done = false;
+    std::deque<double> stack;
     for(j = 0; j < lg ;) 
     {
         type = expr[j];
@@ -140,107 +128,90 @@ double L_exec_sub(unsigned char* expr, int lg, int t, double* stack)
             // extract LEC long constant from the buffer -> update j
             LEC_CONST_LONG al_lconst((unsigned char*) expr, j);
             // add the constant to the stack
-            al_lconst.add_to_stack(stack, pos_stack);
-            done = true;
+            al_lconst.add_to_stack(stack);
         }
-
-        if(type == L_DCONST)
+        else if(type == L_DCONST)
         {
             // extract LEC double constant from the buffer -> update j
             LEC_CONST_REAL al_dconst((unsigned char*) expr, j);
             // add the constant to the stack
-            al_dconst.add_to_stack(stack, pos_stack); 
-            done = true;
+            al_dconst.add_to_stack(stack); 
         }
-
-        if(type == L_COEF)
+        else if(type == L_COEF)
         {
             // extract LEC coefficient from the buffer -> update j
             LEC_COEF al_coef((unsigned char*) expr, j);
             // add the coefficient value to the stack
-            bool ok = al_coef.add_to_stack(stack, pos_stack);
+            bool ok = al_coef.add_to_stack(stack);
             if(!ok) 
             {
                 std::string error_msg = get_l_exec_sub_error_message(expr, t);
                 kerror(0, (char*) error_msg.c_str());
                 return (double) IODE_NAN;
             }
-            done = true;
         }
-
-        if(type == L_PERIOD)
+        else if(type == L_PERIOD)
         {
             // extract LEC Period from the buffer -> update j
             LEC_PERIOD al_period((unsigned char*) expr, j);
             // add the period position to the stack
-            al_period.add_to_stack(stack, pos_stack);
-            done = true;
+            al_period.add_to_stack(stack);
         }
-
         // key = variable or variable[period] 
-        if(type == L_VAR || type == L_VART) 
+        else if(type == L_VAR || type == L_VART) 
         {
             // extract LEC Variable from the buffer -> update j
             LEC_VAR al_var((unsigned char*) expr, j);
             // add the variable value to the stack
-            bool ok = al_var.add_to_stack(stack, pos_stack, t);
+            bool ok = al_var.add_to_stack(stack, t);
             if(!ok) 
             {
                 std::string error_msg = get_l_exec_sub_error_message(expr, t);
                 kerror(0, (char*) error_msg.c_str());
                 return (double) IODE_NAN;
             }
-            done = true;
         }
 
-        if(is_fn(type)) 
+        // ---- executable LEC elements ----
+
+        else if(is_fn(type)) 
         {
             // extract LEC function from the buffer -> update j
             LEC_FN al_fn((unsigned char*) expr, j);
             // execute the function on the stack
-            al_fn.execute(stack, pos_stack);
-            done = true;
+            al_fn.execute(stack);
         }
-
-        if(is_op(type))
+        else if(is_op(type))
         {
             // extract LEC operator from the buffer -> update j
             LEC_OP al_op((unsigned char*) expr, j);
             // execute the operator on the stack
-            al_op.execute(stack, pos_stack);
-            done = true;
+            al_op.execute(stack);
         }
-
-        if(is_tfn(type)) 
+        else if(is_tfn(type)) 
         {
             previous_j = j;
             // extract LEC time function from the buffer -> update j
             LEC_TFN al_tfn((unsigned char*) expr, j);
             // execute the time function on the stack
-            al_tfn.execute(expr, previous_j, t, stack, pos_stack);
-            done = true;
+            al_tfn.execute(expr, previous_j, t, stack);
         }
-
-        if(is_val(type)) 
+        else if(is_val(type)) 
         {
             // extract LEC value from the buffer -> update j
             LEC_VAL_FN al_val((unsigned char*) expr, j);
             // execute the value function on the stack
-            al_val.execute(t, stack, pos_stack);
-            done = true;
+            al_val.execute(t, stack);
         }
-
-        if(is_mtfn(type)) 
+        else if(is_mtfn(type)) 
         {
             previous_j = j;
             // extract LEC multi-time function from the buffer -> update j
             LEC_MTFN al_mtfn((unsigned char*) expr, j);
             // execute the multi-time function on the stack
-            al_mtfn.execute(expr, previous_j, t, stack, pos_stack);
-            done = true;
+            al_mtfn.execute(expr, previous_j, t, stack);
         }
-
-        if(!done) 
+        else 
         {
             std::string error_msg = "Could not execute compiled LEC sub expression: invalid atomic lec type " + std::to_string(type);
             kerror(0, (char*) error_msg.c_str());
@@ -248,7 +219,7 @@ double L_exec_sub(unsigned char* expr, int lg, int t, double* stack)
         }
     }
 
-    return stack[pos_stack];
+    return stack.back();
 }
 
 
@@ -268,14 +239,12 @@ double L_exec_sub(unsigned char* expr, int lg, int t, double* stack)
  */
 double L_exec(KDBVariablesPtr dbv, KDBScalarsPtr dbs, CLEC* clec, int t)
 {
-    double stack[1000];    // 1000 pour reculer certains plantages (non solutionné...) TODO: manage the stack overflow ?
-
     if(!clec) 
-        return (double) IODE_NAN;
+        return IODE_NAN;
 
     // leave if empty CLEC expression
     if(clec->expression == nullptr || clec->len_expr == 0)
-        return (double) IODE_NAN;
+        return IODE_NAN;
 
     // Use globals to limit the number of parameters in function calls
     L_EXEC_DBV = dbv;   
@@ -301,7 +270,7 @@ double L_exec(KDBVariablesPtr dbv, KDBScalarsPtr dbs, CLEC* clec, int t)
     if(setjmp(L_JMP))
         return (double) IODE_NAN; // On FPE, return IODE_NAN
     
-    double value = L_exec_sub(clec->expression, clec->len_expr, t, stack);
+    double value = L_exec_sub(clec->expression, clec->len_expr, t);
     return value;
 }
 
@@ -316,41 +285,11 @@ double L_exec(KDBVariablesPtr dbv, KDBScalarsPtr dbs, CLEC* clec, int t)
 int L_intlag(double lag)
 {
     int intlag;
-
-    if(lag < 0) intlag = (int)(-0.5 + lag);
-    else        intlag = (int)(0.5 + lag);
-
-    return(intlag);
-}
-
-/**
- *  Utility function to retrieve one or 2 optional time values on the stack.
- *  Ex.: 
- *      vmax(1990Y1, 2000Y1, A+B):  from=1990Y1, to=2000Y1
- *      vmax(1990Y1, A+B):          from=1990Y1, to=t
- *      vmax(A+B):                  from=0,      to=t
- *  
- *  @param [in]  t      int     current value of t (in a simulation loop for example)
- *  @param [in]  stack  double  top of the stack
- *  @param [in]  nargs  int     nb of args passed to the function
- *  @param [out] from   int*    position in the sample of the "from" arg
- *  @param [out] to     int*    position in the sample of the "to" arg
- */
-void L_tfn_args(int t, double* stack, int nargs, int* from, int* to)
-{
-    int     j;
-
-    *from = 0;
-    *to = t;
-    if(nargs == 1) return;
-    *from = L_intlag(*stack);
-    if(nargs == 3) *to = L_intlag(*(stack - 1));
-
-    if(*from > *to) {
-        j = *from;
-        *from = *to;
-        *to = j;
-    }
+    if(lag < 0) 
+        intlag = (int) (-0.5 + lag);
+    else        
+        intlag = (int) (0.5 + lag);
+    return intlag;
 }
 
 
@@ -365,22 +304,19 @@ void L_tfn_args(int t, double* stack, int nargs, int* from, int* to)
  */
 double* L_cc_link_exec(char* lec, KDBVariablesPtr dbv, KDBScalarsPtr dbs)
 {
-    int      t, nb;
-    CLEC     *clec = 0;
-    double   *vec = NULL;
-
-    if(lec == 0 || lec[0] == 0) 
-        return(vec);
+    double* vec = NULL;
+    if(lec == NULL || lec[0] == 0) 
+        return vec;
     
-    clec = L_cc(lec);
+    CLEC* clec = L_cc(lec);
     if(clec != 0 && !L_link(dbv, dbs, clec)) 
     {
-        nb = dbv->sample->nb_periods;
+        int nb = dbv->sample->nb_periods;
         vec = (double*) SW_nalloc(nb * sizeof(double));
-        for(t = 0 ; t < nb ; t++)
+        for(int t = 0 ; t < nb ; t++)
             vec[t] = L_exec(dbv, dbs, clec, t);
     }
 
     delete clec;
-    return(vec);
+    return vec;
 }

--- a/api/lec/l_exec_fns.cpp
+++ b/api/lec/l_exec_fns.cpp
@@ -1,71 +1,3 @@
-/**
- * @header4iode
- *
- * Functions to evaluate LEC "functions". 
- * The table (*L_FNS_FN)[] contains the pointers of the functions from L_UNIMUS to L_DIV0 (see iode.h).
- *
- * Function signatures:
- *
- *      double  <fnname>(double *stack, int nbargs);
- *  or 
- *      double  <fnname>(double *stack);
- *  
- *  where *stack* points to the top of the stack and *nbargs* indicates how many parameters have been 
- *  passed to the function in the LEC expression.
- *  
- *  Example: in the LEC expression
- *   
- *      max(A+2, B+1, C) 
- *  
- *  nbargs is 3 and the arguments are *stack, *(stack-1) and *(stack-2).
- *  
- *  
- *  List of functions
- *  -----------------
- *  Note that these functions are all called by L_exec_sub() (@see l_exec.c).
- *  
- *             double L_logn(double v)
- *      double L_uminus(double* stack)
- *      double L_uplus (double* stack)
- *      double L_log(double* stack, int nargs)
- *      double L_ln(double* stack)
- *      double L_not(double* stack)
- *      double L_expn(double* stack, int nargs)
- *      double L_max(double* stack, int nargs)
- *      double L_min(double* stack, int nargs)
- *      double L_sin (double* stack)
- *      double L_cos (double* stack)
- *      double L_acos (double* stack)
- *      double L_asin (double* stack)
- *      double L_tan (double* stack)
- *      double L_atan (double* stack)
- *      double L_tanh (double* stack)
- *      double L_sinh (double* stack)
- *      double L_cosh (double* stack)
- *      double L_abs (double* stack)
- *      double L_sqrt (double* stack)
- *      double L_int (double* stack)
- *      double L_rad (double* stack)
- *      double L_if(double* stack, int nargs)
- *      double L_lsum(double* stack, int nargs)
- *      double L_lmean(double* stack, int nargs)
- *      double L_fnisan(double* stack, int nargs)
- *      double L_lcount(double* stack, int nargs)
- *      double L_lprod(double* stack, int nargs)
- *      double L_sign(double* stack)
- *      double L_lstderr(double* stack, int nargs)
- *      double L_random(double* stack)
- *      double L_floor(double* stack)
- *      double L_ceil (double* stack)
- *      double L_round(double* stack, int nargs)
- *      double L_urandom(double* stack)
- *      double randBoxMuller(double rv_mean, double rv_sd)
- *      double L_grandom(double* stack)
- *      double dgamma(double x)
- *      double L_gamma(double* stack)
- *      double L_div0(double *stack, int nargs)
- *  
- */
 #include <math.h>
 #include <time.h>
 
@@ -77,306 +9,482 @@
 #endif
 
 /* Global functions (not static!) */
-double L_logn(double v)
+double L_logn(const double v)
 {
-    double  x;
+    double x;
+    if(!IODE_IS_A_NUMBER(v) || v <= 0) 
+        return IODE_NAN;
 
-    if(!IODE_IS_A_NUMBER(v) || v <= 0) {
-        return((double)IODE_NAN);
-        /*      L_errno = L_LOG_ERR;
-        	longjmp(L_JMP, 1);
-        */
-    }
-
-    x = log((double)v);
-    if(_isnan(x)) x = IODE_NAN; /* JMP 18-01-02 */
-    return((double)x);
+    x = log(v);
+    if(_isnan(x)) 
+        x = IODE_NAN;
+    return x;
 }
 
 /*------------- GROUP L_FNS_FN ---------------------*/
 
-double L_uminus(double* stack, int unused) {return(- *stack);}
-double L_uplus (double* stack, int unused) {return(*stack);}
-
-double L_log(double* stack, int nargs)
-{   
-    if(nargs == 2) 
-        return(L_divide(L_logn(*stack), L_logn(*(stack - 1))));
-    return(L_logn(*stack));
+double L_uminus(std::deque<double>& stack, int unused) 
+{
+    double value = stack.back();
+    stack.pop_back();
+    return -value;
 }
 
-double L_ln(double* stack, int unused)  {return(L_logn(*stack));}
-double L_not(double* stack, int unused) {return((fabs((double)(*stack)) < 1e-15) ? 1.0: 0.0);}
+double L_uplus (std::deque<double>& stack, int unused) 
+{
+    double value = stack.back();
+    stack.pop_back();
+    return value;
+}
+
+double L_log(std::deque<double>& stack, int nargs)
+{   
+    double value = stack.back();
+    stack.pop_back();
+
+    if(nargs == 2)
+    {
+        double res2 = L_logn(value);
+        value = stack.back();
+        stack.pop_back();
+        double res1 = L_logn(value);
+        return L_divide(res1, res2);
+    }
+    else
+        return L_logn(value);
+}
+
+double L_ln(std::deque<double>& stack, int unused)  
+{
+    double value = stack.back();
+    stack.pop_back();
+    return L_logn(value);
+}
+
+double L_not(std::deque<double>& stack, int unused) 
+{
+    double value = stack.back();
+    stack.pop_back();
+    return (fabs(value) < 1e-15) ? 1.0 : 0.0;
+}
 
 /**
  *  Computes the exponential of the value on the stack.
  *  If nargs == 1, it's the neperian exponential
- *  If nargs == 2, the mantissa is the second to last value on the stack.
- *  
- *  @param [in] stack   double*     pointer to the top of the stack
- *  @param [in] nargs   int         number of arguments 
- *  @return 
- *  
+ *  If nargs == 2, the mantissa is the second argument.
  */
-double L_expn(double* stack, int nargs)
+double L_expn(std::deque<double>& stack, int nargs)
 {
-    double  x, a, b;
+    double n = stack.back();
+    stack.pop_back();
 
-    if(nargs == 1) {
-        if(*stack >= DMAXEXP || *stack <= DMINEXP) return(IODE_NAN);
-        x = exp(*stack);
-        if(x >= MAXDOUBLE || x <= MINDOUBLE) return(IODE_NAN);
-        return(x);
+    if(nargs == 1) 
+    {
+        if(n >= DMAXEXP || n <= DMINEXP)
+            return IODE_NAN;
+        
+        double res = exp(n);
+        if(res >= MAXDOUBLE || res <= MINDOUBLE)
+            return IODE_NAN;
+        
+        return res;
     }
-    else {
-        a = *(stack - 1);
-        b = *stack;
-        return(L_exp(a, b));
-        /* ancienne version pre-2018
-        if(a < 0 && b != (int)b) return(IODE_NAN);
-        x = (double)pow((double)(*(stack - 1)), (double)(*stack)); // JMP 18-01-02
-        if(_isnan(x)) x = IODE_NAN;
-        if(x >= MAXDOUBLE || x <= MINDOUBLE) x = IODE_NAN;
-        return((double)x);
-        */
+    else 
+    {
+        double x = stack.back();
+        stack.pop_back();
+        return L_exp(x, n);
     }
 }
 
-double L_max(double* stack, int nargs)
+double L_max(std::deque<double>& stack, int nargs)
 {
-    double  m;
-    int     j;
+    double max = stack.back();
+    for(int j = 0; j < nargs; j++)
+    {
+        if(stack.back() > max) 
+            max = stack.back();
+        stack.pop_back();
+    }
 
-    m = *stack;
-    for(j = 1 ; j < nargs ; j++)
-        if(m < *(stack - j)) m = *(stack - j);
-    return(m);
+    return max;
 }
 
-double L_min(double* stack, int nargs)
+double L_min(std::deque<double>& stack, int nargs)
 {
-    double  m;
-    int     j;
+    double min = stack.back();
+    for(int j = 0; j < nargs; j++)
+    {
+        if(stack.back() < min) 
+            min = stack.back();
+        stack.pop_back();
+    }
 
-    m = *stack;
-    for(j = 1 ; j < nargs ; j++)
-        if(m > *(stack - j)) m = *(stack - j);
-    return(m);
+    return min;
 }
 
-double L_sin  (double* stack, int unused) {return((double)sin ((double)*stack));}
-double L_cos  (double* stack, int unused) {return((double)cos ((double)*stack));}
-double L_acos (double* stack, int unused) {return((double)acos((double)*stack));}
-double L_asin (double* stack, int unused) {return((double)asin((double)*stack));}
-double L_tan  (double* stack, int unused) {return((double)tan ((double)*stack));}
-double L_atan (double* stack, int unused) {return((double)atan((double)*stack));}
-double L_tanh (double* stack, int unused) {return((double)tanh((double)*stack));}
-double L_sinh (double* stack, int unused) {return((double)sinh((double)*stack));}
-double L_cosh (double* stack, int unused) {return((double)cosh((double)*stack));}
-double L_abs  (double* stack, int unused) {return((double)fabs((double)*stack));}
-double L_sqrt (double* stack, int unused) {return((*stack < 0) ? IODE_NAN: (double)sqrt((double)*stack));}
-double L_int  (double* stack, int unused) {return((double)floor((double)(0.5 + *stack)));}
-double L_rad  (double* stack, int unused) {return((double)(((double)(*stack)) * M_PI / 180.0));}
-
-double L_if(double* stack, int nargs)
+double L_sin(std::deque<double>& stack, int unused) 
 {
-    double  cond = *(stack - 2);
-
-    if(!IODE_IS_A_NUMBER(cond) || fabs(cond) < 1e-15)  return(*stack); /* JMP 14-06-07 */
-    else                                     return(*(stack - 1));
+    double x = stack.back();
+    stack.pop_back();
+    return sin(x);
 }
 
-double L_lsum(double* stack, int nargs)
+double L_cos(std::deque<double>& stack, int unused) 
 {
-    double  m;
-    int     j;
-
-    m = *stack;
-    for(j = 1 ; j < nargs ; j++)
-        m += *(stack - j);
-    return(m);
+    double x = stack.back();
+    stack.pop_back();
+    return cos(x);
 }
 
-double L_lmean(double* stack, int nargs)
+double L_acos(std::deque<double>& stack, int unused) 
 {
-    double  m = 0.0;
-    int     j, no = 0;
+    double x = stack.back();
+    stack.pop_back();
+    return acos(x);
+}
 
-    for(j = 0 ; j < nargs ; j++) {
-        if(IODE_IS_A_NUMBER(*(stack - j))) {             /* JMP 03-03-99 */
-            m += *(stack - j);
-            no++;
+double L_asin(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return asin(x);
+}
+
+double L_tan(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return tan(x);
+}
+
+double L_atan(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return atan(x);
+}
+
+double L_tanh(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return tanh(x);
+}
+
+double L_sinh(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return sinh(x);
+}
+
+double L_cosh(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return cosh(x);
+}
+
+double L_abs(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return fabs(x);
+}
+
+double L_sqrt(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return (x < 0) ? IODE_NAN: sqrt(x);
+}
+
+double L_int(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return floor(0.5 + x);
+}
+
+double L_rad(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return (x * M_PI / 180.0);
+}
+
+double L_if(std::deque<double>& stack, int nargs)
+{
+    double cond = stack.back();
+    stack.pop_back();
+    double arg2 = stack.back();
+    stack.pop_back();
+    double arg1 = stack.back();
+    stack.pop_back();
+
+    if(!IODE_IS_A_NUMBER(cond) || fabs(cond) < 1e-15)  
+        return arg2;
+    else                                     
+        return arg1;
+}
+
+double L_lsum(std::deque<double>& stack, int nargs)
+{
+    double sum = 0.0;
+    for(int j = 0; j < nargs; j++)
+    {
+        sum += stack.back();
+        stack.pop_back();
+    }
+
+    return sum;
+}
+
+double L_lmean(std::deque<double>& stack, int nargs)
+{
+    int nb = 0;
+    double mean = 0.0;
+    double value;
+    for(int j = 0; j < nargs; j++) 
+    {
+        value = stack.back();
+        stack.pop_back();
+        if(IODE_IS_A_NUMBER(value)) 
+        {
+            mean += value;
+            nb++;
         }
     }
-    if(no) return(m / no);
-    else return(IODE_NAN);
+ 
+    return (nb > 0) ? mean / nb : IODE_NAN;
 }
 
-double L_fnisan(double* stack, int nargs) {return((double)IODE_IS_A_NUMBER(*stack));}
-double L_lcount(double* stack, int nargs) {return((double)nargs);}
-
-double L_lprod(double* stack, int nargs)
+double L_fnisan(std::deque<double>& stack, int nargs) 
 {
-    double  m;
-    int     j;
-
-    m = *stack;
-    for(j = 1 ; j < nargs ; j++)
-        m *= *(stack - j);
-    return(m);
+    double x = stack.back();
+    stack.pop_back();
+    return (double) IODE_IS_A_NUMBER(x);
 }
 
-double L_sign(double* stack, int unused)
+double L_lcount(std::deque<double>& stack, int nargs) 
 {
-    if(*stack < 0) return((double)-1.0);
-    else           return((double)1.0);
+    return (double) nargs;
 }
 
-double L_lstderr(double* stack, int nargs)
+double L_lprod(std::deque<double>& stack, int nargs)
 {
-    double  m = 0, x, mean;
-    int     j, no = 0;
+    double prod = 1.0;
+    for(int j = 0; j < nargs; j++)
+    {
+        if(IODE_IS_A_NUMBER(stack.back())) 
+            prod *= stack.back();
+        stack.pop_back();
+    }
 
-    mean = L_lmean(stack, nargs);
-    for(j = 0 ; j < nargs ; j++) {
-        if(IODE_IS_A_NUMBER(*(stack - j))) {             /* JMP 03-03-99 */
-            x = *(stack - j) - mean;
-            m += x * x;
-            no++;
+    return prod;
+}
+
+double L_sign(std::deque<double>& stack, int unused)
+{ 
+    double x = stack.back();
+    stack.pop_back();
+    return (x < 0) ? -1.0 : 1.0;
+}
+
+double L_lstderr(std::deque<double>& stack, int nargs)
+{
+    std::deque<double> copy = stack;
+    double mean = L_lmean(copy, nargs);
+
+    double x;
+    int nb = 0;
+    double sum = 0.0;
+    for(int j = 0; j < nargs; j++) 
+    {
+        x = stack.back();
+        stack.pop_back();
+        if(IODE_IS_A_NUMBER(x)) 
+        {
+            x = x - mean;
+            sum += x * x;
+            nb++;
         }
     }
-    if(no > 1) return(sqrt(m / (no - 1)));
-    else return(IODE_NAN);
+
+    return (nb > 1) ? sqrt(sum / (nb - 1)) : IODE_NAN;
 }
 
-double L_random(double* stack, int unused)
+double L_random(std::deque<double>& stack, int unused)
 {
-    static int init = 0;
-    double  x, s = *stack;
+    static bool init = false;
 
-    if(s == 0.0) return(0.0);
-    if(init == 0) {
+    double value = stack.back();
+    stack.pop_back();
+
+    if(value == 0.0) 
+        return 0.0;
+    
+    if(!init) 
+    {
+        srand((unsigned) time(NULL));
+        init = true;
+    }
+
+    double factor = (rand() - (double) RAND_MAX / 2) / (double) RAND_MAX;
+    return factor * value;
+}
+
+double L_floor(std::deque<double>& stack, int unused) 
+{   
+    double x = stack.back();
+    stack.pop_back();
+    return floor(x); 
+}
+
+double L_ceil(std::deque<double>& stack, int unused) 
+{
+    double x = stack.back();
+    stack.pop_back();
+    return 1.0 + floor(x);
+}
+
+double L_round(std::deque<double>& stack, int nargs)
+{
+    int nb_digits = 0;
+    if(nargs == 2) 
+    {
+        nb_digits = (int) stack.back();
+        stack.pop_back();
+    }
+    double shift = pow(10, nb_digits);
+
+    double value = stack.back();
+    stack.pop_back();
+
+    double res = floor(0.5 + (value * shift));
+    return res / shift;
+}
+
+double L_urandom(std::deque<double>& stack, int unused)
+{
+    static bool init = false;
+
+    double value = stack.back();
+    stack.pop_back();
+
+    if(value == 0.0) 
+        return 0.0;
+
+    if(!init) 
+    {
         srand((unsigned)time(NULL));
-        init = 1;
+        init = true;
     }
 
-    x = (rand() - (double)RAND_MAX / 2) / (double)RAND_MAX;
-    return(x * s);
+    return u_rand() * value;
 }
 
+static double z2 = 0.0;
+static bool use_z2 = true;
 
-double L_floor(double* stack, int unused) {return((double)floor((double)(*stack))); }
-double L_ceil (double* stack, int unused) {return((double)(1.0 + floor((double)(*stack))));}
-
-double L_round(double* stack, int nargs)
-{
-    double cf = 0, val = *stack;
-
-    if(nargs > 1) {
-        cf = (int)(*stack);
-        val = *(stack - 1);
-    }
-    cf = pow(10, cf);
-    val = floor(0.5 + val * cf);
-    return((double)(val / cf));
-}
-
-double L_urandom(double* stack, int unused)
-{
-    static int init = 0;
-    double  x, s = *stack;
-
-    if(s == 0.0) return(0.0);
-    if(init == 0) {
-        srand((unsigned)time(NULL));
-        init = 1;
-    }
-
-    x = (double) rand()/((double)RAND_MAX + 1.0);
-    return(x * s);
-}
-
-/* grandom (gaussian random value) */
-//#include <math.h>
-//#include <stdlib.h>
-
-#define u_rand() ((double) rand()/(1.0+(double) RAND_MAX))
-static double  z2 =0.0;
-static int  use_z2 = 1;
-
+// TODO: check the algorithm
 static double randBoxMuller(double rv_mean, double rv_sd)
 {
-    double  z1, x, y, w;
-    if(use_z2 && z2 != 0.0) {
+    double z1 = 0.0;
+    if(use_z2 && z2 != 0.0) 
+    {
         z1 = z2;
         z2 = 0.0;
     }
-    else {
-        do {
-            /* choose x,y in uniform square (-1,-1) to (+1,+1) */
+    else 
+    {
+        double x, y, w = 2.0;
+        while(w > 1.0 || w == 0.0)
+        {
+            // choose x,y in uniform square (-1,-1) to (+1,+1)
             x = -1.0 + 2.0 * u_rand();
             y = -1.0 + 2.0 * u_rand();
-            /* see if it is in the unit circle */
+            // see if it is in the unit circle
             w = x * x + y * y;
         }
-        while(w > 1.0 || w == 0);
-        /* Box-Muller transform */
-        w = sqrt(-2.0 * log(w)/w);
+
+        // Box-Muller transform
+        w = sqrt(-2.0 * log(w) / w);
         z2 = x * w;
         z1 = y * w;
     }
-    return(rv_mean + rv_sd * z1);
+
+    return rv_mean + rv_sd * z1;
 }
 
-double L_grandom(double* stack, int unused)
+double L_grandom(std::deque<double>& stack, int unused)
 {
-    double  s = *stack, m = *(stack - 1);
+    double sd = stack.back();
+    stack.pop_back();
+    double mean = stack.back();
+    stack.pop_back();
 
-    return(randBoxMuller(m, s));
+    return randBoxMuller(mean, sd);
 }
 
-/* Gamma function in double precision */
+// Gamma function in double precision
 static double dgamma(double x)
 {
-    int k, n;
-    double w, y;
-    n = x < 1.5 ? -((int)(2.5 - x)) : (int)(x - 1.5);
-    w = x - (n + 2);
-    y = ((((((((((((-1.99542863674e-7 * w + 1.337767384067e-6) * w -
-                   2.591225267689e-6) * w - 1.7545539395205e-5) * w +
-                 1.45596568617526e-4) * w - 3.60837876648255e-4) * w -
-               8.04329819255744e-4) * w + 0.008023273027855346) * w -
-             0.017645244547851414) * w - 0.024552490005641278) * w +
-           0.19109110138763841) * w - 0.233093736421782878) * w -
-         0.422784335098466784) * w + 0.99999999999999999;
-    if(n > 0) {
+    int n = x < 1.5 ? -((int) (2.5 - x)) : (int) (x - 1.5);
+    double w = x - (n + 2);
+    std::vector<double> coeffs = {
+        -1.99542863674e-7, 1.337767384067e-6, -2.591225267689e-6, -1.7545539395205e-5,
+        1.45596568617526e-4, -3.60837876648255e-4, -8.04329819255744e-4, 0.008023273027855346,
+        -0.017645244547851414, -0.024552490005641278, 0.19109110138763841, -0.233093736421782878,
+        -0.422784335098466784
+    };
+
+    double y = 0.0;
+    for(const double& coeff : coeffs)
+    {
+        y += coeff;
+        y *= w;
+    }
+    y += 0.99999999999999999;
+
+    if(n > 0) 
+    {
         w = x - 1;
-        for(k = 2; k <= n; k++) {
+        for(int k = 2; k <= n; k++) 
             w *= x - k;
-        }
     }
-    else {
+    else 
+    {
         w = 1;
-        for(k = 0; k > n; k--) {
+        for(int k = 0; k > n; k--) 
             y *= x - k;
-        }
     }
+
     return w / y;
 }
 
-double L_gamma(double* stack, int unused)
+double L_gamma(std::deque<double>& stack, int unused)
 {
-    double  s = *stack;
-
-    return(dgamma(s));
+    double x = stack.back();
+    stack.pop_back();
+    return dgamma(x);
 }
 
-double L_div0(double *stack, int unused)
+double L_div0(std::deque<double>& stack, int unused)
 {
-    double a = *(stack - 1);
-    double b = *stack;
+    double a = stack.back();
+    stack.pop_back();
+    double b = stack.back();
+    stack.pop_back();
 
-    if(!IODE_IS_A_NUMBER(b) || !IODE_IS_A_NUMBER(a)) return((double)IODE_NAN);
-    else if(b == 0) return 0;
-    return(a / b);
+    double res;
+    if(!IODE_IS_A_NUMBER(b) || !IODE_IS_A_NUMBER(a)) 
+        res = IODE_NAN;
+    else if(b == 0) 
+        res = 0.0;
+    else
+        res = a / b;
+
+    return res;
 }

--- a/api/lec/l_exec_fns.h
+++ b/api/lec/l_exec_fns.h
@@ -66,47 +66,52 @@ inline bool is_fn(const int op)
     return op >= L_FN  && op <= L_FN_LAST; 
 }
 
-double L_logn(double v);
+inline double u_rand()
+{
+    return ((double) rand() / (1.0 + (double) RAND_MAX));
+}
 
-double L_uminus(double* stack, int nbargs);
-double L_uplus(double* stack, int nbargs);
-double L_log(double* stack, int nbargs);
-double L_ln(double* stack, int nbargs);
-double L_not(double* stack, int nbargs);
-double L_expn(double* stack, int nargs);
-double L_max(double* stack, int nbargs);
-double L_min(double* stack, int nbargs);
-double L_sin(double* stack, int nbargs);
-double L_asin(double* stack, int nbargs);
-double L_cos(double* stack, int nbargs);
-double L_acos(double* stack, int nbargs);
-double L_tan(double* stack, int nbargs);
-double L_atan(double* stack, int nbargs);
-double L_sinh(double* stack, int nbargs);
-double L_cosh(double* stack, int nbargs);
-double L_tanh(double* stack, int nbargs);
-double L_sqrt(double* stack, int nbargs);
-double L_int(double* stack, int nbargs);
-double L_abs(double* stack, int nbargs);
-double L_sign(double* stack, int nbargs);
-double L_rad(double* stack, int nbargs);
-double L_if(double* stack, int nbargs);
-double L_fnisan(double* stack, int nbargs);
-double L_lcount(double* stack, int nbargs);
-double L_lprod(double* stack, int nbargs);
-double L_lsum(double* stack, int nbargs);
-double L_lstderr(double* stack, int nbargs);
-double L_lmean(double* stack, int nbargs);
-double L_random(double* stack, int nbargs);
-double L_floor(double* stack, int nbargs);
-double L_ceil (double* stack, int nbargs);
-double L_round(double* stack, int nbargs);
-double L_urandom(double* stack, int nbargs);
-double L_grandom(double* stack, int nbargs);
-double L_gamma(double* stack, int nbargs);
-double L_div0(double* stack, int nbargs);
+double L_logn(const double v);
 
-inline double(*L_FNS_FN[])(double* stack, int nbargs) = 
+double L_uminus(std::deque<double>& stack, int nbargs);
+double L_uplus(std::deque<double>& stack, int nbargs);
+double L_log(std::deque<double>& stack, int nbargs);
+double L_ln(std::deque<double>& stack, int nbargs);
+double L_not(std::deque<double>& stack, int nbargs);
+double L_expn(std::deque<double>& stack, int nargs);
+double L_max(std::deque<double>& stack, int nbargs);
+double L_min(std::deque<double>& stack, int nbargs);
+double L_sin(std::deque<double>& stack, int nbargs);
+double L_asin(std::deque<double>& stack, int nbargs);
+double L_cos(std::deque<double>& stack, int nbargs);
+double L_acos(std::deque<double>& stack, int nbargs);
+double L_tan(std::deque<double>& stack, int nbargs);
+double L_atan(std::deque<double>& stack, int nbargs);
+double L_sinh(std::deque<double>& stack, int nbargs);
+double L_cosh(std::deque<double>& stack, int nbargs);
+double L_tanh(std::deque<double>& stack, int nbargs);
+double L_sqrt(std::deque<double>& stack, int nbargs);
+double L_int(std::deque<double>& stack, int nbargs);
+double L_abs(std::deque<double>& stack, int nbargs);
+double L_sign(std::deque<double>& stack, int nbargs);
+double L_rad(std::deque<double>& stack, int nbargs);
+double L_if(std::deque<double>& stack, int nbargs);
+double L_fnisan(std::deque<double>& stack, int nbargs);
+double L_lcount(std::deque<double>& stack, int nbargs);
+double L_lprod(std::deque<double>& stack, int nbargs);
+double L_lsum(std::deque<double>& stack, int nbargs);
+double L_lstderr(std::deque<double>& stack, int nbargs);
+double L_lmean(std::deque<double>& stack, int nbargs);
+double L_random(std::deque<double>& stack, int nbargs);
+double L_floor(std::deque<double>& stack, int nbargs);
+double L_ceil (std::deque<double>& stack, int nbargs);
+double L_round(std::deque<double>& stack, int nbargs);
+double L_urandom(std::deque<double>& stack, int nbargs);
+double L_grandom(std::deque<double>& stack, int nbargs);
+double L_gamma(std::deque<double>& stack, int nbargs);
+double L_div0(std::deque<double>& stack, int nbargs);
+
+inline double(*L_FNS_FN[])(std::deque<double>& stack, int nbargs) = 
 { 
     L_uminus,       // L_UMINUS    L_FN + 0
     L_uplus,        // L_UPLUS     L_FN + 1
@@ -196,7 +201,7 @@ public:
         if(!is_fn(type))
             throw std::invalid_argument("Invalid function type for LEC FUNC: " + std::to_string(type));
         pos = type - L_FN;
-        representation = L_FN_NAMES[pos];
+        fn_name = L_FN_NAMES[pos];
     }
 
     // extract from the buffer starting at pos_buffer and update pos_buffer
@@ -222,18 +227,21 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(double* stack, int& pos_stack)
+    void execute(std::deque<double>& stack)
      {
         // some functions (e.g. L_IF) can accept NaN as argument without returning NaN
         bool fn_accept_nan = (type == L_IF || type == L_FNISAN || type == L_LMEAN || 
                               type == L_LSTDERR || type == L_LCOUNT);
 
-        int shift = nb_args - 1; 
-        if(!fn_accept_nan && L_stack_is_nan(stack, pos_stack, nb_args))
-            stack[pos_stack - shift] = IODE_NAN;
+        double result;
+        if(!fn_accept_nan && L_stack_is_nan(stack))
+        {
+            for(int i = 0; i < nb_args; i++)
+                stack.pop_back();
+            result = IODE_NAN;
+        }
         else
-            stack[pos_stack - shift] = (L_FNS_FN[pos])(stack + pos_stack, nb_args);
-        
-        pos_stack -= shift;
+            result = (L_FNS_FN[pos])(stack, nb_args);
+        stack.push_back(result);
      }
 };

--- a/api/lec/l_exec_mtfn.cpp
+++ b/api/lec/l_exec_mtfn.cpp
@@ -1,6 +1,4 @@
 /**
- * @header4iode
- *
  * Functions to evaluate LEC "time functions" with possibly **more than one expression** 
  * in the function arguments.
  * 
@@ -14,7 +12,7 @@
  * to these functions (#defines from L_LAG to L_LASTOBS (see iode.h)).
  *
  * Function signature:
- *      double <fnname>(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
+ *      double <fnname>(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
  *  
  *  where:
  *      expr   = pointer to the current position in the CLEC expression (ex.: in "X + corr(A, B)", expr points to "A")
@@ -22,27 +20,6 @@
  *      t      = time of calculation
  *      stack  = pointer to the top of the stack of intermediate values / results
  *      nargs  = number of arguments of the calling function that determines the calculation interval.
- *  
- *  
- *  List of functions
- *  -----------------
- *  Note that these functions are all called by L_exec_sub() (@see l_exec.c).
- *  
- *      double L_corr(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, double* stack, int nargs, int orig)
- *      double L_covar(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_covar0(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_var(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_stddev(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_index(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_acf(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      int    L_calcvals(unsigned char* expr1, short len1, int t, double* stack, int* vt, double* vy, int notnul)
- *      double L_interpol(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_app(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_dapp(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
- *      double L_hpall(unsigned char* expr, short len, int t, double* stack, int nargs, int std)
- *      double L_hp(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_hpstd(unsigned char* expr, short len, int t, double* stack, int nargs)
  */
 #include <math.h>
 #include "api/lec/lec.h"
@@ -70,30 +47,38 @@
  *  @return         
  *  
  */
-double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, double* stack, int nargs) 
+double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short len2, 
+    int from, int to, int t, std::deque<double>& stack, int nargs) 
 {
-    double  sxx = 0.0, syy = 0.0, sxy = 0.0, vx, vy, meanx, meany;
-    int     from, to, j;
+    double mean_x = L_mean(expr1, len1, from, to, t, stack, nargs - 1);
+    if(!IODE_IS_A_NUMBER(mean_x)) 
+        return IODE_NAN;
+    
+    double mean_y = L_mean(expr2, len2, from, to, t, stack, nargs - 1);
+    if(!IODE_IS_A_NUMBER(mean_y)) 
+        return IODE_NAN;
 
-    meanx = L_mean(expr1, len1, t, stack, nargs - 1);
-    if(!IODE_IS_A_NUMBER(meanx)) return(IODE_NAN);
-    meany = L_mean(expr2, len2, t, stack, nargs - 1);
-    if(!IODE_IS_A_NUMBER(meany)) return(IODE_NAN);
+    double x, y;
+    double sum_xx = 0.0, sum_yy = 0.0, sum_xy = 0.0;
+    for(int j = from; j <= to; j++) 
+    {
+        x = L_exec_sub(expr1, len1, j);
+        if(!IODE_IS_A_NUMBER(x)) 
+            return IODE_NAN;
+        
+        y = L_exec_sub(expr2, len2, j);
+        if(!IODE_IS_A_NUMBER(y)) 
+            return IODE_NAN;
 
-    L_tfn_args(t, stack, nargs - 1, &from, &to);
-    for(j = from ; j <= to ; j++) {
-        vx = L_exec_sub(expr1, len1, j, stack);
-        if(!IODE_IS_A_NUMBER(vx)) return(IODE_NAN);
-        vy = L_exec_sub(expr2, len2, j, stack);
-        if(!IODE_IS_A_NUMBER(vy)) return(IODE_NAN);
-
-        sxx += (vx - meanx) * (vx - meanx);
-        syy += (vy - meany) * (vy - meany);
-        sxy += (vx - meanx) * (vy - meany);
+        sum_xx += (x - mean_x) * (x - mean_x);
+        sum_yy += (y - mean_y) * (y - mean_y);
+        sum_xy += (x - mean_x) * (y - mean_y);
     }
 
-    if(sxx * syy <= 0) return(IODE_NAN);
-    return(sxy / sqrt(sxx * syy));
+    if(sum_xx * sum_yy <= 0) 
+        return IODE_NAN;
+    
+    return sum_xy / sqrt(sum_xx * sum_yy);
 }
 
 
@@ -125,15 +110,16 @@ double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short 
  *  @return            double           computed correlation 
  *  
  */
-double L_corr(unsigned char* expr, short nvargs, int t, double* stack, int nargs)  /* JMP 17-04-98 */
+double L_corr(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    short   len1, len2;
-
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    return(L_calccorr(expr + sizeof(short), len1,
-                      expr + len1 + 2 * sizeof(short), len2,
-                      t, stack, nargs));
+
+    unsigned char* expr1 = expr + sizeof(short); 
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+    double result = L_calccorr(expr1, len1, expr2, len2, from, to, t, stack, nargs);
+    return result;
 }
 
 /**
@@ -159,32 +145,40 @@ double L_corr(unsigned char* expr, short nvargs, int t, double* stack, int nargs
  *  @return             double          computed covariance.
  *  
  */
+double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, 
+    int from, int to, int t, std::deque<double>& stack, int nargs, int orig) 
+{   
+    int nb = 1 + to - from;
+    if(nb == 0) 
+        return IODE_NAN;
+ 
+    double mean_x = L_mean(expr1, len1, from, to, t, stack, nargs - 1);
+    if(!IODE_IS_A_NUMBER(mean_x)) 
+        return IODE_NAN;
+    
+    double mean_y = L_mean(expr2, len2, from, to, t, stack, nargs - 1);
+    if(!IODE_IS_A_NUMBER(mean_y)) 
+        return IODE_NAN;
 
-double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, double* stack, int nargs, int orig) 
-{
-    double  sxx = 0.0, syy = 0.0, sxy = 0.0, vx, vy, meanx, meany;
-    int     from, to, j, n;
+    double x, y;
+    double sum_xx = 0.0, sum_yy = 0.0, sum_xy = 0.0;
+    for(int j = from; j <= to; j++) 
+    {
+        x = L_exec_sub(expr1, len1, j);
+        if(!IODE_IS_A_NUMBER(x)) 
+            return IODE_NAN;
+        
+        y = L_exec_sub(expr2, len2, j);
+        if(!IODE_IS_A_NUMBER(y)) 
+            return IODE_NAN;
 
-    L_tfn_args(t, stack, nargs - 1, &from, &to);
-    n = 1 + to - from;
-    if(n == 0) return(IODE_NAN);
-
-    meanx = L_mean(expr1, len1, t, stack, nargs - 1);
-    if(!IODE_IS_A_NUMBER(meanx)) return(IODE_NAN);
-    meany = L_mean(expr2, len2, t, stack, nargs - 1);
-    if(!IODE_IS_A_NUMBER(meany)) return(IODE_NAN);
-
-    for(j = from ; j <= to ; j++) {
-        vx = L_exec_sub(expr1, len1, j, stack);
-        if(!IODE_IS_A_NUMBER(vx)) return(IODE_NAN);
-        vy = L_exec_sub(expr2, len2, j, stack);
-        if(!IODE_IS_A_NUMBER(vy)) return(IODE_NAN);
-
-        if(orig) sxy += vx * vy;
-        else     sxy += (vx - meanx) * (vy - meany);
+        if(orig) 
+            sum_xy += x * y;
+        else     
+            sum_xy += (x - mean_x) * (y - mean_y);
     }
 
-    return(sxy / n);
+    return sum_xy / nb;
 }
 
 
@@ -200,15 +194,16 @@ double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short
  *  @see L_corr() for the parameter definition
  *  @see L_calccovar() for the formulas.
  */
-double L_covar(unsigned char* expr, short nvargs, int t, double* stack, int nargs) 
+double L_covar(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) 
 {
-    short   len1, len2;
-
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    return(L_calccovar(expr + sizeof(short), len1,
-                       expr + len1 + 2 * sizeof(short), len2,
-                       t, stack, nargs, 0));
+
+    unsigned char* expr1 = expr + sizeof(short); 
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+    double result = L_calccovar(expr1, len1, expr2, len2, from, to, t, stack, nargs, 0);
+    return result;
 }
 
 
@@ -220,15 +215,16 @@ double L_covar(unsigned char* expr, short nvargs, int t, double* stack, int narg
  *  @see L_calccovar() for the formulas.
  *  
  */
-double L_covar0(unsigned char* expr, short nvargs, int t, double* stack, int nargs) 
+double L_covar0(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) 
 {
-    short   len1, len2;
-
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    return(L_calccovar(expr + sizeof(short), len1,
-                       expr + len1 + 2 * sizeof(short), len2,
-                       t, stack, nargs, 1));
+
+    unsigned char* expr1 = expr + sizeof(short); 
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+    double result = L_calccovar(expr1, len1, expr2, len2, from, to, t, stack, nargs, 1);
+    return result;
 }
 
 
@@ -248,14 +244,14 @@ double L_covar0(unsigned char* expr, short nvargs, int t, double* stack, int nar
  *  @see L_covar() for more details.
  *  
  */
-double L_var(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
+double L_var(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    short   len1;
-
+    short len1;
     memcpy(&len1, expr, sizeof(short));
-    return(L_calccovar(expr + sizeof(short), len1,
-                       expr + sizeof(short), len1,
-                       t, stack, nargs + 1, 0));
+
+    unsigned char* expr1 = expr + sizeof(short); 
+    double result = L_calccovar(expr1, len1, expr1, len1, from, to, t, stack, nargs + 1, 0);
+    return result;
 }
 
 
@@ -269,13 +265,12 @@ double L_var(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
  *  @see L_calccovar() for the formula.
  *  
  */
-double L_stddev(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
+double L_stddev(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1;
-
-    v1 = L_var(expr, nvargs, t, stack, nargs);
-    if(!IODE_IS_A_NUMBER(v1) || v1 < 0) return(IODE_NAN);
-    else return(sqrt(v1));
+    double var = L_var(expr, nvargs, from, to, t, stack, nargs);
+    if(!IODE_IS_A_NUMBER(var) || var < 0.0) 
+        return IODE_NAN;
+    return sqrt(var);
 }
 
 
@@ -307,33 +302,34 @@ double L_stddev(unsigned char* expr, short nvargs, int t, double* stack, int nar
  *  @return            double           computed covariance
  */  
 
- double L_index(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
+ double L_index(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    char    *expr1, *expr2;
-    short   len1, len2;
-    int     from, to, j, n;
-    double  vx, vy;
-
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    expr1 = ((char*) expr) + sizeof(short);
-    expr2 = ((char*) expr) + len1 + 2 * sizeof(short);
+    unsigned char* expr1 = expr + sizeof(short);
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
 
-    L_tfn_args(t, stack, nargs - 1, &from, &to);
-    n = 1 + to - from;
-    if(n == 0) return(IODE_NAN);
+    int nb = 1 + to - from;
+    if(nb == 0) 
+        return IODE_NAN;
 
-    vx = L_exec_sub((unsigned char*) expr1, len1, t, stack);
-    if(!IODE_IS_A_NUMBER(vx)) return(IODE_NAN);
+    double x = L_exec_sub(expr1, len1, t);
+    if(!IODE_IS_A_NUMBER(x)) 
+        return IODE_NAN;
 
-    for(j = from ; j <= to ; j++) {
-        vy = L_exec_sub((unsigned char*) expr2, len2, j, stack);
-        if(!IODE_IS_A_NUMBER(vy)) return(IODE_NAN);
+    double y;
+    for(int j = from; j <= to; j++) 
+    {
+        y = L_exec_sub(expr2, len2, j);
+        if(!IODE_IS_A_NUMBER(y)) 
+            return IODE_NAN;
 
-        if(fabs(vx - vy) < 1e-30) return((double)j);
+        if(fabs(x - y) < 1e-30) 
+            return (double) j;
     }
 
-    return(IODE_NAN);
+    return IODE_NAN;
 }
 
 
@@ -351,46 +347,55 @@ double L_stddev(unsigned char* expr, short nvargs, int t, double* stack, int nar
  *  
  *  @see L_corr() for the parameter definition
  */
-double L_acf(unsigned char* expr, short nvargs, int t, double* stack, int nargs) /* JMP 17-04-98 */
-{
-    char    *expr1, *expr2;
-    short   len1, len2;
-    int     from, to, j, n, k;
-    double  vx, vy, meanx, sxy = 0.0, sxy0 = 0.0;
-
+double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+{    
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    expr1 = ((char*) expr) + sizeof(short);
-    expr2 = ((char*) expr) + len1 + 2 * sizeof(short);
+    unsigned char* expr1 = expr + sizeof(short);
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
 
-    L_tfn_args(t, stack, nargs - 1, &from, &to);
-    n = 1 + to - from;
-    if(n == 0) return(IODE_NAN);
+    int nb = 1 + to - from;
+    if(nb == 0) 
+        return IODE_NAN;
 
-    vx = L_exec_sub((unsigned char*) expr1, len1, t, stack);
-    if(!IODE_IS_A_NUMBER(vx)) return(IODE_NAN);
-    k = (int)vx;
-    if(k < 0 || k > n / 4) return(IODE_NAN);
+    double x = L_exec_sub(expr1, len1, t);
+    if(!IODE_IS_A_NUMBER(x)) 
+        return IODE_NAN;
 
-    meanx = L_mean((unsigned char*) expr2, len2, t, stack, nargs - 1);
-    if(!IODE_IS_A_NUMBER(meanx)) return(IODE_NAN);
+    int k = (int) x;
+    if(k < 0 || k > nb / 4) 
+        return IODE_NAN;
 
-    for(j = from ; j <= to - k ; j++) {
-        vx = L_exec_sub((unsigned char*) expr2, len2, j, stack);
-        if(!IODE_IS_A_NUMBER(vx)) return(IODE_NAN);
-        vy = L_exec_sub((unsigned char*) expr2, len2, j + k, stack);
-        if(!IODE_IS_A_NUMBER(vy)) return(IODE_NAN);
+    double mean_x = L_mean(expr2, len2, from, to, t, stack, nargs - 1);
+    if(!IODE_IS_A_NUMBER(mean_x)) 
+        return IODE_NAN;
 
-        sxy += (vx - meanx) * (vy - meanx);
+    double y;
+    double sum_xy = 0.0, sum_xy0 = 0.0;
+    for(int j = from; j <= to - k; j++) 
+    {
+        x = L_exec_sub(expr2, len2, j);
+        if(!IODE_IS_A_NUMBER(x)) 
+            return IODE_NAN;
+        
+        y = L_exec_sub(expr2, len2, j + k);
+        if(!IODE_IS_A_NUMBER(y)) 
+            return IODE_NAN;
+
+        sum_xy += (x - mean_x) * (y - mean_x);
     }
 
-    for(j = from ; j <= to ; j++) {
-        vx = L_exec_sub((unsigned char*) expr2, len2, j, stack);
-        if(!IODE_IS_A_NUMBER(vx)) return(IODE_NAN);
-        sxy0 += (vx - meanx) * (vx - meanx);
+    for(int j = from; j <= to; j++) 
+    {
+        x = L_exec_sub(expr2, len2, j);
+        if(!IODE_IS_A_NUMBER(x)) 
+            return IODE_NAN;
+        
+        sum_xy0 += (x - mean_x) * (x - mean_x);
     }
 
-    return(sxy / sxy0);
+    return sum_xy / sum_xy0;
 }
 
 
@@ -409,48 +414,59 @@ double L_acf(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
  *  @return             double           computed correlation 
  *  
  */
- 
-int L_calcvals(unsigned char* expr1, short len1, int t, double* stack, int* vt, double* vy, int notnul)
+int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stack, int* vt, double* vy, int notnul)
 {
-    int     nobs;
-
-    /* 1. Calc val after t */
     vy[0] = vy[1] = IODE_NAN;
-    nobs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
-    for(vt[1] = t + 1 ; vt[1] < nobs ; vt[1]++) {
-        vy[1] = L_exec_sub(expr1, len1, vt[1], stack);
-        if(IODE_IS_A_NUMBER(vy[1]) && (notnul == 0 || fabs(vy[1]) > 1e-15)) break;
+    int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
+
+    // 1. Calculate value after t
+    for(vt[1] = t + 1; vt[1] < nb_obs; vt[1]++) 
+    {
+        vy[1] = L_exec_sub(expr1, len1, vt[1]);
+        if(IODE_IS_A_NUMBER(vy[1]) && (notnul == 0 || fabs(vy[1]) > 1e-15)) 
+            break;
     }
 
-    /* 2. Calc val before t */
-    for(vt[0] = t - 1 ; vt[0] >= 0 ; vt[0]--) {
-        vy[0] = L_exec_sub(expr1, len1, vt[0], stack);
-        if(IODE_IS_A_NUMBER(vy[0]) && (notnul == 0 || fabs(vy[0]) > 1e-15)) break;
+    // 2. Calculate value before t
+    for(vt[0] = t - 1; vt[0] >= 0; vt[0]--) 
+    {
+        vy[0] = L_exec_sub(expr1, len1, vt[0]);
+        if(IODE_IS_A_NUMBER(vy[0]) && (notnul == 0 || fabs(vy[0]) > 1e-15)) 
+            break;
     }
 
-    /* if NO value after AND before t, return IODE_NAN */
-    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) return -1;
-    if(IODE_IS_A_NUMBER(vy[0]) && IODE_IS_A_NUMBER(vy[1])) return 0;
+    // if NO value after AND before t, return IODE_NAN
+    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
+        return -1;
+    
+    // if values found before and after t, return success
+    if(IODE_IS_A_NUMBER(vy[0]) && IODE_IS_A_NUMBER(vy[1])) 
+        return 0;
 
-    /* if no value after, calc before t0 */
-    if(!IODE_IS_A_NUMBER(vy[1])) {
+    // if no value after, calculate before t0
+    if(!IODE_IS_A_NUMBER(vy[1])) 
+    {
         vy[1] = vy[0];
         vt[1] = vt[0];
         vy[0] = IODE_NAN;
-        for(vt[0] = vt[1] - 1 ; vt[0] >= 0 ; vt[0]--) {
-            vy[0] = L_exec_sub(expr1, len1, vt[0], stack);
-            if(IODE_IS_A_NUMBER(vy[0]) && (notnul == 0 || fabs(vy[0]) > 1e-15)) break;
+        for(vt[0] = vt[1] - 1; vt[0] >= 0; vt[0]--) 
+        {
+            vy[0] = L_exec_sub(expr1, len1, vt[0]);
+            if(IODE_IS_A_NUMBER(vy[0]) && (notnul == 0 || fabs(vy[0]) > 1e-15)) 
+                break;
         }
     }
-
-    /* if no value before, calc after t1 */
-    else {
+    // if no value before, calculate after t1
+    else 
+    {
         vy[0] = vy[1];
         vt[0] = vt[1];
         vy[1] = IODE_NAN;
-        for(vt[1] = vt[0] + 1 ; vt[1] < nobs ; vt[1]++) {
-            vy[1] = L_exec_sub(expr1, len1, vt[1], stack);
-            if(IODE_IS_A_NUMBER(vy[1])) break;
+        for(vt[1] = vt[0] + 1; vt[1] < nb_obs; vt[1]++) 
+        {
+            vy[1] = L_exec_sub(expr1, len1, vt[1]);
+            if(IODE_IS_A_NUMBER(vy[1])) 
+                break;
         }
     }
 
@@ -466,204 +482,233 @@ int L_calcvals(unsigned char* expr1, short len1, int t, double* stack, int* vt, 
  *  @return     double  value of expr[t] or interpolated value
  *  
  */
-double L_interpol(unsigned char* expr, short nvargs, int t, double* stack, int nargs) /* JMP 17-04-98 */
-{
-    char    *expr1;
-    short   len1;
-    int     nobs, vt[2];
-    double  vx, vy[2], itc;
-
+double L_interpol(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    short len1;
     memcpy(&len1, expr, sizeof(short));
-    expr1 = ((char*) expr) + sizeof(short);
+    unsigned char* expr1 = expr + sizeof(short);
 
-    /* 1. Calc val in t */
-    vx = L_exec_sub((unsigned char*) expr1, len1, t, stack);
-    if(IODE_IS_A_NUMBER(vx)) return(vx);
+    // 1. Calculate value in t
+    double x = L_exec_sub(expr1, len1, t);
+    if(IODE_IS_A_NUMBER(x)) 
+        return x;
 
-    /* 2. Calc values around t */
-    L_calcvals((unsigned char*) expr1, len1, t, stack, vt, vy, 0);
-    nobs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
-
-    /* 3. Calc result */
-    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) return(IODE_NAN);
-    if(vt[0] < 0) return(vy[1]);
-    if(vt[1] >= nobs) return(vy[0]);
-    itc = (vy[0] * vt[1] - vy[1] * vt[0]) / (vt[1] - vt[0]);
-    return(itc + t * (vy[1] - vy[0]) / (vt[1] - vt[0]));
+    // 2. Calculate values around t
+    int vt[2];
+    double vy[2];
+    L_calcvals(expr1, len1, t, stack, vt, vy, 0);
+    
+    // if NO value after AND before t, return IODE_NAN
+    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
+        return IODE_NAN;
+    
+    // 3. Calculate result
+    int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
+    if(vt[0] < 0) 
+        return vy[1];
+    if(vt[1] >= nb_obs) 
+        return vy[0];
+    
+    double interpol = (vy[0] * vt[1] - vy[1] * vt[0]) / (vt[1] - vt[0]);
+    interpol += t * (vy[1] - vy[0]) / (vt[1] - vt[0]);
+    return interpol;
 }
 
-double L_app(unsigned char* expr, short nvargs, int t, double* stack, int nargs) /* JMP 17-04-98 */
-{
-    char    *expr1, *expr2;
-    short   len1, len2;
-    int     j, nobs, vt[2];
-    double  vx, vy[2], ayt, ay[2], delta;
-
+double L_app(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
-    expr1 = ((char*) expr) + sizeof(short);
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    expr2 = ((char*) expr) + len1 + 2 * sizeof(short);
+    unsigned char* expr1 = expr + sizeof(short);
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
 
-    /* 1. Calc val in t */
-    vx = L_exec_sub((unsigned char*) expr1, len1, t, stack);
-    if(IODE_IS_A_NUMBER(vx)) return(vx);
+    // 1. Calculate value in t
+    double x = L_exec_sub(expr1, len1, t);
+    if(IODE_IS_A_NUMBER(x)) 
+        return x;
 
-    /* 2. Calc values around t */
-    L_calcvals((unsigned char*) expr1, len1, t, stack, vt, vy, 1);
-    nobs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
+    // 2. Calculate values around t
+    int vt[2];
+    double vy[2];
+    L_calcvals(expr1, len1, t, stack, vt, vy, 1);
+    
+    // if NO value after AND before t, return IODE_NAN
+    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
+        return IODE_NAN;
+    
+    // ---- Valeurs apparentées ----
+    double ayt = L_exec_sub(expr2, len2, t);
+    if(!IODE_IS_A_NUMBER(ayt)) 
+        return IODE_NAN;
+    
+    double ay[2];
+    int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
+    ay[0] = ay[1] = IODE_NAN;
+    if(vt[0] >= 0)   
+        ay[0] = L_exec_sub(expr2, len2, vt[0]);
+    if(vt[1] < nb_obs) 
+        ay[1] = L_exec_sub(expr2, len2, vt[1]);
 
-    /* if NO value after AND before t, return IODE_NAN */
-    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) return(IODE_NAN);
-
-    /* Valeurs apparentées */
-    ayt = L_exec_sub((unsigned char*) expr2, len2, t, stack);
-    if(!IODE_IS_A_NUMBER(ayt)) return(IODE_NAN);
-    ay[0] = ay[1] = IODE_NAN; /* JMP 19-07-07 */
-    if(vt[0] >= 0)   ay[0] = L_exec_sub((unsigned char*) expr2, len2, vt[0], stack);
-    if(vt[1] < nobs) ay[1] = L_exec_sub((unsigned char*) expr2, len2, vt[1], stack);
-
-    // Deux valeurs trouvées dans la série initiale
+    // ---- Deux valeurs trouvées dans la série initiale ----
     // !! Les deux valeurs doivent exister dans la série apparentée
-    if(IODE_IS_A_NUMBER(ay[0]) && IODE_IS_A_NUMBER(ay[1])) {
-        if(vt[0] < t && vt[1] > t) {
-            /*            return(ayt * (vy[0] / ay[0] + vy[1] / ay[1]) / 2); */
-            // delta = (vy[1]/vy[0])/(ay[1]/ay[0]);
-            if(fabs(vy[0] * ay[1]) < 1e-15) return(IODE_NAN);
-            delta = (vy[1] * ay[0]) / (vy[0] * ay[1]);
-            if(delta < 0) return(IODE_NAN);
+    if(IODE_IS_A_NUMBER(ay[0]) && IODE_IS_A_NUMBER(ay[1])) 
+    {
+        if(vt[0] < t && vt[1] > t) 
+        {
+            if(fabs(vy[0] * ay[1]) < 1e-15) 
+                return IODE_NAN;
+            
+            double delta = (vy[1] * ay[0]) / (vy[0] * ay[1]);
+            if(delta < 0) 
+                return IODE_NAN;
+            
             delta = pow(delta, 1.0/(vt[1]-vt[0]));
-            if(_isnan(delta)) return(IODE_NAN); /* JMP 18-01-02 */
-            return(vy[0] * (ayt/ay[0] * pow(delta, t - vt[0])));
+            if(_isnan(delta)) 
+                return IODE_NAN;
+            
+            double result = vy[0] * (ayt / ay[0] * pow(delta, t - vt[0]));
+            return result;
         }
-        else {
-            j = 0;
-            if(vt[0] < t) j = 1;
-            if(fabs(ay[j]) < 1e-15) return(IODE_NAN); /* JMP 19-07-07 */
-            return(ayt * (vy[j] / ay[j]));
+        else 
+        {
+            int j = (vt[0] < t) ? 1 : 0;
+            if(fabs(ay[j]) < 1e-15) 
+                return IODE_NAN;
+            
+            return ayt * (vy[j] / ay[j]);
         }
     }
+
     // Seule la valeur en t0 est définie : res(t) <- APP(t) * (ORIG(t0) / APP(t0))
-    if(IODE_IS_A_NUMBER(ay[0])) {
-        if(fabs(ay[0]) < 1e-15) return(IODE_NAN); /* JMP 19-07-07 */
-        return(ayt * (vy[0] / ay[0]));
+    if(IODE_IS_A_NUMBER(ay[0])) 
+    {
+        if(fabs(ay[0]) < 1e-15) 
+            return IODE_NAN;
+        
+        return ayt * (vy[0] / ay[0]);
     }
+
     // Seule la valeur en t1 est définie : res(t) <- APP(t) * (ORIG(t1) / APP(t1))
-    if(IODE_IS_A_NUMBER(ay[1])) {
-        if(fabs(ay[1]) < 1e-15) return(IODE_NAN); /* JMP 19-07-07 */
-        return(ayt * (vy[1] / ay[1]));
+    if(IODE_IS_A_NUMBER(ay[1])) 
+    {
+        if(fabs(ay[1]) < 1e-15) 
+            return IODE_NAN;
+        
+        return ayt * (vy[1] / ay[1]);
     }
-    return(IODE_NAN);
+
+    return IODE_NAN;
 }
 
-double L_dapp(unsigned char* expr, short nvargs, int t, double* stack, int nargs)
-{
-    char    *expr1, *expr2;
-    short   len1, len2;
-    int     j, nobs, vt[2];
-    double  vx, vy[2], ayt, ay[2], delta;
-
+double L_dapp(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
-    expr1 = ((char*) expr) + sizeof(short);
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    expr2 = ((char*) expr) + len1 + 2 * sizeof(short);
+    unsigned char* expr1 = expr + sizeof(short);
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
 
-    /* 1. Calc val in t */
-    vx = L_exec_sub((unsigned char*) expr1, len1, t, stack);
-    if(IODE_IS_A_NUMBER(vx)) return(vx);
+    // 1. Calculate value in t
+    double x = L_exec_sub(expr1, len1, t);
+    if(IODE_IS_A_NUMBER(x)) 
+        return x;
 
-    /* 2. Calc values around t */
-    L_calcvals((unsigned char*) expr1, len1, t, stack, vt, vy, 0);
-    nobs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
+    // 2. Calculate values around t
+    int vt[2];
+    double vy[2];
+    L_calcvals(expr1, len1, t, stack, vt, vy, 0);
 
-    /* if NO value after AND before t, return IODE_NAN */
-    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) return(IODE_NAN);
+    // if NO value after AND before t, return IODE_NAN
+    if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
+        return IODE_NAN;
 
-    /* Valeurs apparentées */
-    ayt = L_exec_sub((unsigned char*)  expr2, len2, t, stack);
-    if(!IODE_IS_A_NUMBER(ayt)) return(IODE_NAN);
-    if(vt[0] >= 0)   ay[0] = L_exec_sub((unsigned char*) expr2, len2, vt[0], stack);
-    if(vt[1] < nobs) ay[1] = L_exec_sub((unsigned char*) expr2, len2, vt[1], stack);
+    // ---- Valeurs apparentées ----
+    double ayt = L_exec_sub(expr2, len2, t);
+    if(!IODE_IS_A_NUMBER(ayt)) 
+        return IODE_NAN;
+    
+    double ay[2];
+    int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
+    ay[0] = ay[1] = IODE_NAN;
+    if(vt[0] >= 0)   
+        ay[0] = L_exec_sub(expr2, len2, vt[0]);
+    if(vt[1] < nb_obs) 
+        ay[1] = L_exec_sub(expr2, len2, vt[1]);
 
-    if(IODE_IS_A_NUMBER(ay[0]) && IODE_IS_A_NUMBER(ay[1])) {
-        if(vt[0] < t && vt[1] > t) {
-            delta = (ay[1] - ay[0] + vy[0] - vy[1]) / (vt[1]-vt[0]);
-            return(ayt + vy[0] - ay[0] - (t - vt[0]) * delta);
+    if(IODE_IS_A_NUMBER(ay[0]) && IODE_IS_A_NUMBER(ay[1])) 
+    {
+        if(vt[0] < t && vt[1] > t) 
+        {
+            double delta = (ay[1] - ay[0] + vy[0] - vy[1]) / (vt[1]-vt[0]);
+            return ayt + vy[0] - ay[0] - (t - vt[0]) * delta;
         }
-        else {
-            j = 0;
-            if(vt[0] < t) j = 1;
-            return(ayt + (vy[j] - ay[j]));
+        else 
+        {
+            int j = (vt[0] < t) ? 1 : 0;
+            return ayt + (vy[j] - ay[j]);
         }
     }
+
     if(IODE_IS_A_NUMBER(ay[0]))                
-        return(ayt + (vy[0] - ay[0]));
+        return ayt + (vy[0] - ay[0]);
+    
     if(IODE_IS_A_NUMBER(ay[1]))                
-        return(ayt + (vy[1] - ay[1]));
-    return(IODE_NAN);
+        return ayt + (vy[1] - ay[1]);
+    
+    return IODE_NAN;
 }
 
-double L_hpall(unsigned char* expr, short len, int t, double* stack, int nargs, int std)
-{
-    char    *expr1, *expr2;
-    short   len1, len2;
-    double    v, *itmp = NULL, *otmp = NULL;
-    //int     from, to, j, lg, lambda, nbna, dim;      /* JMP 7-3-2019 */
-    int     from, to, j, lg, nbna, dim;         /* JMP 7-3-2019 */
-    double   lambda;                         /* JMP 7-3-2019 */
-
+double L_hpall(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs, int std)
+{    
+    short len1, len2;
     memcpy(&len1, expr, sizeof(short));
-    expr1 = ((char*) expr) + sizeof(short);
     memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    expr2 = ((char*) expr) + len1 + 2 * sizeof(short);
+    unsigned char* expr1 = expr + sizeof(short);
+    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
 
-    v = L_exec_sub((unsigned char*)  expr1, len1, t, stack);
-    if(!IODE_IS_A_NUMBER(v)) return(IODE_NAN);
-    lambda = v;
+    double value = L_exec_sub(expr1, len1, t);
+    if(!IODE_IS_A_NUMBER(value)) 
+        return IODE_NAN;
 
-    L_tfn_args(t, stack, nargs - 1, &from, &to);
-    if(t < from || t > to) goto err;
-    lg = to - from + 1;
-    if(lg < 5) goto err;
-    itmp = (double *) SCR_malloc(lg * sizeof(double));
-    otmp = (double *) SCR_malloc(lg * sizeof(double));
+    if(t < from || t > to) 
+        return IODE_NAN;
+    int nb = to - from + 1;
+    if(nb < 5) 
+        return IODE_NAN;
+    
+    double* itmp = (double *) SCR_malloc(nb * sizeof(double));
+    double* otmp = (double *) SCR_malloc(nb * sizeof(double));
+    if(itmp == NULL || otmp == NULL) 
+        return IODE_NAN;
+    
+    for(int j = from; j <= to; j++) 
+        itmp[j - from] = L_exec_sub(expr2, len2, j);
 
-    if(itmp == NULL || otmp == NULL) goto err;
-    for(j = from ; j <= to ; j++) {
-        itmp[j - from] = L_exec_sub((unsigned char*) expr2, len2, j, stack);
-        // if(!IODE_IS_A_NUMBER(itmp[j - from])) goto err;            /* JMP 26-07-11 */
+    int nbna, dim;
+    HP_test(itmp, otmp, nb, &nbna, &dim);
+    if(dim < 5) 
+    {
+        SCR_free(itmp);
+        SCR_free(otmp);
+        return IODE_NAN;
     }
-
-    /*
-        for(j = from, nbna = 0 ; j <= to ; j++, nbna++) {
-    	if(IODE_IS_A_NUMBER(itmp[j - from])) break;
-        }
-        if(lg - nbna < 5) goto err;
-    */
-
-    HP_test(itmp, otmp, lg, &nbna, &dim);           /* JMP 26-07-11 */
-    if(dim < 5) goto err;                           /* JMP 26-07-11 */
-    HP_calc(itmp + nbna, otmp + nbna, dim, lambda, std); /* JMP 26-07-11 */ // JMP 12/4/2019
+    
+    double lambda = value;
+    HP_calc(itmp + nbna, otmp + nbna, dim, lambda, std);
 
     SCR_free(itmp);
-    v = otmp[t - from];
+    value = otmp[t - from];
     SCR_free(otmp);
-    //DebugActif = 1;
-    //Debug("t=%d, lambda=%lf, v=%lf, from=%d, to=%d\n", t, lambda, v, from, to);
-    return(v);
-
-err:
-    SCR_free(itmp);
-    SCR_free(otmp);
-    return(IODE_NAN);
+    return value;
 }
 
-double L_hp(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_hp(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    return(L_hpall(expr, len, t, stack, nargs, 0));
+    return(L_hpall(expr, len, from, to, t, stack, nargs, 0));
 }
 
 
-double L_hpstd(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_hpstd(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    return(L_hpall(expr, len, t, stack, nargs, 1));
+    return(L_hpall(expr, len, from, to, t, stack, nargs, 1));
 }

--- a/api/lec/l_exec_mtfn.h
+++ b/api/lec/l_exec_mtfn.h
@@ -32,23 +32,26 @@ inline bool is_mtfn(const int op)
     return op >= L_MTFN; 
 }
 
-double L_calccorr(unsigned char* expr1, short lg1, unsigned char* expr2, short lg2, int t, double* stack, int nargs);
-double L_corr(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_calccovar(unsigned char* expr1, short lg1, unsigned char* expr2, short lg2, int t, double* stack, int nargs, int center);
-double L_covar(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_covar0(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_var(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_stddev(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_index(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_acf(unsigned char* expr, short lg, int t, double* stack, int nargs);
-int L_calcvals(unsigned char* expr, short lg, int t, double* stack, int* p_nargs, double* res, int nbvals);
-double L_interpol(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_app(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_hp(unsigned char* expr, short len, int t, double* stack, int nargs);
-double L_dapp(unsigned char* expr, short nvargs, int t, double* stack, int nargs);
-double L_hpstd(unsigned char* expr, short len, int t, double* stack, int nargs);
+int L_calcvals(unsigned char* expr, short lg, int t, std::deque<double>& stack, int* p_nargs, double* res, int nbvals);
+double L_calccorr(unsigned char* expr1, short lg1, unsigned char* expr2, short lg2, int from, int to, int t, 
+    std::deque<double>& stack, int nargs);
+double L_calccovar(unsigned char* expr1, short lg1, unsigned char* expr2, short lg2, int from, int to, int t, 
+    std::deque<double>& stack, int nargs, int center);
 
-inline double(*L_MTFN_FN[])(unsigned char* expr, short nvargs, int t, double *stack, int nargs) = 
+double L_corr(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_covar(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_covar0(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_var(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_stddev(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_index(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_interpol(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_app(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_hp(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_dapp(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_hpstd(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+
+inline double(*L_MTFN_FN[])(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) = 
 { 
     L_corr,         // L_CORR      L_M
     L_covar,        // L_COVAR     L_M
@@ -93,7 +96,7 @@ public:
         if(!is_mtfn(type))
             throw std::invalid_argument("Invalid multi-time function type for LEC MULTI-TIME FUNC: " + std::to_string(type));
         pos = type - L_MTFN;
-        representation = L_MTFN_NAMES[pos];
+        fn_name = L_MTFN_NAMES[pos];
         // minimum length in bytes of the function arguments (i.e. the sub-expression in the buffer)
         len_args = (short) (sizeof(short) * L_MIN_MTARGS[pos]);
     }
@@ -154,15 +157,20 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, double* stack, int& pos_stack)
+    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack)
     {
+        int from = -1, to = -1;
+        // NOTE: in function L_extract_time_range():
+        //       - If nargs = 1, 'from' is the beginning of the KDB sample and 'to'=t
+        //       - If nargs = 2, 'from' is on the stack and 'to'=t
+        //       - If nargs = 3, 'from' and 'to' are on the stack
+        if(type != L_INTERPOL && type != L_APP)
+            L_extract_time_range(t, stack, nb_args - 1, from, to);
+
         // NOTE: 'j + 3 + sizeof(short)' corresponds to the position of the sub-expression
         //       in the buffer (after type, nb_args, nv_args and len_args)
         j += 3 + sizeof(short);
- 
-        // QUESTION: why '- nv_args' ?
-        int shift = nb_args - nv_args - 1;
-        stack[pos_stack - shift] = (L_MTFN_FN[pos])(expr + j, nv_args, t, stack + pos_stack, nb_args);
-        pos_stack -= shift;
+        double result = (L_MTFN_FN[pos])(expr + j, nv_args, from, to, t, stack, nb_args);
+        stack.push_back(result);
     }
 };

--- a/api/lec/l_exec_ops.cpp
+++ b/api/lec/l_exec_ops.cpp
@@ -1,39 +1,3 @@
-/**
- * @header4iode
- *
- * Functions to evaluate LEC "operators". 
- * 
- * The table (*L_OPS_FN)[] contains the pointers to the operators from L_OR to L_EXP (see iode.h).
- *
- * Function signature:
- *
- *      double  <fnname>(double value1, double value2);
- *  
- *  where value1 and value2 are the parameters that have been passed to the function in the LEC expression.
- *  
- *  Example: in the LEC expression
- *   
- *      2 < 3
- *  
- *  value1 is 2 and value2 is 3
- *  
- *  List of functions
- *  -----------------
- *      double L_or (double a, double b)
- *      double L_and (double a, double b)
- *      double L_ge (double a, double b)
- *      double L_gt (double a, double b)
- *      double L_le (double a, double b)
- *      double L_lt (double a, double b)
- *      double L_eq (double a, double b)
- *      double L_ne (double a, double b)
- *      double L_plus (double a, double b)
- *      double L_minus(double a, double b)
- *      double L_times(double a, double b)
- *             double L_divide(double a, double b)
- *             double L_exp(double a, double b)
- *  
- */
 #include <math.h>
 #include "api/lec/lec.h"
 
@@ -41,41 +5,52 @@
     #define _isnan isnan
 #endif
 
-double L_or   (double a, double b) {return((a || b) ? (double)1.0 : (double)0.0);}
-double L_and  (double a, double b) {return((a && b) ? (double)1.0 : (double)0.0);}
-double L_ge   (double a, double b) {return((a >= b) ? (double)1.0 : (double)0.0);}
-double L_gt   (double a, double b) {return((a > b)  ? (double)1.0 : (double)0.0);}
-double L_le   (double a, double b) {return((a <= b) ? (double)1.0 : (double)0.0);}
-double L_lt   (double a, double b) {return((a < b)  ? (double)1.0 : (double)0.0);}
-double L_eq   (double a, double b) {return((a == b) ? (double)1.0 : (double)0.0);}
-double L_ne   (double a, double b) {return((a != b) ? (double)1.0 : (double)0.0);}
-double L_plus (double a, double b) {return(a + b);}
-double L_minus(double a, double b) {return(a - b);}
-double L_times(double a, double b) {return(a * b);}
-
-/*  Note: L_divide() and L_exp() are used by other functions and must therefore be global. */
+double L_or   (double a, double b) { return (a || b) ? 1.0 : 0.0; }
+double L_and  (double a, double b) { return (a && b) ? 1.0 : 0.0; }
+double L_ge   (double a, double b) { return (a >= b) ? 1.0 : 0.0; }
+double L_gt   (double a, double b) { return (a > b)  ? 1.0 : 0.0; }
+double L_le   (double a, double b) { return (a <= b) ? 1.0 : 0.0; }
+double L_lt   (double a, double b) { return (a < b)  ? 1.0 : 0.0; }
+double L_eq   (double a, double b) { return (a == b) ? 1.0 : 0.0; }
+double L_ne   (double a, double b) { return (a != b) ? 1.0 : 0.0; }
+double L_plus (double a, double b) { return a + b; }
+double L_minus(double a, double b) { return a - b; }
+double L_times(double a, double b) { return a * b; }
 
 double L_divide(double a, double b) 
 {
-    if(!IODE_IS_A_NUMBER(b) || !IODE_IS_A_NUMBER(a) || b == 0) {
-        return((double)IODE_NAN);
-    }
-    return(a / b);
+    if(!IODE_IS_A_NUMBER(b) || !IODE_IS_A_NUMBER(a) || b == 0)
+        return IODE_NAN;
+    return a / b;
 }
 
 double L_exp(double a, double b)
 {
-    double x, ib;
+    double x;
 
-    if(a < 0 && b != (int)b) {
-        // test 2018 : si (-a)^0.333 => faire -a^0.333
-        ib = 1 / b;
-        if(fabs(ib - (int) ib) > 1e-8) return(IODE_NAN);
-        if((int)ib % 2 != 1)           return(IODE_NAN);
-        x = -pow((double)-a, (double)b);
+    // a^b for a < 0 and b not an integer
+    if(a < 0 && b != (int) b) 
+    {
+        // check if a^b can be represented as a^(1/c) where 
+        // 1) c is an integer  
+        double c = 1.0 / b;
+        bool is_fraction = fabs(c - (int) c) < 1e-8;
+        if(!is_fraction) 
+            return IODE_NAN;
+        // 2) c is an odd integer 
+        // (ex: (-8)^(1/3) = -(8^(1/3)) = -2, but (-8)^(1/2) is not a real number)
+        bool is_odd_integer = (int) c % 2 == 1;
+        if(!is_odd_integer)
+            return IODE_NAN;
+
+        // a^b = (-x)^b = (-)^b * x^b = -(x^b) if 1/b is an odd integer
+        x = -pow(-a, b);
     }
     else
-        x = pow((double)a, (double)b);
-    if(_isnan(x)) x = IODE_NAN; /* JMP 18-01-02 */
-    return((double)x);
+        x = pow(a, b);
+    
+    if(_isnan(x)) 
+        x = IODE_NAN;
+    
+    return x;
 }

--- a/api/lec/l_exec_ops.h
+++ b/api/lec/l_exec_ops.h
@@ -87,7 +87,7 @@ public:
         if(!is_op(type))
             throw std::invalid_argument("Invalid operator type for LEC OPERATOR: " + std::to_string(type));
         pos = type - L_OP;
-        representation = L_OPS_NAMES[pos];
+        fn_name = L_OPS_NAMES[pos];
     }
 
     // extract from the buffer starting at pos_buffer and update pos_buffer
@@ -105,13 +105,18 @@ public:
     }
 
     // executes the operator with the given arguments on the stack
-    void execute(double* stack, int& pos_stack)
+    void execute(std::deque<double>& stack)
     {
-        if(L_stack_is_nan(stack, pos_stack, 2)) 
-            stack[pos_stack - 1] = IODE_NAN;
+        double b = stack.back();
+        stack.pop_back();
+        double a = stack.back();
+        stack.pop_back();
+
+        double result;
+        if(!IODE_IS_A_NUMBER(a) || !IODE_IS_A_NUMBER(b))
+            result = IODE_NAN;
         else
-            stack[pos_stack - 1] = (L_OPS_FN[pos])(stack[pos_stack - 1], stack[pos_stack]);
-        
-        pos_stack--;
+            result = (L_OPS_FN[pos])(a, b);
+        stack.push_back(result);
     }
 };

--- a/api/lec/l_exec_tfn.cpp
+++ b/api/lec/l_exec_tfn.cpp
@@ -1,6 +1,4 @@
 /**
- * @header4iode
- *
  * Functions to evaluate LEC "time functions". Time functions depend on "time" or "lag" parameters.
  * 
  * Example 1: optional time parameters
@@ -16,7 +14,7 @@
  *
  * Function signature:
  *
- *      double <fnname>(unsigned char* expr, short len, int t, double* stack, int nargs)
+ *      double <fnname>(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
  *  
  *  where:
  *      - expr points to the current position in the CLEC expression (in "sum(A + B))", expr points to "A + B")
@@ -41,28 +39,54 @@
  *          - len = length of "A+B" (compiled in CLEC)
  *          - t = 1 (2001Y1 is one position right from 2000Y1)
  *          - *stack = 2 is the current stack before the call to L_lag()
- *          - nargs = 2 (2 and A+B are the 2 arguments of dln)
- *  
- *  List of functions
- *  -----------------
- *  Note that these functions are all called by L_exec_sub() (@see l_exec.c).
- *  
- *      double L_diff(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_rapp(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_dln(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_grt(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_mavg(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_vmax(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_vmin(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_sum(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_prod(unsigned char* expr, short len, int t, double* stack, int nargs)
- *             double L_mean(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_stderr(unsigned char* expr, short len, int t, double* stack, int nargs)
- *      double L_lastobs(unsigned char* expr, short len, int t, double* stack, int nargs)
- *  
+ *          - nargs = 2 (2 and A+B are the 2 arguments of dln) 
  */
 #include <math.h>
 #include "api/lec/lec.h"
+
+
+/**
+ *  Utility function to retrieve one or 2 optional time values on the stack.
+ *  Ex.: 
+ *      vmax(1990Y1, 2000Y1, A+B):  from=1990Y1, to=2000Y1
+ *      vmax(1990Y1, A+B):          from=1990Y1, to=t
+ *      vmax(A+B):                  from=0,      to=t
+ * 
+ *  Note: do not consume the arguments on the stack.
+ *  
+ *  @param [in]  t      int     current value of t (in a simulation loop for example)
+ *  @param [in]  stack  double  top of the stack
+ *  @param [in]  nargs  int     nb of args passed to the function
+ *  @param [out] from   int*    position in the sample of the "from" arg
+ *  @param [out] to     int*    position in the sample of the "to" arg
+ */
+void L_extract_time_range(int t, std::deque<double>& stack, int nargs, int& from, int& to)
+{
+    from = 0;
+    to = t;
+    if(nargs == 1) 
+        return;
+
+    double arg;
+    if(nargs == 3)
+    {
+        arg = stack.back();
+        to = L_intlag(arg);
+        stack.pop_back();
+    }
+
+    arg = stack.back();
+    from = L_intlag(arg);
+    stack.pop_back();
+
+    // if from > to, swap them
+    if(from > to) 
+    {
+        int j = from;
+        from = to;
+        to = j;
+    }
+}
 
 /* ============ TFN ============ */
 
@@ -80,13 +104,18 @@
  *  @return             double          result of "expr in t"
  *  
  */
-
-double L_lag(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_lag(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    int     lag = 1;
-
-    if(nargs == 2) lag = L_intlag(*stack);
-    return(L_exec_sub(expr, len, t - lag, stack));
+    int lag = 1;
+    if(nargs == 2)
+    {
+        double x = stack.back();
+        stack.pop_back();
+        lag = L_intlag(x);
+    } 
+    
+    double value = L_exec_sub(expr, len, t - lag);
+    return value;
 }
 
 
@@ -97,17 +126,25 @@ double L_lag(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_diff(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_diff(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1, v2;
-    int     lag = 1;
-
-    if(nargs == 2) lag = L_intlag(*stack);
-    v1 = L_exec_sub(expr, len, t, stack);
-    if(!IODE_IS_A_NUMBER(v1)) return(IODE_NAN);
-    v2 = L_exec_sub(expr, len, t - lag, stack);
-    if(!IODE_IS_A_NUMBER(v2)) return(IODE_NAN);
-    return(v1 - v2);
+    int lag = 1;
+    if(nargs == 2)
+    {
+        double x = stack.back();
+        stack.pop_back();
+        lag = L_intlag(x);
+    }
+    
+    double v1 = L_exec_sub(expr, len, t);
+    if(!IODE_IS_A_NUMBER(v1)) 
+        return IODE_NAN;
+    
+    double v2 = L_exec_sub(expr, len, t - lag);
+    if(!IODE_IS_A_NUMBER(v2)) 
+        return IODE_NAN;
+    
+    return v1 - v2;
 }
 
 
@@ -117,21 +154,23 @@ double L_diff(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_rapp(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_rapp(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1, v2;
-    int     lag = 1;
-
-    if(nargs == 2) 
-        lag = L_intlag(*stack);
+    int lag = 1;
+    if(nargs == 2)
+    {
+        double x = stack.back();
+        stack.pop_back();
+        lag = L_intlag(x);
+    }
     
-    v1 = L_exec_sub(expr, len, t, stack);
+    double v1 = L_exec_sub(expr, len, t);
     if(!IODE_IS_A_NUMBER(v1)) 
-        return(IODE_NAN);
+        return IODE_NAN;
     
-    v2 = L_exec_sub(expr, len, t - lag, stack);
+    double v2 = L_exec_sub(expr, len, t - lag);
     if(!IODE_IS_A_NUMBER(v2)) 
-        return(IODE_NAN);
+        return IODE_NAN;
 
     double result = L_divide(v1, v2);
     return result;
@@ -144,17 +183,25 @@ double L_rapp(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_dln(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_dln(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1, v2;
-    int     lag = 1;
+    int lag = 1;
+    if(nargs == 2)
+    {
+        double x = stack.back();
+        stack.pop_back();
+        lag = L_intlag(x);
+    }
 
-    if(nargs == 2) lag = L_intlag(*stack);
-    v1 = L_exec_sub(expr, len, t, stack);
-    if(!IODE_IS_A_NUMBER(v1)) return(IODE_NAN);
-    v2 = L_exec_sub(expr, len, t - lag, stack);
-    if(!IODE_IS_A_NUMBER(v2)) return(IODE_NAN);
-    return(L_logn(L_divide(v1, v2)));
+    double v1 = L_exec_sub(expr, len, t);
+    if(!IODE_IS_A_NUMBER(v1)) 
+        return IODE_NAN;
+    
+    double v2 = L_exec_sub(expr, len, t - lag);
+    if(!IODE_IS_A_NUMBER(v2)) 
+        return IODE_NAN;
+    
+    return L_logn(L_divide(v1, v2));
 }
 
 
@@ -164,13 +211,12 @@ double L_dln(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_grt(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_grt(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1;
-
-    v1 = L_rapp(expr, len, t, stack, nargs);
-    if(!IODE_IS_A_NUMBER(v1)) return(IODE_NAN);
-    return((double)((v1 - 1.0) * 100.0));
+    double v1 = L_rapp(expr, len, from, to, t, stack, nargs);
+    if(!IODE_IS_A_NUMBER(v1)) 
+        return IODE_NAN;
+    return (v1 - 1.0) * 100.0;
 }
 
 
@@ -180,28 +226,38 @@ double L_grt(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_mavg(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_mavg(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1 = 0.0, tmp;
-    int     n = 1, j;
+    int lag = 1;
+    if(nargs == 2)
+    {
+        double x = stack.back();
+        stack.pop_back();
+        lag = L_intlag(x);
+    }
 
-    if(nargs == 2) n = L_intlag(*stack);
-    n = (n < 1) ? 1 : n;
-    for(j = 0 ; j < n ; j++) {
-        tmp = L_exec_sub(expr, len, t - j, stack);
-        if(!IODE_IS_A_NUMBER(tmp)) return(IODE_NAN);
+    lag = (lag < 1) ? 1 : lag;
+
+    double tmp;
+    double v1 = 0.0;
+    for(int j = 0; j < lag; j++) 
+    {
+        tmp = L_exec_sub(expr, len, t - j);
+        if(!IODE_IS_A_NUMBER(tmp)) 
+            return IODE_NAN;
         v1 += tmp;
     }
-    return((double)(v1 / n));
+
+    return v1 / lag;
 }
 
 
 /**
  *  Computes the maximum of an expression on a sub sample. The boundaries of the sub sample [p1, p2] 
  *  defined below: 
- *      - If nargs = 1, p1 is the beginning of the KDB sample and p2=t
- *      - If nargs = 2, p1 is on the stack and p2=t
- *      - If nargs = 3, p1 and p2 are on the stack
+ *      - If nargs = 1, 'from' is the beginning of the KDB sample and 'to'=t
+ *      - If nargs = 2, 'from' is on the stack and 'to'=t
+ *      - If nargs = 3, 'from' and 'to' are on the stack
  *  
  *  @param [in] expr    unsigned char*  compiled clec sub-expression to compute
  *  @param [in] len     short           length of expr
@@ -211,20 +267,23 @@ double L_mavg(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  @return             double          the maximum of expr on the period [p1, p2]
  *  
  */
-double L_vmax(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_vmax(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1, v2;
-    int     from, to, j;
-
-    L_tfn_args(t, stack, nargs, &from, &to);
-    v1 = L_exec_sub(expr, len, from, stack);
-    if(!IODE_IS_A_NUMBER(v1)) return(IODE_NAN);
-    for(j = from + 1 ; j <= to ; j++) {
-        v2 = L_exec_sub(expr, len, j, stack);
-        if(!IODE_IS_A_NUMBER(v2)) return(IODE_NAN);
-        if(v2 > v1) v1 = v2;
+    double value = L_exec_sub(expr, len, from);
+    if(!IODE_IS_A_NUMBER(value)) 
+        return IODE_NAN;
+ 
+    double max = value;
+    for(int j = from + 1; j <= to; j++) 
+    {
+        value = L_exec_sub(expr, len, j);
+        if(!IODE_IS_A_NUMBER(value)) 
+            return IODE_NAN;
+        if(value > max) 
+            max = value;
     }
-    return(v1);
+
+    return max;
 }
 
 
@@ -233,19 +292,23 @@ double L_vmax(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_vmax() for more details.
  */
-double L_vmin(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_vmin(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1, v2;
-    int     from, to, j;
+    double value = L_exec_sub(expr, len, from);
+    if(!IODE_IS_A_NUMBER(value)) 
+        return IODE_NAN;
 
-    L_tfn_args(t, stack, nargs, &from, &to);
-    v1 = L_exec_sub(expr, len, from, stack);
-    for(j = from + 1 ; j <= to ; j++) {
-        v2 = L_exec_sub(expr, len, j, stack);
-        if(!IODE_IS_A_NUMBER(v2)) return(IODE_NAN);
-        if(v2 < v1) v1 = v2;
+    double min = value;
+    for(int j = from + 1; j <= to; j++) 
+    {
+        value = L_exec_sub(expr, len, j);
+        if(!IODE_IS_A_NUMBER(value)) 
+            return IODE_NAN;
+        if(value < min) 
+            min = value;
     }
-    return(v1);
+
+    return min;
 }
 
 
@@ -254,18 +317,19 @@ double L_vmin(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_vmax() for more details.
  */
-double L_sum(unsigned char* expr, short len, int t, double* stack, int nargs)
-{
-    double    v1 = 0.0, tmp;
-    int     from, to, j;
-
-    L_tfn_args(t, stack, nargs, &from, &to);
-    for(j = from ; j <= to ; j++) {
-        tmp = L_exec_sub(expr, len, j, stack);
-        if(!IODE_IS_A_NUMBER(tmp)) return(IODE_NAN);
-        v1 += tmp;
+double L_sum(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    double value;
+    double sum = 0.0;
+    for(int j = from; j <= to; j++) 
+    {
+        value = L_exec_sub(expr, len, j);
+        if(!IODE_IS_A_NUMBER(value)) 
+            return IODE_NAN;
+        sum += value;
     }
-    return(v1);
+
+    return sum;
 }
 
 
@@ -274,18 +338,19 @@ double L_sum(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  
  *  @see L_vmax() for more details.
  */
-double L_prod(unsigned char* expr, short len, int t, double* stack, int nargs)
+double L_prod(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double  v1 = 1.0, tmp;
-    int     from, to, j;
-
-    L_tfn_args(t, stack, nargs, &from, &to);
-    for(j = from ; j <= to ; j++) {
-        tmp = L_exec_sub(expr, len, j, stack);
-        if(!IODE_IS_A_NUMBER(tmp)) return(IODE_NAN);
-        v1 *= tmp;
+    double value;
+    double prod = 1.0;
+    for(int j = from; j <= to; j++) 
+    {
+        value = L_exec_sub(expr, len, j);
+        if(!IODE_IS_A_NUMBER(value)) 
+            return IODE_NAN;
+        prod *= value;
     }
-    return(v1);
+
+    return prod;
 }
 
 
@@ -297,16 +362,14 @@ double L_prod(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  @note not a function because it is also used by MTFN functions
  */
 
-double L_mean(unsigned char* expr, short len, int t, double* stack, int nargs)
-{
-    double  v1;
-    int     from, to;
+double L_mean(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    double sum = L_sum(expr, len, from, to, t, stack, nargs);
+    if(!IODE_IS_A_NUMBER(sum)) 
+        return IODE_NAN;
 
-    L_tfn_args(t, stack, nargs, &from, &to);
-    v1 = L_sum(expr, len, t, stack, nargs);
-    if(!IODE_IS_A_NUMBER(v1)) return(IODE_NAN);
-    v1 /= (1 + to - from);
-    return(v1);
+    int nb = 1 + to - from;
+    return sum / nb;
 }
 
 
@@ -316,23 +379,25 @@ double L_mean(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  @see L_vmax() for more details.
  *  
  */
-double L_stderr(unsigned char* expr, short len, int t, double* stack, int nargs)
-{
-    double  s = 0.0, s2 = 0.0, v1;
-    int     from, to, j, n;
-
-    L_tfn_args(t, stack, nargs, &from, &to);
-    for(j = from ; j <= to ; j++) {
-        v1  = L_exec_sub(expr, len, j, stack);
-        if(!IODE_IS_A_NUMBER(v1)) return(IODE_NAN);
-        s  += v1;
-        s2 += v1 * v1;
+double L_stderr(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    double value;
+    double sum = 0.0, sum2 = 0.0;
+    for(int j = from; j <= to; j++) 
+    {
+        value = L_exec_sub(expr, len, j);
+        if(!IODE_IS_A_NUMBER(value)) 
+            return IODE_NAN;
+        sum += value;
+        sum2 += value * value;
     }
-    n = 1 + to - from;
-    if(n <= 1 || (s2 - s * s / n) < 0) return(IODE_NAN);  /* JMP 20-04-98 */
-    v1 = sqrt((s2 - s * s / n) / (n - 1));             /* JMP 20-04-98 */
 
-    return(v1);
+    int nb = 1 + to - from;
+    double x = (sum2 - sum * sum / nb);
+    if(nb <= 1 || x < 0) 
+        return IODE_NAN;
+    
+    return sqrt(x / (nb - 1));
 }
 
 
@@ -342,15 +407,15 @@ double L_stderr(unsigned char* expr, short len, int t, double* stack, int nargs)
  *  @see L_vmax() for more details.
  *  
  */
-double L_lastobs(unsigned char* expr, short len, int t, double* stack, int nargs)
-{
-    double  tmp;
-    int     from, to, j;
-
-    L_tfn_args(t, stack, nargs, &from, &to);
-    for(j = to ; j >= from ; j--) {
-        tmp = L_exec_sub(expr, len, j, stack);
-        if(IODE_IS_A_NUMBER(tmp)) return(tmp);
+double L_lastobs(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+{   
+    double value;
+    for(int j = to; j >= from; j--) 
+    {
+        value = L_exec_sub(expr, len, j);
+        if(IODE_IS_A_NUMBER(value)) 
+            return value;
     }
-    return(IODE_NAN);
+
+    return IODE_NAN;
 }

--- a/api/lec/l_exec_tfn.h
+++ b/api/lec/l_exec_tfn.h
@@ -12,12 +12,12 @@ enum LecTimeFunction
     L_DLN,              // dln([n,] expr)
     L_GRT,              // grt([n,] expr)
     L_MAVG,             // ma([n,] expr)
-    L_VMAX,             // vmax([n,[m,]] expr)
-    L_VMIN,             // vmin([n,[m,]] expr)
-    L_SUM,              // sum([n,[m,]] expr)
-    L_PROD,             // prod([n,[m,]] expr)
-    L_MEAN,             // mean([n,[m,]] expr)
-    L_STDERR,           // stderr([n,[m,]] expr)
+    L_VMAX,             // vmax([from, [to,]] expr)
+    L_VMIN,             // vmin([from, [to,]] expr)
+    L_SUM,              // sum([from, [to,]] expr)
+    L_PROD,             // prod([from, [to,]] expr)
+    L_MEAN,             // mean([from, [to,]] expr)
+    L_STDERR,           // stderr([from, [to,]] expr)
     L_DLAG,             // dlag(n, coef, expr)
     L_LASTOBS           // lastobs([from, [to,]] expr)
 };
@@ -35,23 +35,23 @@ inline bool is_tfn(const int op)
     return op >= L_TFN && op <= L_TFN_LAST; 
 }
 
-void L_tfn_args(int nvargs, double* stack, int nargs, int* from, int* to);
+void L_extract_time_range(int t, std::deque<double>& stack, int nargs, int& from, int& to);
 
-double L_lag(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_diff(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_rapp(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_dln(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_grt(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_mavg(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_vmax(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_vmin(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_sum(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_prod(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_mean(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_stderr(unsigned char* expr, short lg, int t, double* stack, int nargs);
-double L_lastobs(unsigned char* expr, short lg, int t, double* stack, int nargs);
+double L_lag(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_diff(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_rapp(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_dln(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_grt(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_mavg(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_vmax(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_vmin(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_sum(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_prod(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_mean(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_stderr(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_lastobs(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
 
-inline double(*L_TFN_FN[])(unsigned char* expr, short length, int t, double *stack, int nargs) = 
+inline double(*L_TFN_FN[])(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs) = 
 { 
     L_lag,          // L_LAG       L_TFN + 0 
     L_diff,         // L_DIFF      L_TFN + 1 
@@ -97,7 +97,7 @@ public:
         if(!is_tfn(type))
             throw std::invalid_argument("Invalid time function type for LEC TIME FUNC: " + std::to_string(type));
         pos = type - L_TFN;
-        representation = L_TFN_NAMES[pos];
+        fn_name = L_TFN_NAMES[pos];
     }
 
     // extract from the buffer starting at pos_buffer and update pos_buffer
@@ -150,15 +150,22 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, double* stack, int& pos_stack)
+    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack)
     {
+        int from = -1, to = -1;
+        // NOTE: for time functions:
+        //       - If nargs = 1, 'from' is the beginning of the KDB sample and 'to'=t
+        //       - If nargs = 2, 'from' is on the stack and 'to'=t
+        //       - If nargs = 3, 'from' and 'to' are on the stack
+        if(type == L_VMAX || type == L_VMIN || type == L_SUM || type == L_PROD || type == L_MEAN || 
+           type == L_STDERR || type == L_LASTOBS)
+            L_extract_time_range(t, stack, nb_args, from, to);
+
         // NOTE: 'j + 2 + sizeof(short)' corresponds to the position of the sub-expression 
         //       in the buffer (after type, nb_args and len_args)
         j += 2 + sizeof(short);
 
-        // QUESTION: why '- 2' ?
-        int shift = nb_args - 2;
-        stack[pos_stack - shift] = (L_TFN_FN[pos])(expr + j, len_args, t, stack + pos_stack, nb_args);
-        pos_stack -= shift;
+        double result = (L_TFN_FN[pos])(expr + j, len_args, from, to, t, stack, nb_args);
+        stack.push_back(result);
     }
 };

--- a/api/lec/l_exec_val.cpp
+++ b/api/lec/l_exec_val.cpp
@@ -1,26 +1,3 @@
-/**
- * @header4iode
- *
- * Functions to evaluate LEC "values". 
- * 
- * The table (*L_VAL_FN)[] contains the function pointers to evaluate L_PI to L_EURO (see iode.h).
- *
- * Function signatures:
- *
- *      double  <fnname>(int t);
- *  or
- *      double  <fnname>(void);
- *  
- *  List of functions
- *  -----------------
- *      double L_pi ()
- *      double L_euro()
- *      double L_e ()
- *      double L_time(int t)
- *      double L_i(int t)
- *     
- */
-
 #include "api/lec/lec.h"
 
 
@@ -28,17 +5,17 @@
 
 double L_pi(int t) 
 { 
-    return (double) M_PI; 
+    return M_PI; 
 }
 
 double L_euro(int t) 
 { 
-    return (double) 40.3399; 
+    return 40.3399; 
 }
 
 double L_e(int t) 
 { 
-    return (double) M_E; 
+    return M_E; 
 }
 
 double L_time(int t) 

--- a/api/lec/l_exec_val.h
+++ b/api/lec/l_exec_val.h
@@ -61,7 +61,7 @@ public:
         if(!is_val(type))
             throw std::invalid_argument("Invalid operator type for LEC VALUE FUNCTION: " + std::to_string(type));
         pos = type - L_VAL;
-        representation = L_VAL_FN_NAMES[pos];
+        fn_name = L_VAL_FN_NAMES[pos];
     }
 
     // extract from the buffer starting at pos_buffer and update pos_buffer
@@ -79,9 +79,9 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(const int t, double* stack, int& pos_stack)
+    void execute(const int t, std::deque<double>& stack)
     {
-        pos_stack++;
-        stack[pos_stack] = (L_VAL_FN[pos])(t);
+        double value = (L_VAL_FN[pos])(t);
+        stack.push_back(value);
     }
 };

--- a/doc/dev/LEC.md
+++ b/doc/dev/LEC.md
@@ -238,7 +238,7 @@ Functions to evaluate a compiled and linked LEC expression.
 
 |Syntax|Description|
 |:---|:---|
-|`double L_exec_sub(unsigned char* expr, int lg, int t, double* stack)`|Execution of a CLEC sub expression.|
+|`double L_exec_sub(unsigned char* expr, int lg, int t, std::deque<double> stack)`|Execution of a CLEC sub expression.|
 |`double L_exec(KDBVariablesPtr dbv, KDBScalarsPtr dbs, CLEC* clec, int t)`|Execution of a compiled and linked CLEC expression.|
 |`double* L_cc_link_exec(char* lec, KDB* dbv, KDB* dbs)`|Compiles, links and executes a LEC expression.|
 
@@ -280,43 +280,43 @@ Functions to evaluate LEC "functions".
 
 |Syntax|Description|
 |:---|:---|
-|`double L_logn(double v)`||
-|`static double L_uminus(double* stack)`||
-|`static double L_uplus (double* stack)`||
-|`static double L_log(double* stack, int nargs)`||
-|`static double L_ln(double* stack)`||
-|`static double L_not(double* stack)`||
-|`static double L_expn(double* stack, int nargs)`||
-|`static double L_max(double* stack, int nargs)`||
-|`static double L_min(double* stack, int nargs)`||
-|`static double L_sin (double* stack)`||
-|`static double L_cos (double* stack)`||
-|`static double L_acos (double* stack)`||
-|`static double L_asin (double* stack)`||
-|`static double L_tan (double* stack)`||
-|`static double L_atan (double* stack)`||
-|`static double L_tanh (double* stack)`||
-|`static double L_sinh (double* stack)`||
-|`static double L_cosh (double* stack)`||
-|`static double L_abs (double* stack)`||
-|`static double L_sqrt (double* stack)`||
-|`static double L_int (double* stack)`||
-|`static double L_rad (double* stack)`||
-|`static double L_if(double* stack, int nargs)`||
-|`static double L_lsum(double* stack, int nargs)`||
-|`static double L_lmean(double* stack, int nargs)`||
-|`static double L_fnisan(double* stack, int nargs)`||
-|`static double L_lcount(double* stack, int nargs)`||
-|`static double L_lprod(double* stack, int nargs)`||
-|`static double L_sign(double* stack)`||
-|`static double L_lstderr(double* stack, int nargs)`||
-|`static double L_random(double* stack)`||
-|`static double L_floor(double* stack)`||
-|`static double L_ceil (double* stack)`||
-|`static double L_round(double* stack, int nargs)`||
-|`static double L_urandom(double* stack)`||
-|`static double L_grandom(double* stack)`||
-|`static double L_gamma(double* stack)`||
+|`double L_logn(const double v)`||
+|`static double L_uminus(std::deque<double>& stack)`||
+|`static double L_uplus (std::deque<double>& stack)`||
+|`static double L_log(std::deque<double>& stack, int nargs)`||
+|`static double L_ln(std::deque<double>& stack)`||
+|`static double L_not(std::deque<double>& stack)`||
+|`static double L_expn(std::deque<double>& stack, int nargs)`||
+|`static double L_max(std::deque<double>& stack, int nargs)`||
+|`static double L_min(std::deque<double>& stack, int nargs)`||
+|`static double L_sin (std::deque<double>& stack)`||
+|`static double L_cos (std::deque<double>& stack)`||
+|`static double L_acos (std::deque<double>& stack)`||
+|`static double L_asin (std::deque<double>& stack)`||
+|`static double L_tan (std::deque<double>& stack)`||
+|`static double L_atan (std::deque<double>& stack)`||
+|`static double L_tanh (std::deque<double>& stack)`||
+|`static double L_sinh (std::deque<double>& stack)`||
+|`static double L_cosh (std::deque<double>& stack)`||
+|`static double L_abs (std::deque<double>& stack)`||
+|`static double L_sqrt (std::deque<double>& stack)`||
+|`static double L_int (std::deque<double>& stack)`||
+|`static double L_rad (std::deque<double>& stack)`||
+|`static double L_if(std::deque<double>& stack, int nargs)`||
+|`static double L_lsum(std::deque<double>& stack, int nargs)`||
+|`static double L_lmean(std::deque<double>& stack, int nargs)`||
+|`static double L_fnisan(std::deque<double>& stack, int nargs)`||
+|`static double L_lcount(std::deque<double>& stack, int nargs)`||
+|`static double L_lprod(std::deque<double>& stack, int nargs)`||
+|`static double L_sign(std::deque<double>& stack)`||
+|`static double L_lstderr(std::deque<double>& stack, int nargs)`||
+|`static double L_random(std::deque<double>& stack)`||
+|`static double L_floor(std::deque<double>& stack)`||
+|`static double L_ceil (std::deque<double>& stack)`||
+|`static double L_round(std::deque<double>& stack, int nargs)`||
+|`static double L_urandom(std::deque<double>& stack)`||
+|`static double L_grandom(std::deque<double>& stack)`||
+|`static double L_gamma(std::deque<double>& stack)`||
 |`static double L_div0(double *stack, int nargs)`||
 
 ### l\_exec\_tfn.c {#T26}
@@ -325,19 +325,19 @@ Functions to evaluate LEC "time functions".
 
 |Syntax|Description|
 |:---|:---|
-|`static double L_lag(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_diff(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_rapp(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_dln(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_grt(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_mavg(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_vmax(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_vmin(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_sum(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_prod(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|` double L_mean(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_stderr(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_lastobs(unsigned char* expr, short len, int t, double* stack, int nargs)`||
+|`static double L_lag(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_diff(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_rapp(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_dln(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_grt(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_mavg(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_vmax(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_vmin(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_sum(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_prod(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|` double L_mean(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_stderr(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_lastobs(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
 
 ### l\_exec\_mtfn.c {#T27}
 
@@ -345,22 +345,22 @@ Functions to evaluate LEC "time functions" with possibly multiple arguments.
 
 |Syntax|Description|
 |:---|:---|
-|`static double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, double* stack, int nargs)`||
-|`static double L_corr(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, double* stack, int nargs, int orig)`||
-|`static double L_covar(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_covar0(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_var(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_stddev(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_index(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_acf(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static int L_calcvals(unsigned char* expr1, short len1, int t, double* stack, int* vt, double* vy, int notnul)`||
-|`static double L_interpol(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_app(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_dapp(unsigned char* expr, short nvargs, int t, double* stack, int nargs)`||
-|`static double L_hpall(unsigned char* expr, short len, int t, double* stack, int nargs, int std)`||
-|`static double L_hp(unsigned char* expr, short len, int t, double* stack, int nargs)`||
-|`static double L_hpstd(unsigned char* expr, short len, int t, double* stack, int nargs)`||
+|`static double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_corr(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, std::deque<double>& stack, int nargs, int orig)`||
+|`static double L_covar(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_covar0(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_var(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_stddev(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_index(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_acf(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stack, int* vt, double* vy, int notnul)`||
+|`static double L_interpol(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_app(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_dapp(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_hpall(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs, int std)`||
+|`static double L_hp(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_hpstd(unsigned char* expr, short len, int t, std::deque<double>& stack, int nargs)`||
 
 ### l\_hodrick.c {#T28}
 

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -979,6 +979,9 @@ TEST_F(LegacyAPITest, Tests_LEC)
     // test time functions (LEC_TFN)
     U_test_lec("LEC", "sum(2000Y1, 2010Y1, A)", 2, 55.0);
     U_test_lec("LEC", "sum(2000Y1, A)", 2, 3.0);
+    U_test_lec("LEC", "sum(A)", 2, 3.0);
+    U_test_lec("LEC", "mean(t, t+1, A)", 2, (A[2] + A[3]) / 2.0);
+    U_test_lec("LEC", "B * mean(t, t+1, A)", 2, B[2] * (A[2] + A[3]) / 2.0);
     U_test_lec("LEC", "r(A)", 2, A[2] / A[1]);
     U_test_lec("LEC", "r(B)", 2, B[2] / B[1]);
     // test variadic time functions (LEC_MTFN)
@@ -994,8 +997,10 @@ TEST_F(LegacyAPITest, Tests_LEC)
     lst = global_ws_lst->get("LST2");
     EXPECT_EQ(lst, "A,B,A");
 
-    U_test_lec("LEC-MACRO", "1 + vmax($LST1)", 2, 1+B[2]);
-    U_test_lec("LEC-MACRO", "1 + vmax($LST2)", 2, 1+B[2]);
+    double max_value = (A[2] > B[2]) ? A[2] : B[2];
+    U_test_lec("LEC-MACRO", "1 + max($LST1)", 2, 1.0 + max_value);
+    U_test_lec("LEC-MACRO", "1 + max(60, $LST1)", 2, 61.0);
+    U_test_lec("LEC-MACRO", "1 + max($LST2)", 2, 1.0 + max_value);
 }
 
 TEST_F(LegacyAPITest, Tests_CLEC_Compile)


### PR DESCRIPTION
And rewrite all executable LEC elements (functions, operators, time functions and multi-arg functions) for clarity and to use the new stack implementation

fix #1187