### PR TITLE
C++ API: refactor KDBVariables to use std::shared_ptr for the sample attribute

### DIFF
--- a/api/ascii/k_ccvar.cpp
+++ b/api/ascii/k_ccvar.cpp
@@ -121,7 +121,7 @@ static bool load_yy(KDBVariables& kdb, YYFILE* yy, int ask)
         return false;
     }
     
-    kdb.set_sample(smpl);
+    kdb.set_sample(*smpl);
 
     /* Loop on var definition 
         NAME1 value ... NAME2 ...

--- a/api/io/k_emain.cpp
+++ b/api/io/k_emain.cpp
@@ -358,12 +358,12 @@ int EXP_RuleExport(char* trace, char* rule, char* out, char* vfile, char* cfile,
     SCR_strip((unsigned char*) from);
     SCR_strip((unsigned char*) to);
 
-    Sample *smpl = nullptr;
+    std::shared_ptr<Sample> smpl_ptr = nullptr;
     if(from[0] != 0 && to[0] != 0)
     {
         try
         {
-            smpl = new Sample(std::string(from), std::string(to));
+            smpl_ptr = std::make_shared<Sample>(std::string(from), std::string(to));
         }
         catch(const std::exception& e)
         {
@@ -393,8 +393,8 @@ int EXP_RuleExport(char* trace, char* rule, char* out, char* vfile, char* cfile,
         success = dbv_ptr->load(std::string(vfile));
         if(!success) 
             return -1;
-        if(smpl) 
-            dbv_ptr->set_sample(smpl);
+        if(smpl_ptr) 
+            dbv_ptr->set_sample(*smpl_ptr);
     }
 
     auto dbc_ptr = KDBComments::KDBComments::Create(false);

--- a/api/io/k_imain.cpp
+++ b/api/io/k_imain.cpp
@@ -107,11 +107,11 @@ KDBVariablesPtr IMP_InterpretVar(const std::unique_ptr<ImportVarFromFile>& impde
     }
 
     rc = impdef->read_header(yy, smpl);
-    if(rc < 0) 
+    if(!smpl || rc < 0) 
         goto err;
 
     kdb = KDBVariables::Create(false);
-    kdb->set_sample(smpl);
+    kdb->set_sample(*smpl);
     nb = smpl->nb_periods;
 
     if(impdef->read_variable_implemented) 

--- a/api/k_exec.cpp
+++ b/api/k_exec.cpp
@@ -340,7 +340,7 @@ static int KI_read_vars_db(KDBVariablesPtr dbv_ptr, KDBVariablesPtr dbv_tmp, cha
     // The sample of the KDB of the variables to read is empty 
     if(!vsmpl) 
     {
-        dbv_ptr->set_sample(tsmpl);
+        dbv_ptr->set_sample(*tsmpl);
         vsmpl = dbv_ptr->get_sample();
     }
     
@@ -839,9 +839,9 @@ KDBVariablesPtr KI_exec(KDBIdentitiesPtr dbi_ptr, KDBVariablesPtr dbv_ptr, int n
 
     KDBVariablesPtr dbv_i_ptr = KI_series_list(dbi_ptr);
     if(var_sample) 
-        dbv_i_ptr->set_sample(var_sample);
+        dbv_i_ptr->set_sample(*var_sample);
     else  
-        dbv_i_ptr->set_sample(exec_sample);
+        dbv_i_ptr->set_sample(*exec_sample);
 
     if(KEXEC_TRACE) 
     {

--- a/api/objs/k_objfile.cpp
+++ b/api/objs/k_objfile.cpp
@@ -241,7 +241,7 @@ int KDBVariables::preload(FILE *fd, const std::string& filepath, const int vers)
     if(data[0] != 0)
     {
         Sample* smpl = (Sample*) data;
-        this->sample = new Sample(*smpl);
+        this->sample = std::make_shared<Sample>(*smpl);
     }
 
     return res.first;

--- a/api/objs/k_wsvar.cpp
+++ b/api/objs/k_wsvar.cpp
@@ -892,7 +892,7 @@ void KDBVariables::update(const std::string& name, const std::string& lec, const
 // WARNING: the returned Sample pointer must not be deleted
 Sample* KDBVariables::get_sample() const
 {
-	return this->sample;
+	return this->sample.get();
 }
 
 bool KDBVariables::set_sample(const std::string& from, const std::string& to)
@@ -923,6 +923,13 @@ bool KDBVariables::set_sample(const Period& from, const Period& to)
     return success;
 }
 
+void KDBVariables::update_sample_child(std::shared_ptr<Sample> parent_sample)
+{
+    this->sample.reset();
+    if(parent_sample)
+        this->sample = parent_sample;
+}
+
 bool KDBVariables::set_sample(const Sample* new_sample)
 {
     if(new_sample == nullptr || new_sample->nb_periods == 0)
@@ -933,7 +940,7 @@ bool KDBVariables::set_sample(const Sample* new_sample)
 
     // check if the new sample is the same as the current one
     // if the new sample is the same as the current one, do nothing
-	if(sample != nullptr && *new_sample == *sample)
+	if(sample && *new_sample == *sample)
 		return true;
 
 	// NOTE: prevent changing the sample on a subset (shallow copy).
@@ -959,30 +966,37 @@ bool KDBVariables::set_sample(const Sample* new_sample)
         }
     }
 
-    if(sample)
-        delete sample;
-    sample = new Sample(*new_sample);
+    sample.reset();
+    sample = std::make_shared<Sample>(*new_sample);
+    // update the sample of all children databases (subsets)
+    for(std::shared_ptr<KDBVariables> child : this->get_children_db())
+        child->update_sample_child(sample);
 
+    bool success = true;
+    Variable var_copy;
     std::shared_ptr<Variable> var_ptr;
-    std::shared_ptr<Variable> new_var_ptr;
     int nb_periods = sample->nb_periods;
     // use iterator to allow modifying k_objs while looping on it
     for(auto it = k_objs.begin(); it != k_objs.end(); it++)   
     {
         var_ptr = it->second;
-        new_var_ptr = std::make_shared<Variable>(nb_periods, IODE_NAN);
-        if(var_ptr) 
+        if(!var_ptr)
         {
-            Variable& var = *var_ptr;
-            Variable& new_var = *new_var_ptr;
-            for(int t = 0; t < intersection_smpl.nb_periods; t++)
-                new_var[start2 + t] = var[start1 + t];
+            std::string error_msg = "Variable '" + it->first + "' is null. Cannot set sample.";
+            kwarning(error_msg.c_str());
+            success = false;
+            continue;
         }
-        it->second.reset();
-        it->second = new_var_ptr;
+
+        Variable& var = *var_ptr;
+        var_copy = var;
+        var.clear();
+        var.resize(nb_periods, IODE_NAN);
+        for(int t = 0; t < intersection_smpl.nb_periods; t++)
+            var[start2 + t] = var_copy[start1 + t];
     }
 
-    return true;
+    return success;
 }
 
 int KDBVariables::get_nb_periods() const

--- a/api/objs/k_wsvar.cpp
+++ b/api/objs/k_wsvar.cpp
@@ -42,7 +42,7 @@ int KV_merge(KDBVariablesPtr kdb1, KDBVariablesPtr kdb2, int replace)
     if(!kdb1->get_sample())
     {
         if(kdb2->get_sample())
-            kdb1->set_sample(kdb2->get_sample());
+            kdb1->set_sample(*kdb2->get_sample());
         else
         {
             kwarning("Cannot merge the 2 Variables databases: sample of both databases is empty");
@@ -126,9 +126,9 @@ void KV_merge_del(KDBVariablesPtr kdb1, KDBVariablesPtr kdb2, int replace)
         if(kdb1->k_type == VARIABLES)
         {
             if(kdb1->get_sample())
-                kdb2->set_sample(kdb1->get_sample());
+                kdb2->set_sample(*kdb1->get_sample());
             else if(kdb2->get_sample())
-                kdb1->set_sample(kdb2->get_sample());
+                kdb1->set_sample(*kdb2->get_sample());
         }
         kdb1->k_objs = kdb2->k_objs;
         kdb2->clear();
@@ -522,7 +522,7 @@ KDBVariablesPtr KV_aggregate(KDBVariablesPtr dbv, int method, char *pattern, cha
     if(!ndbv) 
         goto done;
     
-    ndbv->set_sample(edbv->get_sample());
+    ndbv->set_sample(*edbv->get_sample());
 
     for(const auto& [ename, var_ptr] : edbv->k_objs) 
     {
@@ -917,10 +917,18 @@ bool KDBVariables::set_sample(const std::string& from, const std::string& to)
 
 bool KDBVariables::set_sample(const Period& from, const Period& to)
 {
-	Sample* new_sample = new Sample(from, to);
-    bool success = this->set_sample(new_sample);
-    delete new_sample;
-    return success;
+    try
+    {
+        Sample new_sample(from, to);
+        return this->set_sample(new_sample);
+    }
+    catch(const std::exception& e)
+    {
+        std::string error_msg = "Cannot set sample from '" + from.to_string(); 
+        error_msg += "' to '" + to.to_string() + "':\n" + std::string(e.what());
+        kwarning(error_msg.c_str());
+        return false;
+    }
 }
 
 void KDBVariables::update_sample_child(std::shared_ptr<Sample> parent_sample)
@@ -930,9 +938,9 @@ void KDBVariables::update_sample_child(std::shared_ptr<Sample> parent_sample)
         this->sample = parent_sample;
 }
 
-bool KDBVariables::set_sample(const Sample* new_sample)
+bool KDBVariables::set_sample(const Sample& new_sample)
 {
-    if(new_sample == nullptr || new_sample->nb_periods == 0)
+    if(new_sample.nb_periods == 0)
     {
         kwarning("Empty sample passed to set_sample. No changes will be made to the current sample.");
         return false;
@@ -940,7 +948,7 @@ bool KDBVariables::set_sample(const Sample* new_sample)
 
     // check if the new sample is the same as the current one
     // if the new sample is the same as the current one, do nothing
-	if(sample && *new_sample == *sample)
+	if(sample && new_sample == *sample)
 		return true;
 
 	// NOTE: prevent changing the sample on a subset (shallow copy).
@@ -958,16 +966,16 @@ bool KDBVariables::set_sample(const Sample* new_sample)
     int start2 = 0;
     if(sample) 
     {
-        intersection_smpl = sample->intersection(*new_sample);
+        intersection_smpl = sample->intersection(new_sample);
         if(intersection_smpl.nb_periods > 0) 
         {
             start1 = intersection_smpl.start_period.difference(sample->start_period);
-            start2 = intersection_smpl.start_period.difference(new_sample->start_period);
+            start2 = intersection_smpl.start_period.difference(new_sample.start_period);
         }
     }
 
     sample.reset();
-    sample = std::make_shared<Sample>(*new_sample);
+    sample = std::make_shared<Sample>(new_sample);
     // update the sample of all children databases (subsets)
     for(std::shared_ptr<KDBVariables> child : this->get_children_db())
         child->update_sample_child(sample);
@@ -1100,7 +1108,7 @@ bool KDBVariables::copy_from_file(const std::string& file, const std::string& ob
         return false;
     }
 
-    from_ptr->set_sample(&merge_sample);
+    from_ptr->set_sample(merge_sample);
 
     std::set<std::string> s_objs;
     try

--- a/api/objs/kdb.h
+++ b/api/objs/kdb.h
@@ -546,7 +546,7 @@ protected:
         }
     }
 
-    virtual std::shared_ptr<D> initialize_subset(const std::shared_ptr<D> true_parent)
+    virtual std::shared_ptr<D> initialize_subset(const std::shared_ptr<D> true_parent, const bool copy)
     {
         std::shared_ptr<D> subset_ptr = D::Create(false);
         subset_ptr->description = true_parent->description;
@@ -689,7 +689,7 @@ public:
             throw std::runtime_error(error_msg);
         }
 
-        std::shared_ptr<D> subset_ptr = initialize_subset(true_parent);
+        std::shared_ptr<D> subset_ptr = initialize_subset(true_parent, copy);
         if(copy)
         {
             subset_ptr->k_db_type = DB_STANDALONE;

--- a/api/objs/variables.h
+++ b/api/objs/variables.h
@@ -250,7 +250,7 @@ public:
 
     bool set_sample(const std::string& from, const std::string& to);
     bool set_sample(const Period& from, const Period& to);
-    bool set_sample(const Sample* new_sample);
+    bool set_sample(const Sample& new_sample);
     void update_sample_child(std::shared_ptr<Sample> parent_sample);
 
     int get_nb_periods() const;

--- a/api/objs/variables.h
+++ b/api/objs/variables.h
@@ -7,6 +7,7 @@
 #include "api/objs/pack.h"
 
 #include <string>
+#include <memory>       // for std::shared_ptr
 
 /*----------------------- TYPEDEF ----------------------------*/
 
@@ -80,7 +81,7 @@ struct KDBVariables : public KDBTemplate<KDBVariables, Variable>
 
 private:
     // periods of the Variables database
-    Sample* sample = nullptr;
+    std::shared_ptr<Sample> sample = nullptr;
 
     void check_var_size(const std::string& action, const std::string& name, const Variable& variable)
     {
@@ -104,7 +105,7 @@ private:
     {
         if(this->sample)
         {
-            char* c_smpl = (char*) this->sample; 
+            char* c_smpl = (char*) this->sample.get(); 
             *data = c_smpl;
             return sizeof(Sample);
         }
@@ -123,8 +124,9 @@ private:
     // copy constructor
     KDBVariables(const KDBVariables& other): KDBTemplate(other) 
     {
-        if(other.sample)
-            this->sample = new Sample(*(other.sample));
+        Sample* other_sample = other.sample.get();
+        if(other_sample)
+            this->sample = std::make_shared<Sample>(*other_sample);
         else
             this->sample = nullptr;
     }
@@ -148,29 +150,36 @@ public:
         return std::shared_ptr<KDBVariables>(new KDBVariables(is_global));
     }
 
-    ~KDBVariables() 
-    {
-        if(this->sample)
-            delete this->sample;
-        this->sample = nullptr;
-    }
+    ~KDBVariables() {}
 
     void clear() override
     {
-        if(this->sample)
-            delete this->sample;
-        this->sample = nullptr;
-
         KDBTemplate::clear();
+
+        if(this->sample)
+            this->sample.reset();
+        
+        // reset the sample of all children databases (subsets)
+        for(std::shared_ptr<KDBVariables> child : this->get_children_db())
+            child->update_sample_child(this->sample);
     }
 
     int preload(FILE *fd, const std::string& filepath, const int vers) override;
 
-    std::shared_ptr<KDBVariables> initialize_subset(const std::shared_ptr<KDBVariables> true_parent) override
+    std::shared_ptr<KDBVariables> initialize_subset(const std::shared_ptr<KDBVariables> true_parent, const bool copy) override
     {
-        std::shared_ptr<KDBVariables> subset_ptr = KDBTemplate::initialize_subset(true_parent);
-        if(true_parent->sample)
-            subset_ptr->sample = new Sample(*(true_parent->sample));
+        std::shared_ptr<KDBVariables> subset_ptr = KDBTemplate::initialize_subset(true_parent, copy);
+        
+        // deep copy -> create a new Sample instance for the subset
+        if(copy)
+        {
+            if(true_parent->sample)
+                subset_ptr->sample = std::make_shared<Sample>(*true_parent->sample);
+        }
+        // shallow copy -> share the same Sample pointer
+        else
+            subset_ptr->sample = true_parent->sample;
+        
         return subset_ptr;
     }
 
@@ -242,6 +251,7 @@ public:
     bool set_sample(const std::string& from, const std::string& to);
     bool set_sample(const Period& from, const Period& to);
     bool set_sample(const Sample* new_sample);
+    void update_sample_child(std::shared_ptr<Sample> parent_sample);
 
     int get_nb_periods() const;
     std::string get_period(const int t) const;

--- a/api/report/commands/b_htol.cpp
+++ b/api/report/commands/b_htol.cpp
@@ -149,7 +149,7 @@ static int B_htol(int method, char* arg)
     }
 
     to = KDBVariables::Create(false);
-    to->set_sample(new Sample(*t_smpl));
+    to->set_sample(*t_smpl);
     for(const auto& [from_name, from_var_ptr] : from->k_objs) 
     {
         double* from_values = from_var_ptr->data(); 
@@ -238,7 +238,7 @@ KDBVariablesPtr B_htol_kdb(int method, KDBVariablesPtr kdb_from)
     }
 
     kdb_to = KDBVariables::Create(false);
-    kdb_to->set_sample(new Sample(*t_smpl));
+    kdb_to->set_sample(*t_smpl);
     for(const auto& [from_name, from_var_ptr] : kdb_from->k_objs) 
     {
         double* from_values = from_var_ptr->data(); 

--- a/api/report/commands/b_idt.cpp
+++ b/api/report/commands/b_idt.cpp
@@ -131,8 +131,11 @@ int B_IdtExecuteIdts(Sample* smpl, char** c_idts)
 
     if(!kdb_var) 
         return -1;
+
+    if(!smpl)
+        return -1;
     
-    kdb_var->set_sample(smpl);
+    kdb_var->set_sample(*smpl);
 
     if(global_ws_var) 
         KV_merge_del(global_ws_var, kdb_var, 1);

--- a/api/report/commands/b_ltoh.cpp
+++ b/api/report/commands/b_ltoh.cpp
@@ -369,7 +369,7 @@ static int B_ltoh(int type, char* arg)
     }
 
     to = KDBVariables::Create(false);
-    to->set_sample(new Sample(*t_smpl));
+    to->set_sample(*t_smpl);
     for(const auto& [from_name, from_var_ptr] : from->k_objs) 
     {
         Variable to_var(t_smpl->nb_periods, 0);

--- a/api/report/commands/b_ws.cpp
+++ b/api/report/commands/b_ws.cpp
@@ -292,7 +292,7 @@ int B_WsSample(char* arg, int unused)
         goto err;
     }
 
-    success = global_ws_var->set_sample(new_smpl);
+    success = global_ws_var->set_sample(*new_smpl);
     if(!success)
     {
         error_manager.append_error("Failed to set new sample");

--- a/api/report/undoc/b_season.cpp
+++ b/api/report/undoc/b_season.cpp
@@ -75,7 +75,7 @@ int B_season(char* arg)
         goto done;
     
     to = KDBVariables::Create(false);
-    to->set_sample(new Sample(*t_smpl));
+    to->set_sample(*t_smpl);
     nb = t_smpl->nb_periods;
     t_vec = (double *) SW_nalloc(nb * sizeof(double));
     c_vec = (double *) SW_nalloc(nb * sizeof(double));

--- a/api/report/undoc/b_trend.cpp
+++ b/api/report/undoc/b_trend.cpp
@@ -104,7 +104,7 @@ static int B_WsTrendAll(char* arg, int std)
 
     to = KDBVariables::Create(false);
     nb = t_smpl->nb_periods;
-    to->set_sample(new Sample(*t_smpl));
+    to->set_sample(*t_smpl);
     t_vec = (double *) SW_nalloc(nb * sizeof(double));
     f_vec = (double *) SW_nalloc(nb * sizeof(double));
 

--- a/cpp_api/KDB/kdb_global.cpp
+++ b/cpp_api/KDB/kdb_global.cpp
@@ -136,7 +136,7 @@ void export_as(const std::string& var_file, const std::string cmt_file, const st
             throw std::invalid_argument(error_msg + "\n" + "Variable file: '" + var_file + "'");
         
         if(smpl) 
-            dbv_ptr->set_sample(smpl);
+            dbv_ptr->set_sample(*smpl);
     }
 
     std::string rule_file_ = check_file_exists(rule_file, caller_name);

--- a/tests/test_c_api/test_c_api.cpp
+++ b/tests/test_c_api/test_c_api.cpp
@@ -152,7 +152,7 @@ public:
 
 	    // Set the sample for the variable WS
 	    smpl = new Sample("2000Y1", "2020Y1");
-	    kdb_var->set_sample(smpl);
+	    kdb_var->set_sample(*smpl);
 	    EXPECT_TRUE(kdb_var->get_sample() != nullptr);
 	
 	    // Creates or update new vars
@@ -750,8 +750,10 @@ TEST_F(LegacyAPITest, Tests_OBJECTS)
     EXPECT_TRUE(found);
 
     // Test set_sample()
+    Sample empty_sample;
     std::string asmpl1 = global_ws_var->get_sample()->to_string();
-    global_ws_var->set_sample(nullptr);
+    success = global_ws_var->set_sample(empty_sample);
+    EXPECT_FALSE(success);
     std::string asmpl2 = global_ws_var->get_sample()->to_string();
     EXPECT_EQ(asmpl1, asmpl2);
 }
@@ -2189,7 +2191,7 @@ TEST_F(LegacyAPITest, Tests_B_LTOH)
     // Clear the vars and set the sample for the variable WS
     global_ws_var->clear();
     smpl = new Sample("2010Q1", "2020Q4");
-    global_ws_var->set_sample(smpl);
+    global_ws_var->set_sample(*smpl);
     delete smpl;
 
     sprintf(varfile, "%sfun.av", input_test_dir);
@@ -2251,7 +2253,7 @@ TEST_F(LegacyAPITest, Tests_B_HTOL)
     // Clear the vars and set the sample for the variable WS
     global_ws_var->clear();
     smpl = new Sample("2000Y1", "2020Y1");
-    global_ws_var->set_sample(smpl);
+    global_ws_var->set_sample(*smpl);
     delete smpl;
 
     sprintf(varfile, "%sfun_q.var", input_test_dir);

--- a/tests/test_c_api/test_kdb_variables.cpp
+++ b/tests/test_c_api/test_kdb_variables.cpp
@@ -42,7 +42,6 @@ TEST_F(KDBVariablesTest, Load)
 
 TEST_F(KDBVariablesTest, Subset)
 {
-    Sample* new_sample = nullptr;
     std::string pattern = "A*";
     Variable var;
     Variable new_var;
@@ -68,11 +67,10 @@ TEST_F(KDBVariablesTest, Subset)
 
     // extra test: change the sample of the parent database and 
     // check that the sample of the subset is not updated
-    new_sample = new Sample("1970Y1", "2010Y1");
+    Sample new_sample("1970Y1", "2010Y1");
     global_ws_var->set_sample(new_sample);
     EXPECT_EQ(global_ws_var->get_sample()->to_string(), "1970Y1:2010Y1");
     EXPECT_EQ(kdb_subset_deep_copy->get_sample()->to_string(), original_sample);
-    delete new_sample;
 
     // SHALLOW COPY SUBSET
     var = global_ws_var->get("ACAF");
@@ -88,11 +86,10 @@ TEST_F(KDBVariablesTest, Subset)
 
     // extra test: change the sample of the parent database and 
     // check that the sample of the subset is also updated
-    new_sample = new Sample("1980Y1", "2020Y1");
-    global_ws_var->set_sample(new_sample);
+    Sample new_sample_2("1980Y1", "2020Y1");
+    global_ws_var->set_sample(new_sample_2);
     EXPECT_EQ(global_ws_var->get_sample()->to_string(), "1980Y1:2020Y1");
     EXPECT_EQ(kdb_subset_shallow_copy->get_sample()->to_string(), "1980Y1:2020Y1");
-    delete new_sample;
 }
 
 TEST_F(KDBVariablesTest, Save)

--- a/tests/test_c_api/test_kdb_variables.cpp
+++ b/tests/test_c_api/test_kdb_variables.cpp
@@ -42,19 +42,23 @@ TEST_F(KDBVariablesTest, Load)
 
 TEST_F(KDBVariablesTest, Subset)
 {
+    Sample* new_sample = nullptr;
     std::string pattern = "A*";
-    Variable var = global_ws_var->get("ACAF");
-    std::string lec = "10 + t";
+    Variable var;
     Variable new_var;
-    new_var.reserve(var.size());
-    for (int p = 0; p < var.size(); p++) new_var.push_back(10.0 + p);
+    std::string lec = "10 + t";
 
     // GLOBAL KDB
     EXPECT_EQ(global_ws_var->size(), 394);
     EXPECT_TRUE(global_ws_var->is_global_database());
     std::set<std::string> names = global_ws_var->filter_names(pattern);
+    std::string original_sample = global_ws_var->get_sample()->to_string();
 
     // DEEP COPY SUBSET
+    var = global_ws_var->get("ACAF");
+    new_var.clear();
+    for (int p = 0; p < var.size(); p++) new_var.push_back(10.0 + p);
+
     KDBVariablesPtr kdb_subset_deep_copy = global_ws_var->get_subset(pattern, true);
     EXPECT_EQ(kdb_subset_deep_copy->size(), names.size());
     EXPECT_TRUE(kdb_subset_deep_copy->is_detached_database());
@@ -62,13 +66,33 @@ TEST_F(KDBVariablesTest, Subset)
     EXPECT_EQ(global_ws_var->get("ACAF"), var);
     EXPECT_EQ(kdb_subset_deep_copy->get("ACAF"), new_var);
 
+    // extra test: change the sample of the parent database and 
+    // check that the sample of the subset is not updated
+    new_sample = new Sample("1970Y1", "2010Y1");
+    global_ws_var->set_sample(new_sample);
+    EXPECT_EQ(global_ws_var->get_sample()->to_string(), "1970Y1:2010Y1");
+    EXPECT_EQ(kdb_subset_deep_copy->get_sample()->to_string(), original_sample);
+    delete new_sample;
+
     // SHALLOW COPY SUBSET
+    var = global_ws_var->get("ACAF");
+    new_var.clear();
+    for (int p = 0; p < var.size(); p++) new_var.push_back(10.0 + p);
+    
     KDBVariablesPtr kdb_subset_shallow_copy = global_ws_var->get_subset(pattern, false);
     EXPECT_EQ(kdb_subset_shallow_copy->size(), names.size());
     EXPECT_TRUE(kdb_subset_shallow_copy->is_subset_database());
     kdb_subset_shallow_copy->update("ACAF", lec);
     EXPECT_EQ(global_ws_var->get("ACAF"), new_var);
     EXPECT_EQ(kdb_subset_shallow_copy->get("ACAF"), new_var);
+
+    // extra test: change the sample of the parent database and 
+    // check that the sample of the subset is also updated
+    new_sample = new Sample("1980Y1", "2020Y1");
+    global_ws_var->set_sample(new_sample);
+    EXPECT_EQ(global_ws_var->get_sample()->to_string(), "1980Y1:2020Y1");
+    EXPECT_EQ(kdb_subset_shallow_copy->get_sample()->to_string(), "1980Y1:2020Y1");
+    delete new_sample;
 }
 
 TEST_F(KDBVariablesTest, Save)


### PR DESCRIPTION
fix #1219