### PR TITLE
 C++ API: move includes of C++ std modules into precompiled header pch.h

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -8,6 +8,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_D
 
 add_library(iode_c_api STATIC "")
 
+# Precompiled headers for faster compilation
+target_precompile_headers(iode_c_api PRIVATE pch.h)
+
 # Add source to this project's library.
 add_subdirectory(utils)
 add_subdirectory(ascii)

--- a/api/all.h
+++ b/api/all.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "api/pch.h"
 
 #include "api/time/period.h"
 #include "api/time/sample.h"
@@ -7,7 +8,6 @@
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/b_iodeini.h"
-#include "api/constants.h"
 #include "api/k_exec.h"
 #include "api/k_lang.h"
 #include "api/k_super.h"
@@ -52,7 +52,6 @@
 
 #include "api/simulation/simulation.h"
 
-#include "api/utils/utils.h"
 #include "api/utils/buf.h"
 #include "api/utils/yy.h"
 

--- a/api/ascii/ascii.h
+++ b/api/ascii/ascii.h
@@ -1,8 +1,7 @@
 #pragma once
-
 #include "scr4/s_yy.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/utils/yy.h"
@@ -15,8 +14,6 @@
 #include "api/objs/tables.h"
 #include "api/objs/variables.h"
 
-#include <array>    // for std::array
-#include <memory>   // for std::unique_ptr
 
 /*---------------- FUNCS ------------------ */
 

--- a/api/ascii/k_cceqs.cpp
+++ b/api/ascii/k_cceqs.cpp
@@ -7,7 +7,7 @@
  *     bool save_asc(const std::string& filename)
  *
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/k_super.h"
 #include "api/utils/utils.h"

--- a/api/b_a2mini.cpp
+++ b/api/b_a2mini.cpp
@@ -39,7 +39,6 @@
  */
 #include <s_a2m.h>
 
-#include "api/constants.h"
 #include "api/b_a2mini.h"
 #include "api/write/write.h"
 #include "b_iodeini.h"

--- a/api/b_a2mini.h
+++ b/api/b_a2mini.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "scr4/s_a2m.h"
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/write/write.h"
 
 #define W_GDI       A2M_DESTGDIPRT

--- a/api/b_args.cpp
+++ b/api/b_args.cpp
@@ -16,13 +16,11 @@
 #include "scr4/s_prost.h"
 #include "scr4/s_strs.h"
 
-#include "api/constants.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/report/engine/engine.h"       // SCR_vtomsq
-#include <algorithm>    // for std::min, std::max
 
 
 /**

--- a/api/b_args.h
+++ b/api/b_args.h
@@ -1,7 +1,6 @@
 #pragma once
-
 #include "scr4/s_args.h"
-#include "api/constants.h"
+#include "api/pch.h"
 
 char **B_ainit_chk(char* arg, ADEF* adef, int nb);
 char **B_vtom_chk(char* arg, int nb);

--- a/api/b_errors.h
+++ b/api/b_errors.h
@@ -1,11 +1,7 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/write/write.h"
-
-#include <string>
-#include <vector>
 
 
 class IodeErrorManager

--- a/api/b_iodeini.cpp
+++ b/api/b_iodeini.cpp
@@ -22,11 +22,8 @@
 #include "scr4/s_prost.h"       // SCR_free, SCR_stracpy, SCR_strip
 #include "scr4/s_prodir.h"      // SCR_split_dir
 #include "scr4/s_proini.h"      // IniReadTxtParm, IniWriteParm
-#ifdef _MSC_VER
-    #include <Windows.h>
-#endif
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_iodeini.h"
 
 

--- a/api/b_iodeini.h
+++ b/api/b_iodeini.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "api/constants.h"
-
 inline char* ODE_INIFILE = 0;          // Name of the iode.ini file
 
 void B_IodeIniFile();

--- a/api/estimation/e_print.cpp
+++ b/api/estimation/e_print.cpp
@@ -8,14 +8,13 @@
  *      int E_graph(char** titles, Sample* smpl, MAT* mlhs, MAT* mrhs, int view, int res)   Displays or prints the graphs of residuals or observed / fitted values 
  *      int E_print_results(int corr, int corru, int obs, int grobs, int grres)             Prints the estimation input and output of a block of equations. 
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_lang.h"
 #include "api/objs/objs.h"
 #include "api/objs/scalars.h"
 #include "api/print/print.h"
 #include "api/write/write.h"
 #include "api/estimation/estimation.h"
-#include <algorithm>    // for std::min, std::max
 
 
 // Declarations

--- a/api/estimation/estimation.h
+++ b/api/estimation/estimation.h
@@ -2,7 +2,7 @@
 
 #include "scr4/s_mat.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"

--- a/api/gsample/c_calc.cpp
+++ b/api/gsample/c_calc.cpp
@@ -31,10 +31,10 @@
  */
 #include <math.h>
 
-#include "api/constants.h"
-#include "api/k_super.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
+#include "api/k_super.h"
 #include "api/gsample/gsample.h"
 #include "api/lec/lec.h"
 #include "api/objs/pack.h"

--- a/api/gsample/c_cc.cpp
+++ b/api/gsample/c_cc.cpp
@@ -44,7 +44,7 @@
  */
 #include "scr4/s_prodt.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_lang.h"
 #include "api/objs/kdb.h"
 #include "api/objs/variables.h"

--- a/api/gsample/gsample.h
+++ b/api/gsample/gsample.h
@@ -1,8 +1,7 @@
 #pragma once
-
 #include "scr4/s_yy.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/objs/tables.h"

--- a/api/io/export.h
+++ b/api/io/export.h
@@ -1,7 +1,5 @@
 #pragma once
-
-#include <stdio.h>
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/objs/kdb.h"
 #include "api/objs/comments.h"
@@ -12,10 +10,6 @@
 #include "api/objs/tables.h"
 #include "api/objs/variables.h"
 
-#include <iostream> // for std::cout
-#include <fstream>  // std::ofstream
-#include <array>    // for std::array
-#include <memory>   // for std::unique_ptr
 
 /*---------------- ENUMS -------------------------*/
 

--- a/api/io/import.h
+++ b/api/io/import.h
@@ -1,8 +1,7 @@
 #pragma once
-
 #include "scr4/s_yy.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
@@ -11,8 +10,6 @@
 #include "api/objs/variables.h"
 #include "api/io/dif.h"
 
-#include <array>    // for std::array
-#include <memory>   // for std::unique_ptr
 
 /*---------------- DEFINE -------------------------*/
 

--- a/api/io/k_emain.cpp
+++ b/api/io/k_emain.cpp
@@ -93,7 +93,7 @@
  *
  *  TODO: create report functions 
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_a2mini.h"
 #include "api/b_errors.h"
 #include "api/objs/kdb.h"

--- a/api/io/k_ibst.cpp
+++ b/api/io/k_ibst.cpp
@@ -17,10 +17,10 @@
  */
 #include <math.h>
 
-#include "api/k_super.h"
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
+#include "api/k_super.h"
 #include "api/objs/kdb.h"
 #include "api/objs/objs.h"
 #include "api/objs/comments.h"

--- a/api/io/k_igem.cpp
+++ b/api/io/k_igem.cpp
@@ -16,11 +16,11 @@
  */
 #include <math.h>
 
-#include "api/k_super.h"
-#include "api/constants.h"
-#include "api/utils/yy.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
+#include "api/utils/yy.h"
+#include "api/k_super.h"
 #include "api/io/dif.h"
 #include "api/io/import.h"
 

--- a/api/io/k_inis.cpp
+++ b/api/io/k_inis.cpp
@@ -12,11 +12,10 @@
  *  -----------------
  *  See k_idif.c for a similar group of functions.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/io/import.h"
-#include <algorithm>    // for std::min, std::max
 
 
 int ImportObjsNIS::read_header(YYFILE* yy, Sample* smpl)

--- a/api/io/k_iprn.cpp
+++ b/api/io/k_iprn.cpp
@@ -20,7 +20,7 @@
  *  -----------------
  *  See k_idif.c for a similar group of functions.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/io/import.h"
 

--- a/api/io/k_rules.cpp
+++ b/api/io/k_rules.cpp
@@ -8,7 +8,7 @@
  *      int IMP_readrule(char* filename)                                Reads a "rule file" and stores its contents in 2 global variables IMP_rule and IMP_pat.
  *      int IMP_change(char** rule, char** pat, char* in, char* out)    Modifies an object name according to the rule definitions.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/write/write.h"
 #include "api/io/import.h"

--- a/api/k_exec.cpp
+++ b/api/k_exec.cpp
@@ -64,8 +64,8 @@
  *      - if a calculated VAR already exists in the current WS, its values are left unchanged outside the calculation sample
  *      - if the VAR is created, the values outside the calculation sample are set to IODE_NAN.                                                                                                                Missing vars and scalars are collected from vfiles and sfiles.
  */
+#include "api/pch.h"
 #include "api/b_errors.h"
-#include "api/constants.h"
 #include "api/objs/pack.h"
 #include "api/lec/lec.h"
 #include "api/write/write.h"
@@ -76,8 +76,6 @@
 #include "api/utils/utils.h"
 #include "api/k_exec.h"
 
-#include <string>
-#include <vector>
 
 
 /**

--- a/api/k_exec.h
+++ b/api/k_exec.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/objs.h"
 #include "api/objs/identities.h"
 #include "api/objs/scalars.h"

--- a/api/k_super.cpp
+++ b/api/k_super.cpp
@@ -65,14 +65,9 @@
  *  
  */ 
 #include <stdarg.h>
-#include <stdlib.h>
-#ifdef _MSC_VER
-    #include <Windows.h>
-#endif
-
 #include "scr4/s_args.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/objs/objs.h"
 #include "api/objs/lists.h"

--- a/api/k_super.h
+++ b/api/k_super.h
@@ -1,6 +1,5 @@
 #pragma once 
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 

--- a/api/lec/k_lec.cpp
+++ b/api/lec/k_lec.cpp
@@ -10,6 +10,7 @@
  *      int L_findvar(KDBVariablesPtr kdb, char* name)    Retrieves a variable position.
  */
 
+#include "api/pch.h"
 #include "api/lec/lec.h"
 #include "api/objs/objs.h"
 #include "api/objs/lists.h"
@@ -17,7 +18,6 @@
 #include "api/objs/variables.h"
 #include "api/print/print.h"
 
-#include <algorithm>    // for std::max
 
 
 /**

--- a/api/lec/l_common.h
+++ b/api/lec/l_common.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "scr4/s_yy.h"      // YYKEYS
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/objs/kdb.h"
@@ -10,8 +10,6 @@
 #include "api/utils/utils.h"
 #include "api/lec/l_err.h"
 
-#include <deque>            // for the execution stack
-#include <algorithm>        // for std::min, std::max
 
 
 enum GenericLecType

--- a/api/lec/l_debug.cpp
+++ b/api/lec/l_debug.cpp
@@ -15,7 +15,7 @@
  *  TODO: replace by a "super" function 
  */
 
-#include <stdio.h>
+#include "api/pch.h"
 #include <stdarg.h>
 
 #include "api/lec/lec.h"

--- a/api/lec/l_eqs.cpp
+++ b/api/lec/l_eqs.cpp
@@ -25,8 +25,8 @@
  * 
  */
 
+#include "api/pch.h"
 #include "api/lec/lec.h"
-#include <algorithm>        // for std::move
 
 
 enum EQ_HAND_SIDE

--- a/api/lec/l_err.h
+++ b/api/lec/l_err.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <string>
+#include "api/pch.h"
 #include "scr4/s_yy.h"              // YYKEYS
 
 inline int L_errno = 0;             // LEC error number (during compilation)

--- a/api/lec/l_exec.cpp
+++ b/api/lec/l_exec.cpp
@@ -2,7 +2,7 @@
 #include <signal.h>
 #include <time.h>
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/k_super.h"
 #include "api/objs/variables.h"

--- a/api/lec/lec.h
+++ b/api/lec/lec.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "api/pch.h"
 #include "api/lec/l_common.h"
 #include "api/lec/l_value.h"
 #include "api/lec/l_exec_fns.h"
@@ -10,7 +11,6 @@
 #include "api/lec/l_err.h"
 #include "api/lec/l_token.h"
 
-#include <variant>              // for std::variant
 
 /*----------------- GLOBALS ----------------------*/
 

--- a/api/objs/comments.h
+++ b/api/objs/comments.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"
 #include "api/objs/pack.h"
 

--- a/api/objs/compare.h
+++ b/api/objs/compare.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"
 #include "api/objs/comments.h"
 #include "api/objs/equations.h"

--- a/api/objs/equations.h
+++ b/api/objs/equations.h
@@ -1,8 +1,7 @@
 #pragma once
-
 #include "scr4/s_prodt.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
@@ -11,11 +10,6 @@
 #include "api/objs/objs.h"
 #include "api/objs/scalars.h"
 #include "api/objs/variables.h"
-
-#include <string>
-#include <array>
-#include <vector>
-#include <utility>      // std::pair
 
 /*----------------------- DEFINE ----------------------------*/
 

--- a/api/objs/grep.h
+++ b/api/objs/grep.h
@@ -1,8 +1,6 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"
-
 
 /* k_grep.c */
 char* K_expand(int type, char* file, char* c_pattern, int all);

--- a/api/objs/identities.h
+++ b/api/objs/identities.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/objs.h"
 #include "api/objs/kdb.h"
 #include "api/objs/variables.h"

--- a/api/objs/k_objfile.cpp
+++ b/api/objs/k_objfile.cpp
@@ -1,12 +1,11 @@
 #ifndef UNIX
-#include <io.h>
+    #include <io.h>
 #endif
-#include <filesystem>   // requires C++17 
 
 #include "scr4/s_swap.h"        // SWHDL
 #include "scr4/s_prodir.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/b_errors.h"
 #include "api/time/period.h"

--- a/api/objs/k_pack.cpp
+++ b/api/objs/k_pack.cpp
@@ -24,7 +24,7 @@
  * @note The "modern" terminology for pack and unpack is "serialize" and "deserialize".
  * @see scr4/s_swap.h (http://www.xon.be/scr4/libs1/libs1236.htm) for more details.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/lec/lec.h"
 #include "api/objs/pack.h"
 #include "api/objs/structs_32.h"

--- a/api/objs/k_tbl.cpp
+++ b/api/objs/k_tbl.cpp
@@ -5,7 +5,7 @@
  */
 #include "scr4/s_prost.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/k_super.h"
 #include "api/k_lang.h"

--- a/api/objs/k_vers.cpp
+++ b/api/objs/k_vers.cpp
@@ -8,7 +8,7 @@
  */
 #include "scr4/s_strs.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/vers.h"
 
 

--- a/api/objs/k_xdr.cpp
+++ b/api/objs/k_xdr.cpp
@@ -23,7 +23,7 @@
  *      int (*K_xdrobj[])()                         Table of function pointers, one function for each object type, for translating
  *                                                  big-endian to little-endian and vice-versa
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/lec/lec.h"

--- a/api/objs/kdb.h
+++ b/api/objs/kdb.h
@@ -1,18 +1,10 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"         // B_ainit_chk
 #include "api/b_errors.h"       // error_manager
 #include "api/time/sample.h"    // Period, Sample
 #include "api/objs/xdr.h"
 
-#include <string>
-#include <set>
-#include <map>
-#include <vector>
-#include <array>
-#include <memory>               // std::shared_ptr, std::shared_ptr, std::shared_from_this
-#include <stdexcept>            // std::invalid_argument, std::out_of_range, std::runtime_error
 
 #ifndef SKBUILD
     #include "gtest/gtest.h"

--- a/api/objs/lists.h
+++ b/api/objs/lists.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"       // KDB
 #include "api/objs/pack.h"      // P_get_ptr
 

--- a/api/objs/macros.cpp
+++ b/api/objs/macros.cpp
@@ -1,8 +1,4 @@
 #pragma once
-
-#include "api/constants.h"
-#include "api/objs/kdb.h"
-#include "api/objs/pack.h"
 #include "api/objs/macros.h"
 
 

--- a/api/objs/macros.h
+++ b/api/objs/macros.h
@@ -1,7 +1,7 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"
+#include "api/objs/pack.h"
 
 
 struct KDBMacros : public KDBTemplate<KDBMacros, std::string>

--- a/api/objs/objs.h
+++ b/api/objs/objs.h
@@ -1,6 +1,6 @@
 #pragma once 
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/objs/kdb.h"

--- a/api/objs/old_structs.h
+++ b/api/objs/old_structs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"
 
 

--- a/api/objs/pack.cpp
+++ b/api/objs/pack.cpp
@@ -71,8 +71,10 @@
  *      void *P_alloc_get_ptr(void *ptr, int p) : Allocates a new buffer and copies the p'th element of pack in the new buffer.
  *      int P_nb(char *ptr) : Retrieves the number of elements in a pack pointed to by ptr.
  */
+#pragma once
 #include "scr4/s_swap.h"        // SW_nalloc(), SW_nrealloc(), SW_getptr(), SW_nfree()
-#include "api/constants.h"
+
+#include "api/pch.h"
 #include "api/utils/buf.h"
 #include "api/objs/pack.h"
 

--- a/api/objs/pack.h
+++ b/api/objs/pack.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "api/constants.h"
+#include "api/pch.h"
 
 
 /* pack.c */

--- a/api/objs/scalars.h
+++ b/api/objs/scalars.h
@@ -1,7 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
-#include "api/utils/utils.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"
 #include "api/objs/pack.h"
 

--- a/api/objs/structs_32.h
+++ b/api/objs/structs_32.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 
 typedef long PTR32;
 

--- a/api/objs/tables.h
+++ b/api/objs/tables.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/k_super.h"
 #include "api/objs/kdb.h"           // KDB
@@ -9,9 +8,6 @@
 #include "api/objs/identities.h"    // Identity
 #include "api/objs/grep.h"
 
-#include <string>
-#include <vector>
-#include <bitset>
 
 /*----------------------- ENUMS ----------------------------*/
 

--- a/api/objs/variables.h
+++ b/api/objs/variables.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/objs/kdb.h"
 #include "api/objs/pack.h"
 
-#include <string>
-#include <memory>       // for std::shared_ptr
 
 /*----------------------- TYPEDEF ----------------------------*/
 

--- a/api/objs/vers.h
+++ b/api/objs/vers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 
 /* k_vers.c */
 char *K_CurrentVersion();

--- a/api/objs/ws.h
+++ b/api/objs/ws.h
@@ -1,6 +1,6 @@
 #pragma once 
 
-#include "api/constants.h"
+#include "api/pch.h"
 
 /* k_ws.c */
 void K_init_ws(int ws);

--- a/api/objs/xdr.h
+++ b/api/objs/xdr.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "api/constants.h"
+#include "api/pch.h"
 
 extern int (*K_xdrobj[])(unsigned char* ptr, unsigned char** xdr_ptr);
 

--- a/api/pch.h
+++ b/api/pch.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// Standard C library headers
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
+#include <cmath>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <float.h>
+
+// Standard C++ library headers - Containers
+#include <vector>
+#include <deque>
+#include <map>
+#include <set>
+#include <array>
+#include <bitset>
+#include <string>
+#include <string_view>
+
+// Standard C++ library headers - Memory
+#include <memory>
+#include <functional>
+
+// Standard C++ library headers - Algorithms
+#include <algorithm>
+#include <numeric>
+#include <utility>
+
+// Standard C++ library headers - I/O and Strings
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <regex>
+
+// Standard C++ library headers - Utilities
+#include <variant>
+#include <stdexcept>
+#include <filesystem>
+
+// Platform-specific headers
+#ifdef _WIN32
+    #include <Windows.h>
+#else
+    #include <unistd.h>
+    #include <sys/stat.h>
+    #include <iconv.h>
+#endif
+
+// IODE project headers - these are stable and widely used
+#include "api/constants.h"
+#include "api/utils/utils.h"
+#include "api/utils/logging.h"

--- a/api/print/k_graph.cpp
+++ b/api/print/k_graph.cpp
@@ -24,7 +24,7 @@
  *      int T_prep_smpl(COLS *cls, COLS **fcls, Sample *smpl)                   Given a compiled GSample, constructs a new COLS struct with unique file ops and the minimum Sample smpl containing all periods present in cls.
  *      int V_graph(int view, int mode, int type, int xgrid, int ygrid, int axis, double ymin, double ymax, Sample* smpl, char** names)  Prints or displays graph(s) from variable list(s) or combination(s) or variables.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/b_a2mini.h"
 #include "api/k_lang.h"

--- a/api/print/k_print.cpp
+++ b/api/print/k_print.cpp
@@ -28,7 +28,7 @@
  */
 #include "scr4/s_a2m.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_a2mini.h"
 #include "api/k_lang.h"
 #include "api/b_errors.h"

--- a/api/print/print.h
+++ b/api/print/print.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 #include "api/gsample/gsample.h"

--- a/api/report/commands/b_data.cpp
+++ b/api/report/commands/b_data.cpp
@@ -94,7 +94,7 @@
  */
 #include "scr4/s_args.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/lec/lec.h"
@@ -107,7 +107,6 @@
 #include "api/objs/compare.h"
 #include "api/print/print.h"
 #include "api/report/commands/commands.h"
-#include <algorithm>    // for std::min, std::max
 
 
 /**

--- a/api/report/commands/b_est.cpp
+++ b/api/report/commands/b_est.cpp
@@ -23,7 +23,7 @@
  * int B_EqsSetInstrs(char* arg, int unused)                    Implementation of the report function $EqsSetInstrs.
  */
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/objs/objs.h"

--- a/api/report/commands/b_model.cpp
+++ b/api/report/commands/b_model.cpp
@@ -17,7 +17,7 @@
  *      int B_ModelSimulateSaveNIters(char *arg)                    $ModelSimulateSaveNiters varname
  *      int B_ModelSimulateSaveNorms(char *arg)                     $ModelSimulateSaveNorms varname
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/objs/objs.h"

--- a/api/report/commands/b_ras.cpp
+++ b/api/report/commands/b_ras.cpp
@@ -11,7 +11,7 @@
  */
 #include "scr4/s_mat.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/k_super.h"

--- a/api/report/commands/commands.h
+++ b/api/report/commands/commands.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/objs/kdb.h"        
 #include "api/objs/equations.h"        
 #include "api/report/reports.h"

--- a/api/report/engine/b_rep_cmds.cpp
+++ b/api/report/engine/b_rep_cmds.cpp
@@ -28,7 +28,7 @@
  */
 #include "scr4/scr4.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/k_super.h"

--- a/api/report/engine/b_rep_defs.cpp
+++ b/api/report/engine/b_rep_defs.cpp
@@ -21,7 +21,7 @@
  *      int RP_define_save_list(char **list)        Saves (pushes) a list of macros using RP_define_save() for each macro.
  *      int RP_define_restore_list(char **list)     Restores a list of macros using RP_define_restore() for each macro.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/objs/objs.h"

--- a/api/report/engine/b_rep_fns.cpp
+++ b/api/report/engine/b_rep_fns.cpp
@@ -117,7 +117,7 @@
 #include "scr4/s_prost.h"
 #include "scr4/s_prodt.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/objs/objs.h"
 #include "api/objs/pack.h"
@@ -137,11 +137,8 @@
 #ifdef _MSC_VER
     #include <direct.h>
 #else
-    #include <unistd.h>
 #endif
 #include <time.h>
-
-#include <algorithm>    // for std::min, std::max
 
 
 /*--------------------------- STRING MANIPULATIONS -------------------------------*/

--- a/api/report/engine/engine.h
+++ b/api/report/engine/engine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/lec/lec.h"
 #include "api/objs/macros.h"
 #include "api/objs/tables.h"

--- a/api/report/reports.h
+++ b/api/report/reports.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"         // Period
 #include "api/time/sample.h"         // Sample
 
-#include <string>
-#include <map>
 
 
 /*------------------------ DEFINE ----------------------- */

--- a/api/report/undoc/b_api.cpp
+++ b/api/report/undoc/b_api.cpp
@@ -15,7 +15,7 @@
  */
 #include "scr4/s_args.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_iodeini.h"
 #include "api/k_lang.h"
 #include "api/k_super.h"

--- a/api/report/undoc/b_dde.cpp
+++ b/api/report/undoc/b_dde.cpp
@@ -54,7 +54,7 @@
  */
 #include "scr4/scr4w.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/k_lang.h"
 #include "api/k_super.h"

--- a/api/report/undoc/b_ds.cpp
+++ b/api/report/undoc/b_ds.cpp
@@ -25,7 +25,7 @@
     #include "scr4/s_prowin.h"
 #endif
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/k_super.h"
 #include "api/objs/variables.h"

--- a/api/report/undoc/b_eviews.cpp
+++ b/api/report/undoc/b_eviews.cpp
@@ -76,7 +76,7 @@
 
 //================================================================================================================= */
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/objs/objs.h"
 

--- a/api/report/undoc/b_pdest.cpp
+++ b/api/report/undoc/b_pdest.cpp
@@ -70,7 +70,7 @@
 #include "scr4/s_args.h"
 #include "scr4/s_proa2m.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_a2mini.h"
 #include "api/b_errors.h"
 #include "api/k_lang.h"

--- a/api/report/undoc/b_print.cpp
+++ b/api/report/undoc/b_print.cpp
@@ -17,9 +17,10 @@
  *    int B_PrintObjDef(char* arg, int type)                           | $PrintObjDefXxx object_list
  *    int B_PrintObjDefArgs(char* arg, int type)                       | Print a list of objects of a given type.
  */
+#include "api/pch.h"
 #include "scr4/s_prost.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_a2mini.h"
 #include "api/b_errors.h"
@@ -38,7 +39,6 @@
 #include "api/write/write.h"
 #include "api/report/undoc/undoc.h"
 
-#include <algorithm>    // for std::min, std::max
 
 /*================================= UTILITIES ===============================*/
 

--- a/api/report/undoc/b_season.cpp
+++ b/api/report/undoc/b_season.cpp
@@ -8,17 +8,13 @@
  *  
  *  @See GB for details
  */
-#include <math.h>
-#include <string.h>
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/objs/objs.h"
 #include "api/objs/variables.h"
 
 #include "api/report/undoc/undoc.h"
-#include <algorithm>    // for std::min, std::max
 
 double  SEASON_EPS = 5.0;
 

--- a/api/report/undoc/b_sql.cpp
+++ b/api/report/undoc/b_sql.cpp
@@ -25,7 +25,7 @@
  *  TODO: rename b_sql.c in b_rep_sql.c
  */
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/report/undoc/undoc.h"
 
 // These functions are NOT implemented (yet) under Linux or in VC64

--- a/api/report/undoc/b_step.cpp
+++ b/api/report/undoc/b_step.cpp
@@ -8,7 +8,7 @@
  *  -----------------
  *      int B_EqsStepWise(char* arg, int unused) | $EqsStepWise from to eqname leccond {r2|fstat}
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/k_super.h"
 #include "api/objs/objs.h"

--- a/api/report/undoc/b_trend.cpp
+++ b/api/report/undoc/b_trend.cpp
@@ -19,7 +19,7 @@
  */
 #include <string.h>
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/objs/objs.h"

--- a/api/report/undoc/b_view.cpp
+++ b/api/report/undoc/b_view.cpp
@@ -24,7 +24,7 @@
  */
 #include "scr4/s_args.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/b_errors.h"
 #include "api/objs/objs.h"
@@ -36,7 +36,6 @@
 #include "api/report/engine/engine.h"
 #include "api/report/undoc/undoc.h"
 
-#include <algorithm>    // for std::min
 
 
 int B_viewmode;         // 0: displays the graph/table on screen, 1: print graph/table

--- a/api/report/undoc/undoc.h
+++ b/api/report/undoc/undoc.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/report/reports.h"
 #include "api/gsample/gsample.h"
 #include "api/objs/kdb.h"

--- a/api/simulation/k_sim_exo2endo.cpp
+++ b/api/simulation/k_sim_exo2endo.cpp
@@ -59,7 +59,7 @@
  *
  *  
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_errors.h"
 #include "api/lec/lec.h"
 #include "api/objs/equations.h"

--- a/api/simulation/k_sim_main.cpp
+++ b/api/simulation/k_sim_main.cpp
@@ -78,7 +78,7 @@
  *  The solution is reached when the difference between 2 iterations is under a defined threshold for each endogenous {y1...yn}.
  */
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/b_errors.h"
 #include "api/lec/lec.h"
@@ -88,7 +88,6 @@
 #include "api/objs/lists.h"
 #include "api/objs/variables.h"
 #include "api/simulation/simulation.h"
-#include <algorithm>    // for std::min, std::max
 
 
 extern "C" int SCR_vtime;

--- a/api/simulation/k_sim_order.cpp
+++ b/api/simulation/k_sim_order.cpp
@@ -16,7 +16,7 @@
  *      int get_eq_position(int posendo)                       Searches the equation whose endogenous is the variable posendo. 
  *      void compute_tri(KDBEquationsPtr dbe, std::vector<std::vector<int>>& predecessors, int passes)    Sort the equations by making successive 'pseudo-triangulation' passes.
  */
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/lec/lec.h"
 #include "api/objs/objs.h"

--- a/api/simulation/k_sim_scc.cpp
+++ b/api/simulation/k_sim_scc.cpp
@@ -10,7 +10,7 @@
  *  The simulation can later be run multiple times without having to reorder the model for each simulation.
  */
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/k_super.h"
 #include "api/b_errors.h"
 #include "api/lec/lec.h"

--- a/api/simulation/simulation.h
+++ b/api/simulation/simulation.h
@@ -1,9 +1,8 @@
 #pragma once
-
 #include "scr4/s_mat.h"
 #include "scr4/scr4.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/b_args.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
@@ -12,8 +11,6 @@
 #include "api/objs/scalars.h"
 #include "api/objs/variables.h"
 
-#include <vector>
-#include <string>
 
 /* ---------------------- ENUMS ---------------------- */
 

--- a/api/time/period.h
+++ b/api/time/period.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#include <ctype.h>
+#include "api/pch.h"
 #include "api/utils/utils.h"
 
-#include <string>
-#include <map>
-#include <array>
-#include <stdexcept>
 
 /**
  *  Variables for period definitions: 

--- a/api/time/sample.h
+++ b/api/time/sample.h
@@ -1,7 +1,7 @@
 #pragma once
+#include "api/pch.h"
 #include "api/utils/utils.h"
 #include "api/time/period.h"
-#include <stdexcept>
 
 
 struct Sample

--- a/api/utils/buf.cpp
+++ b/api/utils/buf.cpp
@@ -13,8 +13,8 @@
  * 
  *   - char *BUF_DATA : NULL or pointer to the allocated buffer
  */
+#include "api/pch.h"
 #include <s_swap.h>
-#include <stdio.h>
 #include "api/utils/buf.h"
 
 

--- a/api/utils/buf.h
+++ b/api/utils/buf.h
@@ -1,6 +1,5 @@
 #pragma once
-
-#include "api/constants.h"
+#include "api/pch.h"
 
 /* buf.c */
 char *BUF_alloc(int len);

--- a/api/utils/yy.cpp
+++ b/api/utils/yy.cpp
@@ -5,8 +5,8 @@
  * Some of these functions parse files and/or strings using the SCR4 group of functions "YY". 
  * See http://www.xon.be/scr4/libs1/libs157.htm for more details.
  */
+#include "api/pch.h"
 #include "api/k_super.h"
-#include "api/constants.h"
 #include "api/objs/tables.h"
 #include "api/utils/yy.h"
 

--- a/api/utils/yy.h
+++ b/api/utils/yy.h
@@ -1,8 +1,7 @@
 #pragma once
-
 #include "scr4/s_yy.h"
 
-#include "api/constants.h"
+#include "api/pch.h"
 #include "api/time/period.h"
 #include "api/time/sample.h"
 

--- a/api/version.h.in
+++ b/api/version.h.in
@@ -1,7 +1,5 @@
 #pragma once
-
 #include <string>
-#include "api/constants.h"
 
 #define IODE_VERSION "IODE Modeling Software ${PROJECT_VERSION} - (c) 1990-${CURRENT_YEAR} Federal Planning Bureau - Brussels"
 #define IODE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR}

--- a/api/write/write.h
+++ b/api/write/write.h
@@ -1,10 +1,10 @@
 #pragma once
-
 #include "scr4/s_prost.h"       // SCR_free, SCR_stracpy, SCR_strip
 #include "scr4/s_a2m.h"
 
 #include <stdarg.h>             // for va_list
-#include "api/constants.h"
+
+#include "api/pch.h"
 
 
 inline double   A2M_GWIDTH = 9.5;     // Default graph width in cm

--- a/tests/test_c_api/CMakeLists.txt
+++ b/tests/test_c_api/CMakeLists.txt
@@ -4,6 +4,9 @@ add_executable(${test_c_api} pch.cpp test_period.cpp test_sample.cpp test_c_api.
                                   test_kdb_comments.cpp test_kdb_equations.cpp test_kdb_identities.cpp 
                                   test_kdb_lists.cpp test_kdb_scalars.cpp test_kdb_tables.cpp 
                                   test_kdb_variables.cpp test_report.cpp)
+
+# Precompiled headers for faster compilation
+target_precompile_headers(${test_c_api} PRIVATE pch.h)
 target_link_libraries(${test_c_api} PUBLIC gtest_main iode_cpp_api)
 target_link_options(${test_c_api} PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/FORCE:MULTIPLE>)
 

--- a/tests/test_cpp_api/CMakeLists.txt
+++ b/tests/test_cpp_api/CMakeLists.txt
@@ -3,6 +3,8 @@ add_executable(${test_cpp_api} pch.cpp test_utils.cpp test_lec.cpp
                test_computed_table.cpp test_report.cpp test_simulation.cpp 
                test_estimation.cpp test_kdb_global.cpp)
 
+# Precompiled headers for faster compilation
+target_precompile_headers(${test_cpp_api} PRIVATE pch.h)
 target_link_libraries(${test_cpp_api} PUBLIC gtest_main iode_cpp_api)
 target_link_options(${test_cpp_api} PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/FORCE:MULTIPLE>)
 


### PR DESCRIPTION
To speed up the compilation of the api folder