### PR TITLE
C++ API: (CLEC) passing CLEC& argument instead of unsigned char* to all TFN and MTFN functions 

### DIFF
--- a/api/lec/k_lec.cpp
+++ b/api/lec/k_lec.cpp
@@ -278,12 +278,12 @@ void CLEC::initialize(std::vector<ATOMIC_LEC>& expr, const std::string& lec)
     L_EXPR.clear();
 }
 
-CLEC::CLEC(std::vector<ATOMIC_LEC>& expr, const std::string& lec)
+CLEC::CLEC(std::vector<ATOMIC_LEC>& expr, const std::string& lec) : AbstractCLEC()
 {
     initialize(L_EXPR, lec);
 }
 
-CLEC::CLEC(const std::string& lec)
+CLEC::CLEC(const std::string& lec) : AbstractCLEC()
 {
     if(L_open_string((char*) lec.c_str()) != 0) 
         throw std::runtime_error("Error opening LEC string");
@@ -301,7 +301,7 @@ CLEC::CLEC(const std::string& lec)
  * Generates a CLEC form with the result and set clec->duplicated_endo to 1 if the
  * generated form is of the form "0 := LHS - RHS")
 */
-CLEC::CLEC(const std::string& eq, const std::string& endo)
+CLEC::CLEC(const std::string& eq, const std::string& endo) : AbstractCLEC()
 {
     int duplicated_endo = 0;
     std::string lec = eq;

--- a/api/lec/l_common.h
+++ b/api/lec/l_common.h
@@ -78,7 +78,6 @@ inline std::vector<int> V_EXEC_POS;
 /* l_exec.cpp */
 int L_intlag(double lag);
 bool L_stack_is_nan(const std::deque<double>& stack);
-double L_exec_sub(unsigned char* expr, int lg, int t);
 
 /* l_debug.cpp */
 void L_debug(char*, ...);
@@ -98,6 +97,19 @@ void L_link_sample_expr(KDBVariablesPtr dbv, unsigned char* expr, short lg);
 
 
 /*----------------- STRUCTS ----------------------*/
+
+// Abstract class to be passed ot the execute() method of the sub-classes of LEC_EXECUTABLE
+struct AbstractCLEC
+{
+public:
+    AbstractCLEC() {}
+    
+    virtual double execute_sub_expression(const int pos, const int length, const int t) = 0;
+
+    // for MTFN functions
+    virtual void get_sub_expression_length(const int start, int& start_1, short& length_1) = 0; 
+    virtual void split_sub_expression(const int start, int& start_1, short& length_1, int& start_2, short& length_2) = 0;
+};
 
 struct LEC_ABSTRACT
 {
@@ -147,7 +159,7 @@ protected:
     LEC_EXECUTABLE(const int type, const int nb_args) 
     : LEC_ABSTRACT(type, GEN_LEC_EXECUTABLE), nb_args(nb_args), pos(-1) {}
 
-    virtual void execute(unsigned char* expr, int j, int t, std::deque<double>& stack) = 0;
+    virtual void execute(AbstractCLEC& clec, int start, int t, std::deque<double>& stack) = 0;
 };
 
 struct LEC_OTHER: public LEC_ABSTRACT

--- a/api/lec/l_exec.cpp
+++ b/api/lec/l_exec.cpp
@@ -92,6 +92,25 @@ static std::string get_l_exec_sub_error_message(unsigned char* expr, int t)
     return error_msg;
 }
 
+void CLEC::get_sub_expression_length(const int start, int& start_1, short& length_1)
+{
+    memcpy(&length_1, this->expression + start, sizeof(short));
+    start_1 = start + sizeof(short);
+}
+
+void CLEC::split_sub_expression(const int start, int& start_1, short& length_1, 
+    int& start_2, short& length_2)
+{
+    // sub expression 1
+    memcpy(&length_1, this->expression + start, sizeof(short));
+    start_1 = start + sizeof(short);
+
+    // sub expression 2
+    start_2 = start + length_1 + sizeof(short);
+    memcpy(&length_2, this->expression + start_2, sizeof(short));
+    start_2 += sizeof(short);
+}
+
 /**
  *  Execution of a CLEC sub expression.
  * 
@@ -105,46 +124,46 @@ static std::string get_l_exec_sub_error_message(unsigned char* expr, int t)
  *      - the first byte (type) is an identifier (+, ln, VAR, ...)
  *      - according to the identifier, one or more values are read from the stack, 
  *          the function/operator is called and the result is placed on the stack
- *      
- *  @param [in] expr    unsigned char*  pointer to the beginning of the sub expression (heterogeneous container)
- *  @param [in] lg      int             length of the sub expression
+ *  
+ *  @param [in] start   int             position of the sub expression in the CLEC->expression buffer
+ *  @param [in] length  int             length of the sub expression
  *  @param [in] t       int             time (index in dbv) of execution
  *  @return             double          result of the computation
  *  
  */
-double L_exec_sub(unsigned char* expr, int lg, int t)
+double CLEC::execute_sub_expression(const int start, const int length, const int t)
 {
     int type;
     int previous_j;
     int pos_stack = 0;  
     std::deque<double> stack;
-    for(int j = 0; j < lg ;) 
+    for(int j = start; j < start + length ;) 
     {
-        type = expr[j];
+        type = this->expression[j];
 
         if(type == L_LCONST)
         {
             // extract LEC long constant from the buffer -> update j
-            LEC_CONST_LONG al_lconst(expr, j);
+            LEC_CONST_LONG al_lconst(this->expression, j);
             // add the constant to the stack
             al_lconst.add_to_stack(stack, t);
         }
         else if(type == L_DCONST)
         {
             // extract LEC double constant from the buffer -> update j
-            LEC_CONST_REAL al_dconst(expr, j);
+            LEC_CONST_REAL al_dconst(this->expression, j);
             // add the constant to the stack
             al_dconst.add_to_stack(stack, t); 
         }
         else if(type == L_COEF)
         {
             // extract LEC coefficient from the buffer -> update j
-            LEC_COEF al_coef(expr, j);
+            LEC_COEF al_coef(this->expression, j);
             // add the coefficient value to the stack
             bool ok = al_coef.add_to_stack(stack, t);
             if(!ok) 
             {
-                std::string error_msg = get_l_exec_sub_error_message(expr, t);
+                std::string error_msg = get_l_exec_sub_error_message(this->expression + start, t);
                 kerror(0, (char*) error_msg.c_str());
                 return (double) IODE_NAN;
             }
@@ -152,7 +171,7 @@ double L_exec_sub(unsigned char* expr, int lg, int t)
         else if(type == L_PERIOD)
         {
             // extract LEC Period from the buffer -> update j
-            LEC_PERIOD al_period(expr, j);
+            LEC_PERIOD al_period(this->expression, j);
             // add the period position to the stack
             al_period.add_to_stack(stack, t);
         }
@@ -160,12 +179,12 @@ double L_exec_sub(unsigned char* expr, int lg, int t)
         else if(type == L_VAR || type == L_VART) 
         {
             // extract LEC Variable from the buffer -> update j
-            LEC_VAR al_var(expr, j);
+            LEC_VAR al_var(this->expression, j);
             // add the variable value to the stack
             bool ok = al_var.add_to_stack(stack, t);
             if(!ok) 
             {
-                std::string error_msg = get_l_exec_sub_error_message(expr, t);
+                std::string error_msg = get_l_exec_sub_error_message(this->expression + start, t);
                 kerror(0, (char*) error_msg.c_str());
                 return (double) IODE_NAN;
             }
@@ -177,41 +196,41 @@ double L_exec_sub(unsigned char* expr, int lg, int t)
         {
             previous_j = j;
             // extract LEC function from the buffer -> update j
-            LEC_FN al_fn(expr, j);
+            LEC_FN al_fn(this->expression, j);
             // execute the function on the stack
-            al_fn.execute(expr, previous_j, t, stack);
+            al_fn.execute(*this, previous_j, t, stack);
         }
         else if(is_op(type))
         {
             previous_j = j;
             // extract LEC operator from the buffer -> update j
-            LEC_OP al_op(expr, j);
+            LEC_OP al_op(this->expression, j);
             // execute the operator on the stack
-            al_op.execute(expr, previous_j, t, stack);
+            al_op.execute(*this, previous_j, t, stack);
         }
         else if(is_tfn(type)) 
         {
             previous_j = j;
             // extract LEC time function from the buffer -> update j
-            LEC_TFN al_tfn(expr, j);
+            LEC_TFN al_tfn(this->expression, j);
             // execute the time function on the stack
-            al_tfn.execute(expr, previous_j, t, stack);
+            al_tfn.execute(*this, previous_j, t, stack);
         }
         else if(is_val(type)) 
         {
             previous_j = j;
             // extract LEC value from the buffer -> update j
-            LEC_VAL_FN al_val(expr, j);
+            LEC_VAL_FN al_val(this->expression, j);
             // execute the value function on the stack
-            al_val.execute(expr, previous_j, t, stack);
+            al_val.execute(*this, previous_j, t, stack);
         }
         else if(is_mtfn(type)) 
         {
             previous_j = j;
             // extract LEC multi-time function from the buffer -> update j
-            LEC_MTFN al_mtfn(expr, j);
+            LEC_MTFN al_mtfn(this->expression, j);
             // execute the multi-time function on the stack
-            al_mtfn.execute(expr, previous_j, t, stack);
+            al_mtfn.execute(*this, previous_j, t, stack);
         }
         else 
         {
@@ -229,7 +248,7 @@ double L_exec_sub(unsigned char* expr, int lg, int t)
  *  
  *  - Assign global variables that could be used by calculation functions.
  *  - initiate the exception handling on floating point errors
- *  - call L_exec_sub() which is the real (recursive) calculator
+ *  - call execute_sub_expression() which is the real (recursive) calculator
  *  
  *  @param [in] dbv  KDBVariablesPtr  input variable KDB
  *  @param [in] dbs  KDBScalarsPtr    input scalars KDB
@@ -266,7 +285,7 @@ double CLEC::execute(KDBVariablesPtr dbv, KDBScalarsPtr dbs, const int t)
     if(setjmp(L_JMP))
         return (double) IODE_NAN; // On FPE, return IODE_NAN
     
-    double value = L_exec_sub(this->expression, this->len_expr, t);
+    double value = this->execute_sub_expression(0, this->len_expr, t);
     return value;
 }
 

--- a/api/lec/l_exec_fns.h
+++ b/api/lec/l_exec_fns.h
@@ -234,7 +234,7 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack) override
+    void execute(AbstractCLEC& clec, int start, int t, std::deque<double>& stack) override
      {
         // some functions (e.g. L_IF) can accept NaN as argument without returning NaN
         bool fn_accept_nan = (type == L_IF || type == L_FNISAN || type == L_LMEAN || 

--- a/api/lec/l_exec_mtfn.cpp
+++ b/api/lec/l_exec_mtfn.cpp
@@ -12,7 +12,7 @@
  * to these functions (#defines from L_LAG to L_LASTOBS (see iode.h)).
  *
  * Function signature:
- *      double <fnname>(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+ *      double <fnname>(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
  *  
  *  where:
  *      expr   = pointer to the current position in the CLEC expression (ex.: in "X + corr(A, B)", expr points to "A")
@@ -47,14 +47,14 @@
  *  @return         
  *  
  */
-double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short len2, 
+double L_calccorr(AbstractCLEC& clec, int start_1, short length_1, int start_2, short length_2, 
     int from, int to, int t, std::deque<double>& stack, int nargs) 
 {
-    double mean_x = L_mean(expr1, len1, from, to, t, stack, nargs - 1);
+    double mean_x = L_mean(clec, start_1, length_1, from, to, t, stack, nargs - 1);
     if(!IODE_IS_A_NUMBER(mean_x)) 
         return IODE_NAN;
     
-    double mean_y = L_mean(expr2, len2, from, to, t, stack, nargs - 1);
+    double mean_y = L_mean(clec, start_2, length_2, from, to, t, stack, nargs - 1);
     if(!IODE_IS_A_NUMBER(mean_y)) 
         return IODE_NAN;
 
@@ -62,11 +62,11 @@ double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short 
     double sum_xx = 0.0, sum_yy = 0.0, sum_xy = 0.0;
     for(int j = from; j <= to; j++) 
     {
-        x = L_exec_sub(expr1, len1, j);
+        x = clec.execute_sub_expression(start_1, length_1, j);
         if(!IODE_IS_A_NUMBER(x)) 
             return IODE_NAN;
         
-        y = L_exec_sub(expr2, len2, j);
+        y = clec.execute_sub_expression(start_2, length_2, j);
         if(!IODE_IS_A_NUMBER(y)) 
             return IODE_NAN;
 
@@ -110,15 +110,15 @@ double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short 
  *  @return            double           computed correlation 
  *  
  */
-double L_corr(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_corr(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
+    int start_1, start_2;
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
-    unsigned char* expr1 = expr + sizeof(short); 
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
-    double result = L_calccorr(expr1, len1, expr2, len2, from, to, t, stack, nargs);
+    double result = L_calccorr(clec, start_1, length_1, start_2, length_2, 
+                               from, to, t, stack, nargs);
     return result;
 }
 
@@ -145,18 +145,18 @@ double L_corr(unsigned char* expr, short nvargs, int from, int to, int t, std::d
  *  @return             double          computed covariance.
  *  
  */
-double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, 
+double L_calccovar(AbstractCLEC& clec, int start_1, short length_1, int start_2, short length_2, 
     int from, int to, int t, std::deque<double>& stack, int nargs, int orig) 
 {   
     int nb = 1 + to - from;
     if(nb == 0) 
         return IODE_NAN;
  
-    double mean_x = L_mean(expr1, len1, from, to, t, stack, nargs - 1);
+    double mean_x = L_mean(clec, start_1, length_1, from, to, t, stack, nargs - 1);
     if(!IODE_IS_A_NUMBER(mean_x)) 
         return IODE_NAN;
     
-    double mean_y = L_mean(expr2, len2, from, to, t, stack, nargs - 1);
+    double mean_y = L_mean(clec, start_2, length_2, from, to, t, stack, nargs - 1);
     if(!IODE_IS_A_NUMBER(mean_y)) 
         return IODE_NAN;
 
@@ -164,11 +164,11 @@ double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short
     double sum_xx = 0.0, sum_yy = 0.0, sum_xy = 0.0;
     for(int j = from; j <= to; j++) 
     {
-        x = L_exec_sub(expr1, len1, j);
+        x = clec.execute_sub_expression(start_1, length_1, j);
         if(!IODE_IS_A_NUMBER(x)) 
             return IODE_NAN;
         
-        y = L_exec_sub(expr2, len2, j);
+        y = clec.execute_sub_expression(start_2, length_2, j);
         if(!IODE_IS_A_NUMBER(y)) 
             return IODE_NAN;
 
@@ -194,15 +194,15 @@ double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short
  *  @see L_corr() for the parameter definition
  *  @see L_calccovar() for the formulas.
  */
-double L_covar(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) 
+double L_covar(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs) 
 {
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
+    int start_1, start_2;
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
-    unsigned char* expr1 = expr + sizeof(short); 
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
-    double result = L_calccovar(expr1, len1, expr2, len2, from, to, t, stack, nargs, 0);
+    double result = L_calccovar(clec, start_1, length_1, start_2, length_2, 
+                                from, to, t, stack, nargs, 0);
     return result;
 }
 
@@ -215,15 +215,15 @@ double L_covar(unsigned char* expr, short nvargs, int from, int to, int t, std::
  *  @see L_calccovar() for the formulas.
  *  
  */
-double L_covar0(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) 
+double L_covar0(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs) 
 {
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
+    int start_1, start_2;
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
-    unsigned char* expr1 = expr + sizeof(short); 
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
-    double result = L_calccovar(expr1, len1, expr2, len2, from, to, t, stack, nargs, 1);
+    double result = L_calccovar(clec, start_1, length_1, start_2, length_2, 
+                                from, to, t, stack, nargs, 1);
     return result;
 }
 
@@ -244,13 +244,13 @@ double L_covar0(unsigned char* expr, short nvargs, int from, int to, int t, std:
  *  @see L_covar() for more details.
  *  
  */
-double L_var(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_var(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {
-    short len1;
-    memcpy(&len1, expr, sizeof(short));
-
-    unsigned char* expr1 = expr + sizeof(short); 
-    double result = L_calccovar(expr1, len1, expr1, len1, from, to, t, stack, nargs + 1, 0);
+    int start_1;
+    short length_1; 
+    clec.get_sub_expression_length(start, start_1, length_1);
+    double result = L_calccovar(clec, start_1, length_1, start_1, length_1, from, to, t, stack, nargs + 1, 0);
     return result;
 }
 
@@ -265,9 +265,10 @@ double L_var(unsigned char* expr, short nvargs, int from, int to, int t, std::de
  *  @see L_calccovar() for the formula.
  *  
  */
-double L_stddev(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_stddev(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {
-    double var = L_var(expr, nvargs, from, to, t, stack, nargs);
+    double var = L_var(clec, start, nvargs, from, to, t, stack, nargs);
     if(!IODE_IS_A_NUMBER(var) || var < 0.0) 
         return IODE_NAN;
     return sqrt(var);
@@ -302,26 +303,25 @@ double L_stddev(unsigned char* expr, short nvargs, int from, int to, int t, std:
  *  @return            double           computed covariance
  */  
 
- double L_index(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+ double L_index(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    unsigned char* expr1 = expr + sizeof(short);
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+    int start_1, start_2;
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
     int nb = 1 + to - from;
     if(nb == 0) 
         return IODE_NAN;
 
-    double x = L_exec_sub(expr1, len1, t);
+    double x = clec.execute_sub_expression(start_1, length_1, t);
     if(!IODE_IS_A_NUMBER(x)) 
         return IODE_NAN;
 
     double y;
     for(int j = from; j <= to; j++) 
     {
-        y = L_exec_sub(expr2, len2, j);
+        y = clec.execute_sub_expression(start_2, length_2, j);
         if(!IODE_IS_A_NUMBER(y)) 
             return IODE_NAN;
 
@@ -347,19 +347,18 @@ double L_stddev(unsigned char* expr, short nvargs, int from, int to, int t, std:
  *  
  *  @see L_corr() for the parameter definition
  */
-double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
-{    
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    unsigned char* expr1 = expr + sizeof(short);
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+double L_acf(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
+{
+    int start_1, start_2;    
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
     int nb = 1 + to - from;
     if(nb == 0) 
         return IODE_NAN;
 
-    double x = L_exec_sub(expr1, len1, t);
+    double x = clec.execute_sub_expression(start_1, length_1, t);
     if(!IODE_IS_A_NUMBER(x)) 
         return IODE_NAN;
 
@@ -367,7 +366,7 @@ double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::de
     if(k < 0 || k > nb / 4) 
         return IODE_NAN;
 
-    double mean_x = L_mean(expr2, len2, from, to, t, stack, nargs - 1);
+    double mean_x = L_mean(clec, start_2, length_2, from, to, t, stack, nargs - 1);
     if(!IODE_IS_A_NUMBER(mean_x)) 
         return IODE_NAN;
 
@@ -375,11 +374,11 @@ double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::de
     double sum_xy = 0.0, sum_xy0 = 0.0;
     for(int j = from; j <= to - k; j++) 
     {
-        x = L_exec_sub(expr2, len2, j);
+        x = clec.execute_sub_expression(start_2, length_2, j);
         if(!IODE_IS_A_NUMBER(x)) 
             return IODE_NAN;
         
-        y = L_exec_sub(expr2, len2, j + k);
+        y = clec.execute_sub_expression(start_2, length_2, j + k);
         if(!IODE_IS_A_NUMBER(y)) 
             return IODE_NAN;
 
@@ -388,7 +387,7 @@ double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::de
 
     for(int j = from; j <= to; j++) 
     {
-        x = L_exec_sub(expr2, len2, j);
+        x = clec.execute_sub_expression(start_1, length_2,j);
         if(!IODE_IS_A_NUMBER(x)) 
             return IODE_NAN;
         
@@ -414,7 +413,8 @@ double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::de
  *  @return             double           computed correlation 
  *  
  */
-int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stack, int* vt, double* vy, int notnul)
+int L_calcvals(AbstractCLEC& clec, int start, short length, int t, std::deque<double>& stack, 
+    int* vt, double* vy, int notnul)
 {
     vy[0] = vy[1] = IODE_NAN;
     int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
@@ -422,7 +422,7 @@ int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stac
     // 1. Calculate value after t
     for(vt[1] = t + 1; vt[1] < nb_obs; vt[1]++) 
     {
-        vy[1] = L_exec_sub(expr1, len1, vt[1]);
+        vy[1] = clec.execute_sub_expression(start, length, vt[1]);
         if(IODE_IS_A_NUMBER(vy[1]) && (notnul == 0 || fabs(vy[1]) > 1e-15)) 
             break;
     }
@@ -430,7 +430,7 @@ int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stac
     // 2. Calculate value before t
     for(vt[0] = t - 1; vt[0] >= 0; vt[0]--) 
     {
-        vy[0] = L_exec_sub(expr1, len1, vt[0]);
+        vy[0] = clec.execute_sub_expression(start, length, vt[0]);
         if(IODE_IS_A_NUMBER(vy[0]) && (notnul == 0 || fabs(vy[0]) > 1e-15)) 
             break;
     }
@@ -451,7 +451,7 @@ int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stac
         vy[0] = IODE_NAN;
         for(vt[0] = vt[1] - 1; vt[0] >= 0; vt[0]--) 
         {
-            vy[0] = L_exec_sub(expr1, len1, vt[0]);
+            vy[0] = clec.execute_sub_expression(start, length, vt[0]);
             if(IODE_IS_A_NUMBER(vy[0]) && (notnul == 0 || fabs(vy[0]) > 1e-15)) 
                 break;
         }
@@ -464,7 +464,7 @@ int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stac
         vy[1] = IODE_NAN;
         for(vt[1] = vt[0] + 1; vt[1] < nb_obs; vt[1]++) 
         {
-            vy[1] = L_exec_sub(expr1, len1, vt[1]);
+            vy[1] = clec.execute_sub_expression(start, length, vt[1]);
             if(IODE_IS_A_NUMBER(vy[1])) 
                 break;
         }
@@ -482,21 +482,22 @@ int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stac
  *  @return     double  value of expr[t] or interpolated value
  *  
  */
-double L_interpol(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_interpol(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {   
-    short len1;
-    memcpy(&len1, expr, sizeof(short));
-    unsigned char* expr1 = expr + sizeof(short);
+    int start_1;
+    short length_1; 
+    clec.get_sub_expression_length(start, start_1, length_1);
 
     // 1. Calculate value in t
-    double x = L_exec_sub(expr1, len1, t);
+    double x = clec.execute_sub_expression(start_1, length_1, t);
     if(IODE_IS_A_NUMBER(x)) 
         return x;
 
     // 2. Calculate values around t
     int vt[2];
     double vy[2];
-    L_calcvals(expr1, len1, t, stack, vt, vy, 0);
+    L_calcvals(clec, start_1, length_1, t, stack, vt, vy, 0);
     
     // if NO value after AND before t, return IODE_NAN
     if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
@@ -514,30 +515,29 @@ double L_interpol(unsigned char* expr, short nvargs, int from, int to, int t, st
     return interpol;
 }
 
-double L_app(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_app(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {   
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    unsigned char* expr1 = expr + sizeof(short);
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+    int start_1, start_2;
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
     // 1. Calculate value in t
-    double x = L_exec_sub(expr1, len1, t);
+    double x = clec.execute_sub_expression(start_1, length_1, t);
     if(IODE_IS_A_NUMBER(x)) 
         return x;
 
     // 2. Calculate values around t
     int vt[2];
     double vy[2];
-    L_calcvals(expr1, len1, t, stack, vt, vy, 1);
+    L_calcvals(clec, start_1, length_1, t, stack, vt, vy, 1);
     
     // if NO value after AND before t, return IODE_NAN
     if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
         return IODE_NAN;
     
     // ---- Valeurs apparentées ----
-    double ayt = L_exec_sub(expr2, len2, t);
+    double ayt = clec.execute_sub_expression(start_1, length_2, t);
     if(!IODE_IS_A_NUMBER(ayt)) 
         return IODE_NAN;
     
@@ -545,9 +545,9 @@ double L_app(unsigned char* expr, short nvargs, int from, int to, int t, std::de
     int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
     ay[0] = ay[1] = IODE_NAN;
     if(vt[0] >= 0)   
-        ay[0] = L_exec_sub(expr2, len2, vt[0]);
+        ay[0] = clec.execute_sub_expression(start_2, length_2, vt[0]);
     if(vt[1] < nb_obs) 
-        ay[1] = L_exec_sub(expr2, len2, vt[1]);
+        ay[1] = clec.execute_sub_expression(start_2, length_2, vt[1]);
 
     // ---- Deux valeurs trouvées dans la série initiale ----
     // !! Les deux valeurs doivent exister dans la série apparentée
@@ -600,30 +600,29 @@ double L_app(unsigned char* expr, short nvargs, int from, int to, int t, std::de
     return IODE_NAN;
 }
 
-double L_dapp(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_dapp(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {   
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    unsigned char* expr1 = expr + sizeof(short);
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+    int start_1, start_2;
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
     // 1. Calculate value in t
-    double x = L_exec_sub(expr1, len1, t);
+    double x = clec.execute_sub_expression(start_1, length_1, t);
     if(IODE_IS_A_NUMBER(x)) 
         return x;
 
     // 2. Calculate values around t
     int vt[2];
     double vy[2];
-    L_calcvals(expr1, len1, t, stack, vt, vy, 0);
+    L_calcvals(clec, start_1, length_1, t, stack, vt, vy, 0);
 
     // if NO value after AND before t, return IODE_NAN
     if(!IODE_IS_A_NUMBER(vy[0]) && !IODE_IS_A_NUMBER(vy[1])) 
         return IODE_NAN;
 
     // ---- Valeurs apparentées ----
-    double ayt = L_exec_sub(expr2, len2, t);
+    double ayt = clec.execute_sub_expression(start_2, length_2, t);
     if(!IODE_IS_A_NUMBER(ayt)) 
         return IODE_NAN;
     
@@ -631,9 +630,9 @@ double L_dapp(unsigned char* expr, short nvargs, int from, int to, int t, std::d
     int nb_obs = (L_getsmpl(L_EXEC_DBV))->nb_periods;
     ay[0] = ay[1] = IODE_NAN;
     if(vt[0] >= 0)   
-        ay[0] = L_exec_sub(expr2, len2, vt[0]);
+        ay[0] = clec.execute_sub_expression(start_2, length_2, vt[0]);
     if(vt[1] < nb_obs) 
-        ay[1] = L_exec_sub(expr2, len2, vt[1]);
+        ay[1] = clec.execute_sub_expression(start_2, length_2, vt[1]);
 
     if(IODE_IS_A_NUMBER(ay[0]) && IODE_IS_A_NUMBER(ay[1])) 
     {
@@ -658,15 +657,14 @@ double L_dapp(unsigned char* expr, short nvargs, int from, int to, int t, std::d
     return IODE_NAN;
 }
 
-double L_hpall(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs, int std)
-{    
-    short len1, len2;
-    memcpy(&len1, expr, sizeof(short));
-    memcpy(&len2, expr + len1 + sizeof(short), sizeof(short));
-    unsigned char* expr1 = expr + sizeof(short);
-    unsigned char* expr2 = expr + len1 + 2 * sizeof(short);
+double L_hpall(AbstractCLEC& clec, int start, short length, int from, int to, int t, 
+    std::deque<double>& stack, int nargs, int std)
+{   
+    int start_1, start_2; 
+    short length_1, length_2;
+    clec.split_sub_expression(start, start_1, length_1, start_2, length_2);
 
-    double value = L_exec_sub(expr1, len1, t);
+    double value = clec.execute_sub_expression(start_1, length_1, t);
     if(!IODE_IS_A_NUMBER(value)) 
         return IODE_NAN;
 
@@ -682,7 +680,7 @@ double L_hpall(unsigned char* expr, short len, int from, int to, int t, std::deq
         return IODE_NAN;
     
     for(int j = from; j <= to; j++) 
-        itmp[j - from] = L_exec_sub(expr2, len2, j);
+        itmp[j - from] = clec.execute_sub_expression(start_2, length_2, j);
 
     int nbna, dim;
     HP_test(itmp, otmp, nb, &nbna, &dim);
@@ -702,13 +700,15 @@ double L_hpall(unsigned char* expr, short len, int from, int to, int t, std::deq
     return value;
 }
 
-double L_hp(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_hp(AbstractCLEC& clec, int start, short length, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {
-    return(L_hpall(expr, len, from, to, t, stack, nargs, 0));
+    return(L_hpall(clec, start, length, from, to, t, stack, nargs, 0));
 }
 
 
-double L_hpstd(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_hpstd(AbstractCLEC& clec, int start, short length, int from, int to, int t, 
+    std::deque<double>& stack, int nargs)
 {
-    return(L_hpall(expr, len, from, to, t, stack, nargs, 1));
+    return(L_hpall(clec, start, length, from, to, t, stack, nargs, 1));
 }

--- a/api/lec/l_exec_mtfn.h
+++ b/api/lec/l_exec_mtfn.h
@@ -32,26 +32,27 @@ inline bool is_mtfn(const int op)
     return op >= L_MTFN; 
 }
 
-int L_calcvals(unsigned char* expr, short lg, int t, std::deque<double>& stack, int* p_nargs, double* res, int nbvals);
-double L_calccorr(unsigned char* expr1, short lg1, unsigned char* expr2, short lg2, int from, int to, int t, 
-    std::deque<double>& stack, int nargs);
-double L_calccovar(unsigned char* expr1, short lg1, unsigned char* expr2, short lg2, int from, int to, int t, 
-    std::deque<double>& stack, int nargs, int center);
+int L_calcvals(AbstractCLEC& clec, int start, short length, int t, std::deque<double>& stack, int* p_nargs, 
+    double* res, int nbvals);
+double L_calccorr(AbstractCLEC& clec, int start_1, short length_1, int start_2, short length_2, int from, 
+    int to, int t, std::deque<double>& stack, int nargs);
+double L_calccovar(AbstractCLEC& clec, int start_1, short length_1, int start_2, short length_2, int from, 
+    int to, int t, std::deque<double>& stack, int nargs, int center);
 
-double L_corr(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_covar(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_covar0(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_var(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_stddev(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_index(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_acf(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_interpol(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_app(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_hp(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_dapp(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_hpstd(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_corr(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_covar(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_covar0(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_var(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_stddev(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_index(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_acf(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_interpol(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_app(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_hp(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_dapp(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_hpstd(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs);
 
-inline double(*L_MTFN_FN[])(unsigned char* expr, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) = 
+inline double(*L_MTFN_FN[])(AbstractCLEC& clec, int start, short nvargs, int from, int to, int t, std::deque<double>& stack, int nargs) = 
 { 
     L_corr,         // L_CORR      L_M
     L_covar,        // L_COVAR     L_M
@@ -173,7 +174,7 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack) override
+    void execute(AbstractCLEC& clec, int start, int t, std::deque<double>& stack) override
     {
         int from = -1, to = -1;
         // NOTE: in function L_extract_time_range():
@@ -183,10 +184,10 @@ public:
         if(type != L_INTERPOL && type != L_APP)
             L_extract_time_range(t, stack, nb_args - 1, from, to);
 
-        // NOTE: 'j + 3 + sizeof(short)' corresponds to the position of the sub-expression
+        // NOTE: 'start + 3 + sizeof(short)' corresponds to the position of the sub-expression
         //       in the buffer (after type, nb_args, nv_args and len_args)
-        j += 3 + sizeof(short);
-        double result = (L_MTFN_FN[pos])(expr + j, nv_args, from, to, t, stack, nb_args);
+        start += 3 + sizeof(short);
+        double result = (L_MTFN_FN[pos])(clec, start, nv_args, from, to, t, stack, nb_args);
         stack.push_back(result);
     }
 };

--- a/api/lec/l_exec_ops.h
+++ b/api/lec/l_exec_ops.h
@@ -112,7 +112,7 @@ public:
     }
 
     // executes the operator with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack) override
+    void execute(AbstractCLEC& clec, int start, int t, std::deque<double>& stack) override
     {
         double b = stack.back();
         stack.pop_back();

--- a/api/lec/l_exec_tfn.cpp
+++ b/api/lec/l_exec_tfn.cpp
@@ -14,7 +14,7 @@
  *
  * Function signature:
  *
- *      double <fnname>(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+ *      double <fnname>(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
  *  
  *  where:
  *      - expr points to the current position in the CLEC expression (in "sum(A + B))", expr points to "A + B")
@@ -104,7 +104,7 @@ void L_extract_time_range(int t, std::deque<double>& stack, int nargs, int& from
  *  @return             double          result of "expr in t"
  *  
  */
-double L_lag(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_lag(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
     int lag = 1;
     if(nargs == 2)
@@ -114,7 +114,7 @@ double L_lag(unsigned char* expr, short len, int from, int to, int t, std::deque
         lag = L_intlag(x);
     } 
     
-    double value = L_exec_sub(expr, len, t - lag);
+    double value = clec.execute_sub_expression(start, length, t - lag);
     return value;
 }
 
@@ -126,7 +126,7 @@ double L_lag(unsigned char* expr, short len, int from, int to, int t, std::deque
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_diff(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_diff(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
     int lag = 1;
     if(nargs == 2)
@@ -136,11 +136,11 @@ double L_diff(unsigned char* expr, short len, int from, int to, int t, std::dequ
         lag = L_intlag(x);
     }
     
-    double v1 = L_exec_sub(expr, len, t);
+    double v1 = clec.execute_sub_expression(start, length, t);
     if(!IODE_IS_A_NUMBER(v1)) 
         return IODE_NAN;
     
-    double v2 = L_exec_sub(expr, len, t - lag);
+    double v2 = clec.execute_sub_expression(start, length, t - lag);
     if(!IODE_IS_A_NUMBER(v2)) 
         return IODE_NAN;
     
@@ -154,7 +154,7 @@ double L_diff(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_rapp(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_rapp(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
     int lag = 1;
     if(nargs == 2)
@@ -164,11 +164,11 @@ double L_rapp(unsigned char* expr, short len, int from, int to, int t, std::dequ
         lag = L_intlag(x);
     }
     
-    double v1 = L_exec_sub(expr, len, t);
+    double v1 = clec.execute_sub_expression(start, length, t);
     if(!IODE_IS_A_NUMBER(v1)) 
         return IODE_NAN;
     
-    double v2 = L_exec_sub(expr, len, t - lag);
+    double v2 = clec.execute_sub_expression(start, length, t - lag);
     if(!IODE_IS_A_NUMBER(v2)) 
         return IODE_NAN;
 
@@ -183,7 +183,7 @@ double L_rapp(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_dln(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_dln(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
     int lag = 1;
     if(nargs == 2)
@@ -193,11 +193,11 @@ double L_dln(unsigned char* expr, short len, int from, int to, int t, std::deque
         lag = L_intlag(x);
     }
 
-    double v1 = L_exec_sub(expr, len, t);
+    double v1 = clec.execute_sub_expression(start, length, t);
     if(!IODE_IS_A_NUMBER(v1)) 
         return IODE_NAN;
     
-    double v2 = L_exec_sub(expr, len, t - lag);
+    double v2 = clec.execute_sub_expression(start, length, t - lag);
     if(!IODE_IS_A_NUMBER(v2)) 
         return IODE_NAN;
     
@@ -211,9 +211,9 @@ double L_dln(unsigned char* expr, short len, int from, int to, int t, std::deque
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_grt(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_grt(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double v1 = L_rapp(expr, len, from, to, t, stack, nargs);
+    double v1 = L_rapp(clec, start, length, from, to, t, stack, nargs);
     if(!IODE_IS_A_NUMBER(v1)) 
         return IODE_NAN;
     return (v1 - 1.0) * 100.0;
@@ -226,7 +226,7 @@ double L_grt(unsigned char* expr, short len, int from, int to, int t, std::deque
  *  
  *  @see L_lag() for more details on parameters.
  */
-double L_mavg(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_mavg(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
     int lag = 1;
     if(nargs == 2)
@@ -242,7 +242,7 @@ double L_mavg(unsigned char* expr, short len, int from, int to, int t, std::dequ
     double v1 = 0.0;
     for(int j = 0; j < lag; j++) 
     {
-        tmp = L_exec_sub(expr, len, t - j);
+        tmp = clec.execute_sub_expression(start, length, t - j);
         if(!IODE_IS_A_NUMBER(tmp)) 
             return IODE_NAN;
         v1 += tmp;
@@ -267,16 +267,16 @@ double L_mavg(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  @return             double          the maximum of expr on the period [p1, p2]
  *  
  */
-double L_vmax(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_vmax(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double value = L_exec_sub(expr, len, from);
+    double value = clec.execute_sub_expression(start, length, from);
     if(!IODE_IS_A_NUMBER(value)) 
         return IODE_NAN;
  
     double max = value;
     for(int j = from + 1; j <= to; j++) 
     {
-        value = L_exec_sub(expr, len, j);
+        value = clec.execute_sub_expression(start, length, j);
         if(!IODE_IS_A_NUMBER(value)) 
             return IODE_NAN;
         if(value > max) 
@@ -292,16 +292,16 @@ double L_vmax(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  
  *  @see L_vmax() for more details.
  */
-double L_vmin(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_vmin(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
-    double value = L_exec_sub(expr, len, from);
+    double value = clec.execute_sub_expression(start, length, from);
     if(!IODE_IS_A_NUMBER(value)) 
         return IODE_NAN;
 
     double min = value;
     for(int j = from + 1; j <= to; j++) 
     {
-        value = L_exec_sub(expr, len, j);
+        value = clec.execute_sub_expression(start, length, j);
         if(!IODE_IS_A_NUMBER(value)) 
             return IODE_NAN;
         if(value < min) 
@@ -317,13 +317,13 @@ double L_vmin(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  
  *  @see L_vmax() for more details.
  */
-double L_sum(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_sum(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {   
     double value;
     double sum = 0.0;
     for(int j = from; j <= to; j++) 
     {
-        value = L_exec_sub(expr, len, j);
+        value = clec.execute_sub_expression(start, length, j);
         if(!IODE_IS_A_NUMBER(value)) 
             return IODE_NAN;
         sum += value;
@@ -338,13 +338,13 @@ double L_sum(unsigned char* expr, short len, int from, int to, int t, std::deque
  *  
  *  @see L_vmax() for more details.
  */
-double L_prod(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_prod(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {
     double value;
     double prod = 1.0;
     for(int j = from; j <= to; j++) 
     {
-        value = L_exec_sub(expr, len, j);
+        value = clec.execute_sub_expression(start, length, j);
         if(!IODE_IS_A_NUMBER(value)) 
             return IODE_NAN;
         prod *= value;
@@ -362,9 +362,9 @@ double L_prod(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  @note not a function because it is also used by MTFN functions
  */
 
-double L_mean(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_mean(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {   
-    double sum = L_sum(expr, len, from, to, t, stack, nargs);
+    double sum = L_sum(clec, start, length, from, to, t, stack, nargs);
     if(!IODE_IS_A_NUMBER(sum)) 
         return IODE_NAN;
 
@@ -379,13 +379,13 @@ double L_mean(unsigned char* expr, short len, int from, int to, int t, std::dequ
  *  @see L_vmax() for more details.
  *  
  */
-double L_stderr(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_stderr(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {   
     double value;
     double sum = 0.0, sum2 = 0.0;
     for(int j = from; j <= to; j++) 
     {
-        value = L_exec_sub(expr, len, j);
+        value = clec.execute_sub_expression(start, length, j);
         if(!IODE_IS_A_NUMBER(value)) 
             return IODE_NAN;
         sum += value;
@@ -407,12 +407,12 @@ double L_stderr(unsigned char* expr, short len, int from, int to, int t, std::de
  *  @see L_vmax() for more details.
  *  
  */
-double L_lastobs(unsigned char* expr, short len, int from, int to, int t, std::deque<double>& stack, int nargs)
+double L_lastobs(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs)
 {   
     double value;
     for(int j = to; j >= from; j--) 
     {
-        value = L_exec_sub(expr, len, j);
+        value = clec.execute_sub_expression(start, length, j);
         if(IODE_IS_A_NUMBER(value)) 
             return value;
     }

--- a/api/lec/l_exec_tfn.h
+++ b/api/lec/l_exec_tfn.h
@@ -37,21 +37,21 @@ inline bool is_tfn(const int op)
 
 void L_extract_time_range(int t, std::deque<double>& stack, int nargs, int& from, int& to);
 
-double L_lag(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_diff(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_rapp(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_dln(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_grt(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_mavg(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_vmax(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_vmin(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_sum(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_prod(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_mean(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_stderr(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
-double L_lastobs(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_lag(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_diff(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_rapp(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_dln(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_grt(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_mavg(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_vmax(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_vmin(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_sum(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_prod(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_mean(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_stderr(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
+double L_lastobs(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs);
 
-inline double(*L_TFN_FN[])(unsigned char* expr, short lg, int from, int to, int t, std::deque<double>& stack, int nargs) = 
+inline double(*L_TFN_FN[])(AbstractCLEC& clec, int start, int length, int from, int to, int t, std::deque<double>& stack, int nargs) = 
 { 
     L_lag,          // L_LAG       L_TFN + 0 
     L_diff,         // L_DIFF      L_TFN + 1 
@@ -160,7 +160,7 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack) override
+    void execute(AbstractCLEC& clec, int start, int t, std::deque<double>& stack) override
     {
         int from = -1, to = -1;
         // NOTE: for time functions:
@@ -171,11 +171,11 @@ public:
            type == L_STDERR || type == L_LASTOBS)
             L_extract_time_range(t, stack, nb_args, from, to);
 
-        // NOTE: 'j + 2 + sizeof(short)' corresponds to the position of the sub-expression 
+        // NOTE: 'start + 2 + sizeof(short)' corresponds to the position of the sub-expression 
         //       in the buffer (after type, nb_args and len_args)
-        j += 2 + sizeof(short);
+        start += 2 + sizeof(short);
 
-        double result = (L_TFN_FN[pos])(expr + j, len_args, from, to, t, stack, nb_args);
+        double result = (L_TFN_FN[pos])(clec, start, len_args, from, to, t, stack, nb_args);
         stack.push_back(result);
     }
 };

--- a/api/lec/l_exec_val.h
+++ b/api/lec/l_exec_val.h
@@ -86,7 +86,7 @@ public:
     }
 
     // executes the function with the given arguments on the stack
-    void execute(unsigned char* expr, int j, int t, std::deque<double>& stack) override
+    void execute(AbstractCLEC& clec, int start, int t, std::deque<double>& stack) override
     {
         double value = (L_VAL_FN[pos])(t);
         stack.push_back(value);

--- a/api/lec/lec.h
+++ b/api/lec/lec.h
@@ -21,7 +21,7 @@ inline std::vector<ATOMIC_LEC> L_EXPR;      // Table of pairs <type, atomic elem
 
 /*---------------- STRUCTS ------------------------*/
 
-struct CLEC
+struct CLEC: public AbstractCLEC
 {
     // duplicate endogenous variable in the LEC expression
     char duplicated_endo = 0;
@@ -313,6 +313,35 @@ public:
      * @return            double              result of the calculation, IODE_NAN on error
      */
     double execute(KDBVariablesPtr dbv, KDBScalarsPtr dbs, const int t);
+
+    /**
+     * @brief Execution of a CLEC sub expression.
+     * 
+     * @param pos       first position of the sub expression in the CLEC expression
+     * @param length    length of the sub expression
+     * @param t         time of calculation (index in dbv sample)
+     * @return double 
+     */
+    double execute_sub_expression(const int pos, const int length, const int t);
+
+    /**
+     * @brief Get the length of the sub expression
+     * 
+     * @param start 
+     * @return short 
+     */
+    void get_sub_expression_length(const int start, int& start_1, short& length_1);
+
+    /**
+     * @brief extract the lengths of the two sub expressions and the starting position 
+     *        of the second sub expression.
+     * 
+     * @param start 
+     * @param length_1 
+     * @param length_2 
+     * @param start_2 
+     */
+    void split_sub_expression(const int start, int& start_1, short& length_1, int& start_2, short& length_2);
 };
 
 /* ---------------------- FUNCS ---------------------- */

--- a/doc/dev/LEC.md
+++ b/doc/dev/LEC.md
@@ -317,16 +317,16 @@ Functions to evaluate LEC "time functions" with possibly multiple arguments.
 
 |Syntax|Description|
 |:---|:---|
-|`static double L_calccorr(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, std::deque<double>& stack, int nargs)`||
+|`static double L_calccorr(AbstractCLEC& clec, int start_1, short len1, int start_2, short len2, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_corr(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
-|`static double L_calccovar(unsigned char* expr1, short len1, unsigned char* expr2, short len2, int t, std::deque<double>& stack, int nargs, int orig)`||
+|`static double L_calccovar(AbstractCLEC& clec, int start_1, short len1, int start_2, short len2, int t, std::deque<double>& stack, int nargs, int orig)`||
 |`static double L_covar(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_covar0(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_var(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_stddev(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_index(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_acf(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
-|`static int L_calcvals(unsigned char* expr1, short len1, int t, std::deque<double>& stack, int* vt, double* vy, int notnul)`||
+|`static int L_calcvals(AbstractCLEC& clec, int start, short length, int t, std::deque<double>& stack, int* vt, double* vy, int notnul)`||
 |`static double L_interpol(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_app(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||
 |`static double L_dapp(unsigned char* expr, short nvargs, int t, std::deque<double>& stack, int nargs)`||


### PR DESCRIPTION
Part of issue #1185